### PR TITLE
Kitchen: settings for cronInstallation + recipe cron jobs list

### DIFF
--- a/src/app/api/cron/job/route.ts
+++ b/src/app/api/cron/job/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { runOpenClaw } from "@/lib/openclaw";
+
+export async function POST(req: Request) {
+  const body = (await req.json()) as { id?: string; action?: string };
+  const id = String(body.id ?? "").trim();
+  const action = String(body.action ?? "").trim();
+
+  if (!id) return NextResponse.json({ ok: false, error: "id is required" }, { status: 400 });
+  if (!["enable", "disable", "run"].includes(action)) {
+    return NextResponse.json({ ok: false, error: "action must be enable|disable|run" }, { status: 400 });
+  }
+
+  if (action === "run") {
+    const { stdout, stderr } = await runOpenClaw(["cron", "run", id, "--json"]);
+    return NextResponse.json({ ok: true, action, id, stdout, stderr });
+  }
+
+  const flag = action === "enable" ? "--enable" : "--disable";
+  const { stdout, stderr } = await runOpenClaw(["cron", "edit", id, flag, "--json"].filter(Boolean));
+  return NextResponse.json({ ok: true, action, id, stdout, stderr });
+}

--- a/src/app/api/cron/recipe-installed/route.ts
+++ b/src/app/api/cron/recipe-installed/route.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { runOpenClaw } from "@/lib/openclaw";
+
+type MappingStateV1 = {
+  version: 1;
+  entries: Record<string, { installedCronId: string; orphaned?: boolean }>;
+};
+
+async function readJson<T>(p: string): Promise<T> {
+  const raw = await fs.readFile(p, "utf8");
+  return JSON.parse(raw) as T;
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const teamId = String(url.searchParams.get("teamId") ?? "").trim();
+  if (!teamId) {
+    return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
+  }
+
+  // Team workspace root is a sibling of agents.defaults.workspace: ~/.openclaw/workspace-<teamId>
+  const { stdout: wsOut } = await runOpenClaw(["config", "get", "agents.defaults.workspace"]);
+  const baseWorkspace = wsOut.trim();
+  if (!baseWorkspace) {
+    return NextResponse.json({ ok: false, error: "agents.defaults.workspace not set" }, { status: 500 });
+  }
+  const teamDir = path.resolve(baseWorkspace, "..", `workspace-${teamId}`);
+  const mappingPath = path.join(teamDir, "notes", "cron-jobs.json");
+
+  let mapping: MappingStateV1 | null = null;
+  try {
+    mapping = await readJson<MappingStateV1>(mappingPath);
+  } catch {
+    // no mapping (yet)
+    mapping = null;
+  }
+
+  const ids = new Set(
+    Object.values(mapping?.entries ?? {})
+      .filter((e) => e && typeof e.installedCronId === "string" && !e.orphaned)
+      .map((e) => e.installedCronId)
+  );
+
+  const { stdout } = await runOpenClaw(["cron", "list", "--all", "--json"]);
+  const parsed = JSON.parse(stdout) as { jobs: unknown[] };
+  const jobs = (parsed.jobs ?? []).filter((j) => ids.has(String((j as { id?: unknown })?.id ?? "")));
+
+  return NextResponse.json({ ok: true, teamId, teamDir, mappingPath, jobCount: jobs.length, jobs });
+}

--- a/src/app/api/settings/cron-installation/route.ts
+++ b/src/app/api/settings/cron-installation/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { runOpenClaw } from "@/lib/openclaw";
+
+const CFG_PATH = "plugins.entries.recipes.config.cronInstallation";
+
+export async function GET() {
+  const { stdout, stderr } = await runOpenClaw(["config", "get", CFG_PATH]);
+  const value = stdout.trim();
+  return NextResponse.json({ ok: true, path: CFG_PATH, value, stderr });
+}
+
+export async function PUT(req: Request) {
+  const body = (await req.json()) as { value?: string };
+  const value = String(body.value ?? "").trim();
+  if (!value || !["off", "prompt", "on"].includes(value)) {
+    return NextResponse.json({ ok: false, error: "value must be one of: off|prompt|on" }, { status: 400 });
+  }
+
+  const { stdout, stderr } = await runOpenClaw(["config", "set", CFG_PATH, value]);
+  return NextResponse.json({ ok: true, path: CFG_PATH, value, stdout, stderr });
+}

