### PR TITLE
Mission Control-style theme + glass surfaces (red accent)

### DIFF
--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
   let data: unknown;
   try {
     data = JSON.parse(stdout);
-  } catch (e) {
+  } catch {
     return NextResponse.json(
       { error: "Failed to parse openclaw recipes list output", stderr, stdout },
       { status: 500 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,47 @@
 @import "tailwindcss";
 
+/*
+  Claw Kitchen UI tokens
+  Goal: macOS Mission Control vibe — dark neutral base, frosted glass surfaces,
+  subtle depth, and system-red accents.
+*/
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  /* Base colors */
+  --ck-bg-base: #0b0c10;
+  --ck-bg-glass: rgba(24, 25, 31, 0.72);
+  --ck-bg-glass-strong: rgba(24, 25, 31, 0.88);
+
+  --ck-border-subtle: rgba(255, 255, 255, 0.10);
+  --ck-border-strong: rgba(255, 255, 255, 0.16);
+
+  --ck-text-primary: rgba(255, 255, 255, 0.92);
+  --ck-text-secondary: rgba(255, 255, 255, 0.66);
+  --ck-text-tertiary: rgba(255, 255, 255, 0.50);
+
+  /* Accent (macOS-ish system red) */
+  --ck-accent-red: #ff3b30;
+  --ck-accent-red-hover: #ff5a52;
+  --ck-accent-red-active: #e6372d;
+
+  /* Focus ring (visible on glass) */
+  --ck-focus-ring: rgba(255, 59, 48, 0.70);
+
+  /* Radii */
+  --ck-radius-sm: 10px;
+  --ck-radius-md: 14px;
+  --ck-radius-lg: 18px;
+
+  /* Elevation */
+  --ck-shadow-1: 0 10px 30px rgba(0, 0, 0, 0.35);
+  --ck-shadow-2: 0 18px 50px rgba(0, 0, 0, 0.45);
+
+  /* Glass */
+  --ck-glass-blur: 18px;
+  --ck-glass-saturation: 1.25;
+
+  /* Legacy mappings (Next starter defaults) */
+  --background: var(--ck-bg-base);
+  --foreground: var(--ck-text-primary);
 }
 
 @theme inline {
@@ -12,15 +51,64 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+html,
+body {
+  height: 100%;
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  background: var(--ck-bg-base);
+  color: var(--ck-text-primary);
+  font-family: var(--font-geist-sans), system-ui, -apple-system, Segoe UI, Roboto,
+    Arial, Helvetica, sans-serif;
+}
+
+/* Wallpaper-like backdrop (kept subtle; readability first) */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background:
+    radial-gradient(1200px 700px at 20% 15%, rgba(255, 59, 48, 0.14), transparent 60%),
+    radial-gradient(900px 600px at 75% 25%, rgba(255, 255, 255, 0.08), transparent 55%),
+    radial-gradient(1100px 700px at 55% 80%, rgba(120, 140, 255, 0.10), transparent 60%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(0, 0, 0, 0));
+}
+
+/* Universal focus ring: ensures keyboard nav remains obvious on glass. */
+:where(a, button, input, textarea, select, summary, [role="button"], [tabindex]):focus-visible {
+  outline: 2px solid var(--ck-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Glass surface utility classes (fallback-first) */
+.ck-glass {
+  background: var(--ck-bg-glass);
+  border: 1px solid var(--ck-border-subtle);
+  border-radius: var(--ck-radius-md);
+  box-shadow: var(--ck-shadow-1);
+  transition: background-color 160ms ease-out, box-shadow 180ms ease-out, border-color 160ms ease-out;
+}
+
+@supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+  .ck-glass {
+    -webkit-backdrop-filter: blur(var(--ck-glass-blur)) saturate(var(--ck-glass-saturation));
+    backdrop-filter: blur(var(--ck-glass-blur)) saturate(var(--ck-glass-saturation));
+  }
+}
+
+.ck-glass-strong {
+  background: var(--ck-bg-glass-strong);
+  border: 1px solid var(--ck-border-strong);
+  border-radius: var(--ck-radius-md);
+  box-shadow: var(--ck-shadow-2);
+  transition: background-color 160ms ease-out, box-shadow 180ms ease-out, border-color 160ms ease-out;
+}
+
+@supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+  .ck-glass-strong {
+    -webkit-backdrop-filter: blur(calc(var(--ck-glass-blur) + 4px)) saturate(var(--ck-glass-saturation));
+    backdrop-filter: blur(calc(var(--ck-glass-blur) + 4px)) saturate(var(--ck-glass-saturation));
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,19 +2,23 @@ import Link from "next/link";
 
 export default function Home() {
   return (
-    <main className="p-8 max-w-3xl">
-      <h1 className="text-3xl font-semibold">Claw Kitchen (Phase 1)</h1>
-      <p className="mt-3 text-slate-600">
-        Local-first UI for authoring Clawcipes recipes and scaffolding agents/teams.
-      </p>
+    <main className="min-h-screen p-8">
+      <div className="ck-glass mx-auto max-w-3xl p-6 sm:p-8">
+        <h1 className="text-3xl font-semibold tracking-tight">
+          Claw Kitchen <span className="text-sm align-middle text-[color:var(--ck-text-secondary)]">(Phase 1)</span>
+        </h1>
+        <p className="mt-3 max-w-prose text-[color:var(--ck-text-secondary)]">
+          Local-first UI for authoring Clawcipes recipes and scaffolding agents/teams.
+        </p>
 
-      <div className="mt-6 flex gap-3">
-        <Link
-          href="/recipes"
-          className="rounded bg-black text-white px-4 py-2 text-sm"
-        >
-          Recipes
-        </Link>
+        <div className="mt-6 flex gap-3">
+          <Link
+            href="/recipes"
+            className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-4 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[var(--ck-accent-red-hover)] active:bg-[var(--ck-accent-red-active)]"
+          >
+            Recipes
+          </Link>
+        </div>
       </div>
     </main>
   );

--- a/src/app/recipes/[id]/RecipeEditor.tsx
+++ b/src/app/recipes/[id]/RecipeEditor.tsx
@@ -54,8 +54,9 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
       const json = await res.json();
       if (!res.ok) throw new Error(json.error || "Save failed");
       setMessage(`Saved to ${json.filePath}`);
-    } catch (e: any) {
-      setMessage(e?.message ?? String(e));
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setMessage(msg);
     } finally {
       setSaving(false);
     }
@@ -79,23 +80,24 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
       const json = await res.json();
       if (!res.ok) throw new Error(json.error || "Scaffold failed");
       setScaffoldOut([json.stdout, json.stderr].filter(Boolean).join("\n"));
-    } catch (e: any) {
-      setScaffoldOut(e?.message ?? String(e));
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setScaffoldOut(msg);
     }
   }
 
-  if (loading) return <div className="p-8">Loading…</div>;
-  if (!recipe) return <div className="p-8">Not found.</div>;
+  if (loading) return <div className="ck-glass mx-auto max-w-4xl p-6">Loading…</div>;
+  if (!recipe) return <div className="ck-glass mx-auto max-w-4xl p-6">Not found.</div>;
 
   return (
-    <div className="p-8">
-      <div className="flex items-start justify-between gap-6">
-        <div>
-          <h1 className="text-2xl font-semibold">{recipe.name}</h1>
-          <div className="mt-1 text-xs text-slate-600">
+    <div className="ck-glass mx-auto max-w-6xl p-6 sm:p-8">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+        <div className="min-w-0">
+          <h1 className="truncate text-2xl font-semibold tracking-tight">{recipe.name}</h1>
+          <div className="mt-1 text-xs text-[color:var(--ck-text-secondary)]">
             {recipe.id} • {recipe.kind} • {recipe.source}
           </div>
-          <div className="mt-1 text-xs text-slate-500">
+          <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
             Path: {recipe.filePath ?? "(unknown / not writable)"}
           </div>
         </div>
@@ -103,14 +105,14 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
         <div className="flex gap-2">
           <button
             onClick={onScaffold}
-            className="rounded border px-3 py-2 text-sm"
+            className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-white/10 active:bg-white/15"
           >
             Scaffold
           </button>
           <button
             disabled={!canSave || saving}
             onClick={onSave}
-            className="rounded bg-black text-white px-3 py-2 text-sm disabled:opacity-50"
+            className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[var(--ck-accent-red-hover)] active:bg-[var(--ck-accent-red-active)] disabled:opacity-50"
           >
             {saving ? "Saving…" : "Save"}
           </button>
@@ -118,28 +120,30 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
       </div>
 
       {message ? (
-        <div className="mt-4 rounded border bg-white p-3 text-sm">{message}</div>
+        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-sm text-[color:var(--ck-text-primary)]">
+          {message}
+        </div>
       ) : null}
 
-      <div className="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div>
-          <div className="text-sm font-medium">Recipe markdown</div>
+      <div className="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="ck-glass-strong p-4">
+          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Recipe markdown</div>
           <textarea
             value={content}
             onChange={(e) => setContent(e.target.value)}
-            className="mt-2 h-[70vh] w-full rounded border p-3 font-mono text-xs"
+            className="mt-2 h-[70vh] w-full resize-none rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 p-3 font-mono text-xs text-[color:var(--ck-text-primary)] placeholder:text-[color:var(--ck-text-tertiary)]"
             spellCheck={false}
           />
         </div>
-        <div>
-          <div className="text-sm font-medium">Scaffold output</div>
-          <pre className="mt-2 h-[70vh] w-full overflow-auto rounded border p-3 text-xs bg-slate-50">
+        <div className="ck-glass-strong p-4">
+          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Scaffold output</div>
+          <pre className="mt-2 h-[70vh] w-full overflow-auto rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 p-3 text-xs text-[color:var(--ck-text-primary)]">
             {scaffoldOut || "(no output yet)"}
           </pre>
         </div>
       </div>
 
-      <p className="mt-6 text-xs text-slate-500">
+      <p className="mt-6 text-xs text-[color:var(--ck-text-tertiary)]">
         Phase 1: Scaffold button runs <code>openclaw recipes scaffold</code> or <code>scaffold-team</code>.
         We’ll add apply-config/overwrite toggles and a dry-run/plan view next.
       </p>

--- a/src/app/recipes/[id]/page.tsx
+++ b/src/app/recipes/[id]/page.tsx
@@ -4,9 +4,12 @@ import RecipeEditor from "./RecipeEditor";
 export default async function RecipePage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   return (
-    <main>
-      <div className="px-8 pt-6">
-        <Link href="/recipes" className="text-sm underline">
+    <main className="min-h-screen p-8">
+      <div className="mx-auto mb-4 max-w-6xl">
+        <Link
+          href="/recipes"
+          className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
+        >
           ← Back to recipes
         </Link>
       </div>

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -13,25 +13,28 @@ async function getRecipes(): Promise<Recipe[]> {
   return JSON.parse(stdout) as Recipe[];
 }
 
-export default async function RecipesPage() {
-  const recipes = await getRecipes();
-
-  const builtin = recipes.filter((r) => r.source === "builtin");
-  const workspace = recipes.filter((r) => r.source === "workspace");
-
-  const Section = ({ title, items }: { title: string; items: Recipe[] }) => (
+function RecipesSection({ title, items }: { title: string; items: Recipe[] }) {
+  return (
     <section className="mt-8">
-      <h2 className="text-xl font-semibold">{title}</h2>
-      <ul className="mt-3 space-y-2">
+      <h2 className="text-lg font-semibold tracking-tight text-[color:var(--ck-text-primary)]">
+        {title}
+      </h2>
+      <ul className="mt-3 space-y-3">
         {items.map((r) => (
-          <li key={`${r.source}:${r.id}`} className="flex items-center justify-between rounded border p-3">
-            <div>
-              <div className="font-medium">{r.name}</div>
-              <div className="text-xs text-slate-600">
+          <li
+            key={`${r.source}:${r.id}`}
+            className="ck-glass flex items-center justify-between gap-4 px-4 py-3"
+          >
+            <div className="min-w-0">
+              <div className="truncate font-medium">{r.name}</div>
+              <div className="mt-0.5 text-xs text-[color:var(--ck-text-secondary)]">
                 {r.id} • {r.kind} • {r.source}
               </div>
             </div>
-            <Link className="text-sm underline" href={`/recipes/${r.id}`}>
+            <Link
+              className="shrink-0 rounded-[var(--ck-radius-sm)] px-3 py-1.5 text-sm font-medium text-[color:var(--ck-accent-red)] transition-colors hover:text-[color:var(--ck-accent-red-hover)]"
+              href={`/recipes/${r.id}`}
+            >
               Edit
             </Link>
           </li>
@@ -39,22 +42,34 @@ export default async function RecipesPage() {
       </ul>
     </section>
   );
+}
+
+export default async function RecipesPage() {
+  const recipes = await getRecipes();
+
+  const builtin = recipes.filter((r) => r.source === "builtin");
+  const workspace = recipes.filter((r) => r.source === "workspace");
 
   return (
-    <main className="p-8 max-w-4xl">
-      <div className="flex items-baseline justify-between">
-        <h1 className="text-2xl font-semibold">Recipes</h1>
-        <Link href="/" className="text-sm underline">
-          Home
-        </Link>
+    <main className="min-h-screen p-8">
+      <div className="ck-glass mx-auto max-w-4xl p-6 sm:p-8">
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="text-2xl font-semibold tracking-tight">Recipes</h1>
+          <Link
+            href="/"
+            className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
+          >
+            Home
+          </Link>
+        </div>
+
+        <RecipesSection title={`Builtin (${builtin.length})`} items={builtin} />
+        <RecipesSection title={`Workspace (${workspace.length})`} items={workspace} />
+
+        <p className="mt-10 text-xs text-[color:var(--ck-text-tertiary)]">
+          Note: editing builtin recipes will modify the recipes plugin install path on this machine.
+        </p>
       </div>
-
-      <Section title={`Builtin (${builtin.length})`} items={builtin} />
-      <Section title={`Workspace (${workspace.length})`} items={workspace} />
-
-      <p className="mt-10 text-xs text-slate-500">
-        Note: editing builtin recipes will modify the recipes plugin install path on this machine.
-      </p>
     </main>
   );
 }

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { runOpenClaw } from "@/lib/openclaw";
 
 type Recipe = {
   id: string;
@@ -8,10 +9,8 @@ type Recipe = {
 };
 
 async function getRecipes(): Promise<Recipe[]> {
-  const res = await fetch("/api/recipes", { cache: "no-store" });
-  if (!res.ok) throw new Error("Failed to load recipes");
-  const json = (await res.json()) as { recipes: Recipe[] };
-  return json.recipes;
+  const { stdout } = await runOpenClaw(["recipes", "list"]);
+  return JSON.parse(stdout) as Recipe[];
 }
 
 export default async function RecipesPage() {


### PR DESCRIPTION
Implements Mission Control-inspired styling for Claw Kitchen (no feature changes).

## What changed
- Added CSS tokens for base/glass surfaces, borders, radii, shadows, blur, accent red, focus ring.
- Added reusable `.ck-glass` / `.ck-glass-strong` utilities with `backdrop-filter` + graceful fallback.
- Restyled primary routes:
  - `/` (home)
  - `/recipes` (list)
  - `/recipes/[id]` (editor shell)
- Ensured keyboard focus visibility via a global `:focus-visible` ring.

## Token changelog (globals.css)
- `--ck-bg-base`, `--ck-bg-glass`, `--ck-bg-glass-strong`
- `--ck-border-subtle`, `--ck-border-strong`
- `--ck-text-primary|secondary|tertiary`
- `--ck-accent-red|hover|active`
- `--ck-focus-ring`
- `--ck-radius-sm|md|lg`
- `--ck-shadow-1|2`
- `--ck-glass-blur`, `--ck-glass-saturation`

## Screenshots
Captured locally (before/after) under:
`/Users/rjjohnston/.openclaw/workspace-development-team/work/in-progress/0001-screenshots/`

- `baseline/`: home.png, recipes.png, recipe-1.png
- `after/`: home.png, recipes.png, recipe-1.png