--- a/src/app/cron-jobs/cron-jobs-client.tsx
+++ b/src/app/cron-jobs/cron-jobs-client.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type CronJob = {
+  id: string;
+  name?: string;
+  enabled?: boolean;
+  schedule?: { kind?: string; expr?: string };
+  state?: { nextRunAtMs?: number };
+};
+
+export default function CronJobsClient() {
+  const [teamId, setTeamId] = useState<string>("development-team-team");
+  const [loading, setLoading] = useState(false);
+  const [jobs, setJobs] = useState<CronJob[]>([]);
+  const [msg, setMsg] = useState<string>("");
+
+  const sorted = useMemo(() => {
+    return [...jobs].sort((a, b) => String(a.name ?? "").localeCompare(String(b.name ?? "")));
+  }, [jobs]);
+
+  async function refresh() {
+    setLoading(true);
+    setMsg("");
+    try {
+      const res = await fetch(`/api/cron/recipe-installed?teamId=${encodeURIComponent(teamId)}`, { cache: "no-store" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Failed to load");
+      setJobs(json.jobs ?? []);
+      if ((json.jobs ?? []).length === 0) {
+        setMsg("No recipe-installed cron jobs found for this team (or mapping file is missing).");
+      }
+    } catch (e: unknown) {
+      setMsg(e instanceof Error ? e.message : String(e));
+      setJobs([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function act(id: string, action: "enable" | "disable" | "run") {
+    setLoading(true);
+    setMsg("");
+    try {
+      const res = await fetch("/api/cron/job", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id, action }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Action failed");
+      setMsg(action === "run" ? "Triggered run." : "Updated.");
+      await refresh();
+    } catch (e: unknown) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div>
+      <div className="ck-glass-strong p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="flex-1">
+            <label className="text-sm font-medium">Team id</label>
+            <input
+              value={teamId}
+              onChange={(e) => setTeamId(e.target.value)}
+              className="mt-2 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm"
+              placeholder="development-team-team"
+            />
+            <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
+              Team workspace is resolved as <code>workspace-&lt;teamId&gt;</code> next to agents.defaults.workspace.
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={refresh}
+              disabled={loading}
+              className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium shadow-[var(--ck-shadow-1)] transition-colors hover:bg-white/10 active:bg-white/15"
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {msg ? (
+        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-sm">
+          {msg}
+        </div>
+      ) : null}
+
+      <div className="mt-6 space-y-3">
+        {sorted.map((j) => (
+          <div key={j.id} className="ck-glass px-4 py-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0">
+                <div className="truncate font-medium">{j.name ?? j.id}</div>
+                <div className="mt-1 text-xs text-[color:var(--ck-text-secondary)]">
+                  {j.schedule?.kind === "cron" ? j.schedule.expr : j.schedule?.kind ?? ""}
+                  {" · "}
+                  {j.enabled ? "enabled" : "disabled"}
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => act(j.id, j.enabled ? "disable" : "enable")}
+                  disabled={loading}
+                  className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium transition-colors hover:bg-white/10"
+                >
+                  {j.enabled ? "Disable" : "Enable"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => act(j.id, "run")}
+                  disabled={loading}
+                  className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-[var(--ck-accent-red-hover)] active:bg-[var(--ck-accent-red-active)]"
+                >
+                  Run now
+                </button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/cron-jobs/page.tsx
+++ b/src/app/cron-jobs/page.tsx
@@ -1,0 +1,36 @@
+import CronJobsClient from "./cron-jobs-client";
+import Link from "next/link";
+
+export default function CronJobsPage() {
+  return (
+    <main className="min-h-screen p-8">
+      <div className="ck-glass mx-auto max-w-5xl p-6 sm:p-8">
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="text-2xl font-semibold tracking-tight">Cron Jobs (recipe-installed)</h1>
+          <div className="flex gap-3">
+            <Link
+              href="/settings"
+              className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
+            >
+              Settings
+            </Link>
+            <Link
+              href="/"
+              className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
+            >
+              Home
+            </Link>
+          </div>
+        </div>
+        <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+          This page only shows cron jobs installed by recipes (based on the scaffold mapping file
+          <code className="ml-1">notes/cron-jobs.json</code> in the team workspace).
+        </p>
+
+        <div className="mt-6">
+          <CronJobsClient />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,12 +11,24 @@ export default function Home() {
           Local-first UI for authoring Clawcipes recipes and scaffolding agents/teams.
         </p>
 
-        <div className="mt-6 flex gap-3">
+        <div className="mt-6 flex flex-wrap gap-3">
           <Link
             href="/recipes"
             className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-4 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[var(--ck-accent-red-hover)] active:bg-[var(--ck-accent-red-active)]"
           >
             Recipes
+          </Link>
+          <Link
+            href="/settings"
+            className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-white/10"
+          >
+            Settings
+          </Link>
+          <Link
+            href="/cron-jobs"
+            className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-white/10"
+          >
+            Cron jobs
           </Link>
         </div>
       </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,28 @@
+import SettingsClient from "./settings-client";
+
+export default function SettingsPage() {
+  return (
+    <main className="min-h-screen p-8">
+      <div className="ck-glass mx-auto max-w-3xl p-6 sm:p-8">
+        <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+        <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+          Configuration that affects scaffold behavior and automation.
+        </p>
+
+        <div className="mt-8">
+          <h2 className="text-lg font-semibold tracking-tight">Cron installation</h2>
+          <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+            Recipes can declare cron jobs. This controls whether Kitchen installs/reconciles them during scaffold.
+            <span className="block mt-2 text-[color:var(--ck-text-tertiary)]">
+              Safety note: jobs can send messages / run automatically. Default should remain conservative.
+            </span>
+          </p>
+
+          <div className="mt-4">
+            <SettingsClient />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/settings/settings-client.tsx
+++ b/src/app/settings/settings-client.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Mode = "off" | "prompt" | "on";
+
+export default function SettingsClient() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [mode, setMode] = useState<Mode>("prompt");
+  const [msg, setMsg] = useState<string>("");
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      setMsg("");
+      try {
+        const res = await fetch("/api/settings/cron-installation", { cache: "no-store" });
+        const json = await res.json();
+        if (!res.ok) throw new Error(json.error || "Failed to load config");
+        const v = String(json.value || "").trim();
+        if (v === "off" || v === "prompt" || v === "on") setMode(v);
+        else setMode("prompt");
+      } catch (e: unknown) {
+        setMsg(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  async function save(next: Mode) {
+    setSaving(true);
+    setMsg("");
+    try {
+      const res = await fetch("/api/settings/cron-installation", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ value: next }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Save failed");
+      setMode(next);
+      setMsg("Saved.");
+    } catch (e: unknown) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const Option = ({ value, title, help }: { value: Mode; title: string; help: string }) => (
+    <button
+      type="button"
+      onClick={() => save(value)}
+      disabled={loading || saving}
+      className={`ck-glass w-full text-left px-4 py-3 transition-colors hover:bg-white/10 ${
+        mode === value ? "border-[color:var(--ck-accent-red)]" : ""
+      }`}
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="font-medium">{title}</div>
+        {mode === value ? (
+          <div className="text-xs font-medium text-[color:var(--ck-accent-red)]">Selected</div>
+        ) : null}
+      </div>
+      <div className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">{help}</div>
+    </button>
+  );
+
+  return (
+    <div className="space-y-3">
+      <Option value="off" title="Off" help="Never install or reconcile recipe-defined cron jobs." />
+      <Option
+        value="prompt"
+        title="Prompt (default)"
+        help="Ask at scaffold time. Default answer should be No; jobs are installed disabled unless you opt in."
+      />
+      <Option value="on" title="On" help="Install/reconcile jobs during scaffold (enabledByDefault controls new jobs)." />
+
+      {msg ? (
+        <div className="mt-2 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-sm">
+          {msg}
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds minimal Cron management surfaces to Claw Kitchen.

## Settings: cron installation mode
- New page: `/settings`
- Config backed by `openclaw config get/set plugins.entries.recipes.config.cronInstallation`
- Modes:
  - off: never install/reconcile recipe cron jobs
  - prompt (default): Kitchen should ask at scaffold time (safe default)
  - on: install/reconcile; new jobs follow recipe `enabledByDefault`

## Cron Jobs (recipe-installed)
- New page: `/cron-jobs`
- Uses the scaffold mapping file for the selected team workspace:
  - `workspace-<teamId>/notes/cron-jobs.json`
- Lists only jobs whose `installedCronId` appears in the mapping file.
- Controls:
  - enable/disable (via `openclaw cron edit --enable/--disable`)
  - run now (via `openclaw cron run`)

## Scaffold UX
Kitchen scaffolds non-interactively, so CLI prompts won’t show.
This PR adds an optional request field to `/api/scaffold`:
- `cronInstallChoice: "yes" | "no"`
When provided, the route temporarily overrides `cronInstallation` (try/finally restore) for that scaffold run.

## How to test
1) `npm run dev -- --port 3050`
2) Visit:
   - `/settings` → switch cron mode off/prompt/on (confirm it persists)
   - `/cron-jobs` → enter a teamId that has `notes/cron-jobs.json` mapping (e.g. from ticket 0009 smoke)
3) Toggle enabled/disabled and run-now on a listed job.

## Notes
- This intentionally avoids arbitrary cron creation/editing; recipe-installed only.
- Team workspace is resolved from `agents.defaults.workspace` parent dir as `workspace-<teamId>`.
