### PR TITLE
Tickets: show title-cased slug instead of Created timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claw Kitchen
 
-Local-first UI companion for **Clawcipes** (OpenClaw Recipes plugin).
+Local-first UI companion for **ClawRecipes** (OpenClaw Recipes plugin).
 
 Phase 1 focus:
 - list recipes (builtin + workspace)
@@ -9,7 +9,7 @@ Phase 1 focus:
 
 ## Prerequisites
 - OpenClaw installed and on PATH (`openclaw`)
-- Clawcipes plugin installed/linked so `openclaw recipes ...` works
+- ClawRecipes plugin installed/linked so `openclaw recipes ...` works
 
 ## Running locally
 ```bash

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+type AgentListItem = {
+  id: string;
+  identityName?: string;
+  workspace?: string;
+  model?: string;
+  isDefault?: boolean;
+};
+
+function inferTeamIdFromWorkspace(workspace: string | undefined) {
+  if (!workspace) return null;
+  const base = workspace.split("/").filter(Boolean).pop() ?? "";
+  if (!base.startsWith("workspace-")) return null;
+  const team = base.slice("workspace-".length);
+  return team || null;
+}
+
+export default function HomeClient({ agents }: { agents: AgentListItem[] }) {
+  const teamIds = useMemo(() => {
+    const s = new Set<string>();
+    for (const a of agents) {
+      const t = inferTeamIdFromWorkspace(a.workspace);
+      if (t) s.add(t);
+    }
+    return Array.from(s).sort();
+  }, [agents]);
+
+  const [teamFilter, setTeamFilter] = useState<string>("all");
+
+  const grouped = useMemo(() => {
+    const groups = new Map<string, AgentListItem[]>();
+
+    for (const a of agents) {
+      const teamId = inferTeamIdFromWorkspace(a.workspace) ?? "personal";
+      if (teamFilter !== "all" && teamId !== teamFilter) continue;
+      const key = teamId;
+      const list = groups.get(key) ?? [];
+      list.push(a);
+      groups.set(key, list);
+    }
+
+    // Stable ordering: teams first (alphabetical), then personal.
+    const keys = Array.from(groups.keys()).sort((a, b) => {
+      if (a === "personal") return 1;
+      if (b === "personal") return -1;
+      return a.localeCompare(b);
+    });
+
+    return keys.map((k) => ({
+      key: k,
+      title: k === "personal" ? "Personal / Unassigned" : k,
+      agents: (groups.get(k) ?? []).slice().sort((a, b) => a.id.localeCompare(b.id)),
+      isTeam: k !== "personal",
+    }));
+  }, [agents, teamFilter]);
+
+  return (
+    <div className="ck-glass mx-auto max-w-5xl p-6 sm:p-8">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">
+            Claw Kitchen{" "}
+            <span className="text-sm align-middle text-[color:var(--ck-text-secondary)]">(v2)</span>
+          </h1>
+          <p className="mt-2 max-w-prose text-[color:var(--ck-text-secondary)]">
+            Installed agents on this machine, grouped by team workspace when available.
+          </p>
+        </div>
+
+        <div className="flex flex-col items-start gap-2 sm:items-end">
+          <Link
+            href="/recipes"
+            className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
+          >
+            Recipes
+          </Link>
+          <Link
+            href="/tickets"
+            className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
+          >
+            Tickets
+          </Link>
+          <Link
+            href="/settings"
+            className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
+          >
+            Settings
+          </Link>
+        </div>
+      </div>
+
+      {teamIds.length ? (
+        <div className="mt-6">
+          <label className="block text-xs font-medium text-[color:var(--ck-text-secondary)]">Team filter</label>
+          <select
+            className="mt-2 w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] px-3 py-2 text-sm text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] sm:w-[280px]"
+            value={teamFilter}
+            onChange={(e) => setTeamFilter(e.target.value)}
+          >
+            <option value="all">All teams</option>
+            {teamIds.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+            <option value="personal">Personal / Unassigned</option>
+          </select>
+        </div>
+      ) : null}
+
+      <div className="mt-8 space-y-8">
+        {grouped.map((g) => (
+          <section key={g.key}>
+            <div className="flex items-center justify-between gap-4">
+              <h2 className="text-lg font-semibold tracking-tight text-[color:var(--ck-text-primary)]">{g.title}</h2>
+              {g.isTeam ? (
+                <Link
+                  href={`/teams/${encodeURIComponent(g.key)}`}
+                  className="rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] px-3 py-1.5 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[color:var(--ck-bg-glass-strong)]"
+                >
+                  Edit
+                </Link>
+              ) : null}
+            </div>
+
+            <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {g.agents.map((a) => (
+                <Link
+                  key={a.id}
+                  href={`/agents/${encodeURIComponent(a.id)}`}
+                  className="ck-glass block px-4 py-3 transition-colors hover:bg-[color:var(--ck-bg-glass-strong)]"
+                >
+                  <div className="truncate font-medium text-[color:var(--ck-text-primary)]">
+                    {a.identityName || a.id}
+                  </div>
+                  <div className="mt-1 text-xs text-[color:var(--ck-text-secondary)]">
+                    {a.id}
+                    {a.isDefault ? " • default" : ""}
+                  </div>
+                  {a.model ? (
+                    <div className="mt-1 truncate text-xs text-[color:var(--ck-text-tertiary)]">{a.model}</div>
+                  ) : null}
+                </Link>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      <p className="mt-10 text-xs text-[color:var(--ck-text-tertiary)]">
+        Note: Team detection currently uses the convention <code>~/.openclaw/workspace-&lt;teamId&gt;</code>.
+      </p>
+    </div>
+  );
+}

--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type AgentListItem = {
+  id: string;
+  identityName?: string;
+  workspace?: string;
+  model?: string;
+  isDefault?: boolean;
+};
+
+export default function AgentEditor({ agentId }: { agentId: string }) {
+  const [agent, setAgent] = useState<AgentListItem | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string>("");
+
+  const [name, setName] = useState<string>("");
+  const [emoji, setEmoji] = useState<string>("");
+  const [theme, setTheme] = useState<string>("");
+  const [avatar, setAvatar] = useState<string>("");
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      setMessage("");
+      try {
+        const res = await fetch("/api/agents", { cache: "no-store" });
+        const json = await res.json();
+        const list = (json.agents ?? []) as AgentListItem[];
+        const found = list.find((a) => a.id === agentId) ?? null;
+        setAgent(found);
+        setName(found?.identityName ?? "");
+      } catch (e: unknown) {
+        setMessage(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [agentId]);
+
+  async function onSave() {
+    setSaving(true);
+    setMessage("");
+    try {
+      const res = await fetch("/api/agents/identity", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ agentId, name, emoji, theme, avatar }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Save failed");
+      setMessage("Saved identity via openclaw agents set-identity");
+    } catch (e: unknown) {
+      setMessage(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) return <div className="ck-glass mx-auto max-w-4xl p-6">Loading…</div>;
+  if (!agent) return <div className="ck-glass mx-auto max-w-4xl p-6">Agent not found: {agentId}</div>;
+
+  return (
+    <div className="ck-glass mx-auto max-w-4xl p-6 sm:p-8">
+      <h1 className="text-2xl font-semibold tracking-tight">Agent editor</h1>
+      <div className="mt-1 text-xs text-[color:var(--ck-text-secondary)]">
+        {agent.id}
+        {agent.isDefault ? " • default" : ""}
+        {agent.model ? ` • ${agent.model}` : ""}
+      </div>
+      {agent.workspace ? (
+        <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Workspace: {agent.workspace}</div>
+      ) : null}
+
+      <div className="mt-6 grid grid-cols-1 gap-4">
+        <div className="ck-glass-strong p-4">
+          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Identity</div>
+
+          <label className="mt-3 block text-xs font-medium text-[color:var(--ck-text-secondary)]">Name</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+          />
+
+          <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div>
+              <label className="block text-xs font-medium text-[color:var(--ck-text-secondary)]">Emoji</label>
+              <input
+                value={emoji}
+                onChange={(e) => setEmoji(e.target.value)}
+                placeholder="🦞"
+                className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-[color:var(--ck-text-secondary)]">Theme</label>
+              <input
+                value={theme}
+                onChange={(e) => setTheme(e.target.value)}
+                placeholder="warm, sharp, calm"
+                className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-[color:var(--ck-text-secondary)]">Avatar</label>
+              <input
+                value={avatar}
+                onChange={(e) => setAvatar(e.target.value)}
+                placeholder="avatars/openclaw.png"
+                className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+              />
+            </div>
+          </div>
+
+          <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+            <button
+              disabled={saving}
+              onClick={onSave}
+              className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[var(--ck-accent-red-hover)] active:bg-[var(--ck-accent-red-active)] disabled:opacity-50"
+            >
+              {saving ? "Saving…" : "Save"}
+            </button>
+
+            <button
+              disabled
+              className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] opacity-50"
+              title="Not implemented yet"
+            >
+              Save As New
+            </button>
+          </div>
+        </div>
+
+        {message ? (
+          <div className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-sm text-[color:var(--ck-text-primary)]">
+            {message}
+          </div>
+        ) : null}
+
+        <div className="ck-glass-strong p-4">
+          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Next sub-areas (not yet)</div>
+          <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-[color:var(--ck-text-secondary)]">
+            <li>Skills management</li>
+            <li>Agent config fields beyond identity</li>
+            <li>Edit agent-created files</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -71,7 +71,7 @@ export default function AgentEditor({ agentId }: { agentId: string }) {
       const res = await fetch("/api/agents/add", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ newAgentId, name, emoji, theme, avatar, model: agent.model }),
+        body: JSON.stringify({ newAgentId, name, emoji, theme, avatar, model: agent?.model }),
       });
       const json = await res.json();
       if (!res.ok) throw new Error(json.message || json.error || "Save As New failed");

--- a/src/app/agents/[agentId]/page.tsx
+++ b/src/app/agents/[agentId]/page.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import AgentEditor from "./agent-editor";
+
+export default async function AgentPage({ params }: { params: Promise<{ agentId: string }> }) {
+  const { agentId } = await params;
+
+  return (
+    <main className="min-h-screen p-8">
+      <div className="mx-auto mb-4 flex max-w-6xl items-center justify-between gap-4">
+        <Link
+          href="/"
+          className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
+        >
+          ← Home
+        </Link>
+        <div className="text-xs text-[color:var(--ck-text-tertiary)]">Agent: {agentId}</div>
+      </div>
+
+      <AgentEditor agentId={agentId} />
+    </main>
+  );
+}

--- a/src/app/api/agents/add/route.ts
+++ b/src/app/api/agents/add/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import path from "node:path";
+
+import { runOpenClaw } from "@/lib/openclaw";
+
+type Body = {
+  newAgentId: string;
+  name?: string;
+  emoji?: string;
+  theme?: string;
+  avatar?: string;
+  model?: string;
+};
+
+function homeDir() {
+  return process.env.HOME || "/home/control";
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as Body;
+
+    const newAgentId = body.newAgentId?.trim();
+    if (!newAgentId) {
+      return NextResponse.json({ error: "newAgentId is required" }, { status: 400 });
+    }
+
+    // Convention used by most installs: ~/.openclaw/workspace-<agentId>
+    const workspace = path.join(homeDir(), ".openclaw", `workspace-${newAgentId}`);
+
+    const addArgs = ["agents", "add", newAgentId, "--non-interactive", "--workspace", workspace, "--json"];
+    if (body.model?.trim()) addArgs.push("--model", body.model.trim());
+
+    const addResult = await runOpenClaw(addArgs);
+
+    // Best-effort: set identity after creation.
+    const identityArgs = ["agents", "set-identity", newAgentId];
+    if (body.name?.trim()) identityArgs.push("--name", body.name.trim());
+    if (body.emoji?.trim()) identityArgs.push("--emoji", body.emoji.trim());
+    if (body.theme?.trim()) identityArgs.push("--theme", body.theme.trim());
+    if (body.avatar?.trim()) identityArgs.push("--avatar", body.avatar.trim());
+
+    const identityResult = await runOpenClaw(identityArgs);
+
+    return NextResponse.json({
+      ok: true,
+      workspace,
+      add: addResult,
+      identity: identityResult,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error: "Failed to add agent",
+        message: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/agents/file/route.ts
+++ b/src/app/api/agents/file/route.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { runOpenClaw } from "@/lib/openclaw";
+
+type AgentListItem = { id: string; workspace?: string };
+
+async function resolveAgentWorkspace(agentId: string) {
+  const { stdout } = await runOpenClaw(["agents", "list", "--json"]);
+  const list = JSON.parse(stdout) as AgentListItem[];
+  const agent = list.find((a) => a.id === agentId);
+  if (!agent?.workspace) throw new Error(`Agent workspace not found for ${agentId}`);
+  return agent.workspace;
+}
+
+function assertSafeName(name: string) {
+  const n = name.replace(/\\/g, "/");
+  if (!n || n.startsWith("/") || n.includes("..")) throw new Error("Invalid file name");
+  return n;
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const agentId = String(searchParams.get("agentId") ?? "").trim();
+  const name = String(searchParams.get("name") ?? "").trim();
+  if (!agentId) return NextResponse.json({ ok: false, error: "agentId is required" }, { status: 400 });
+  if (!name) return NextResponse.json({ ok: false, error: "name is required" }, { status: 400 });
+
+  const ws = await resolveAgentWorkspace(agentId);
+  const safe = assertSafeName(name);
+  const filePath = path.join(ws, safe);
+
+  try {
+    const content = await fs.readFile(filePath, "utf8");
+    return NextResponse.json({ ok: true, agentId, workspace: ws, name: safe, filePath, content });
+  } catch (e: unknown) {
+    return NextResponse.json({ ok: false, error: e instanceof Error ? e.message : String(e) }, { status: 404 });
+  }
+}
+
+export async function PUT(req: Request) {
+  const body = (await req.json()) as { agentId?: string; name?: string; content?: string };
+  const agentId = String(body.agentId ?? "").trim();
+  const name = String(body.name ?? "").trim();
+  const content = typeof body.content === "string" ? body.content : null;
+
+  if (!agentId) return NextResponse.json({ ok: false, error: "agentId is required" }, { status: 400 });
+  if (!name) return NextResponse.json({ ok: false, error: "name is required" }, { status: 400 });
+  if (content === null) return NextResponse.json({ ok: false, error: "content is required" }, { status: 400 });
+
+  const ws = await resolveAgentWorkspace(agentId);
+  const safe = assertSafeName(name);
+  const filePath = path.join(ws, safe);
+
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, "utf8");
+  return NextResponse.json({ ok: true, agentId, workspace: ws, name: safe, filePath });
+}

--- a/src/app/api/agents/files/route.ts
+++ b/src/app/api/agents/files/route.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { runOpenClaw } from "@/lib/openclaw";
+
+type AgentListItem = {
+  id: string;
+  identityName?: string;
+  workspace?: string;
+};
+
+async function resolveAgentWorkspace(agentId: string) {
+  const { stdout } = await runOpenClaw(["agents", "list", "--json"]);
+  const list = JSON.parse(stdout) as AgentListItem[];
+  const agent = list.find((a) => a.id === agentId);
+  if (!agent?.workspace) throw new Error(`Agent workspace not found for ${agentId}`);
+  return agent.workspace;
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const agentId = String(searchParams.get("agentId") ?? "").trim();
+  if (!agentId) return NextResponse.json({ ok: false, error: "agentId is required" }, { status: 400 });
+
+  const ws = await resolveAgentWorkspace(agentId);
+
+  const candidates = ["IDENTITY.md", "SOUL.md", "USER.md", "AGENTS.md", "TOOLS.md", "HEARTBEAT.md", "MEMORY.md"];
+
+  const files = await Promise.all(
+    candidates.map(async (name) => {
+      const p = path.join(ws, name);
+      try {
+        const st = await fs.stat(p);
+        return { name, path: p, missing: false, size: st.size, updatedAtMs: st.mtimeMs };
+      } catch {
+        return { name, path: p, missing: true };
+      }
+    })
+  );
+
+  return NextResponse.json({ ok: true, agentId, workspace: ws, files });
+}

--- a/src/app/api/agents/identity/route.ts
+++ b/src/app/api/agents/identity/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+import { runOpenClaw } from "@/lib/openclaw";
+
+type Body = {
+  agentId: string;
+  name?: string;
+  emoji?: string;
+  theme?: string;
+  avatar?: string;
+};
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as Body;
+    const agentId = body.agentId?.trim();
+
+    if (!agentId) {
+      return NextResponse.json({ error: "agentId is required" }, { status: 400 });
+    }
+
+    const args = ["agents", "set-identity", agentId];
+
+    if (body.name?.trim()) args.push("--name", body.name.trim());
+    if (body.emoji?.trim()) args.push("--emoji", body.emoji.trim());
+    if (body.theme?.trim()) args.push("--theme", body.theme.trim());
+    if (body.avatar?.trim()) args.push("--avatar", body.avatar.trim());
+
+    const { stdout, stderr } = await runOpenClaw(args);
+
+    return NextResponse.json({ ok: true, stdout, stderr });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error: "Failed to set agent identity",
+        message: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+type Team = { id: string; name: string };
+
+type Agent = {
+  id: string;
+  teamId: string | null;
+  role: string | null;
+};
+
+function getHomeDir() {
+  return process.env.HOME || "/home/control";
+}
+
+async function listDirectories(dir: string) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+}
+
+async function getInstalledTeams(): Promise<Team[]> {
+  const openclawRoot = path.join(getHomeDir(), ".openclaw");
+  const all = await listDirectories(openclawRoot);
+
+  // Convention: team workspaces are stored as ~/.openclaw/workspace-<teamId>
+  const teams = all
+    .filter((d) => d.startsWith("workspace-") && d !== "workspace-main")
+    .map((d) => d.slice("workspace-".length))
+    // Only treat these as teams if the workspace looks like a team recipe workspace.
+    // (We keep this permissive: any non-main workspace can represent a team install.)
+    .filter(Boolean)
+    .map((id) => ({ id, name: id }));
+
+  teams.sort((a, b) => a.id.localeCompare(b.id));
+  return teams;
+}
+
+async function getInstalledAgents(teams: Team[]): Promise<Agent[]> {
+  const agentsRoot = path.join(getHomeDir(), ".openclaw", "agents");
+  const ids = await listDirectories(agentsRoot);
+
+  const teamIds = new Set(teams.map((t) => t.id));
+
+  const agents: Agent[] = ids.map((id) => {
+    // Team agents are conventionally named <teamId>-<role>
+    const teamMatch = teams.find((t) => id.startsWith(`${t.id}-`));
+
+    const teamId = teamMatch ? teamMatch.id : null;
+    const role = teamId ? id.slice(teamId.length + 1) : null;
+
+    return {
+      id,
+      teamId: teamId && teamIds.has(teamId) ? teamId : null,
+      role,
+    };
+  });
+
+  agents.sort((a, b) => a.id.localeCompare(b.id));
+  return agents;
+}
+
+export async function GET() {
+  try {
+    const teams = await getInstalledTeams();
+    const agents = await getInstalledAgents(teams);
+
+    return NextResponse.json({ teams, agents });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error: "Failed to list installed agents",
+        message: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,75 +1,26 @@
 import { NextResponse } from "next/server";
-import fs from "node:fs/promises";
-import path from "node:path";
 
-type Team = { id: string; name: string };
+import { runOpenClaw } from "@/lib/openclaw";
 
-type Agent = {
+type AgentListItem = {
   id: string;
-  teamId: string | null;
-  role: string | null;
+  identityName?: string;
+  workspace?: string;
+  model?: string;
+  isDefault?: boolean;
 };
-
-function getHomeDir() {
-  return process.env.HOME || "/home/control";
-}
-
-async function listDirectories(dir: string) {
-  const entries = await fs.readdir(dir, { withFileTypes: true });
-  return entries.filter((e) => e.isDirectory()).map((e) => e.name);
-}
-
-async function getInstalledTeams(): Promise<Team[]> {
-  const openclawRoot = path.join(getHomeDir(), ".openclaw");
-  const all = await listDirectories(openclawRoot);
-
-  // Convention: team workspaces are stored as ~/.openclaw/workspace-<teamId>
-  const teams = all
-    .filter((d) => d.startsWith("workspace-") && d !== "workspace-main")
-    .map((d) => d.slice("workspace-".length))
-    // Only treat these as teams if the workspace looks like a team recipe workspace.
-    // (We keep this permissive: any non-main workspace can represent a team install.)
-    .filter(Boolean)
-    .map((id) => ({ id, name: id }));
-
-  teams.sort((a, b) => a.id.localeCompare(b.id));
-  return teams;
-}
-
-async function getInstalledAgents(teams: Team[]): Promise<Agent[]> {
-  const agentsRoot = path.join(getHomeDir(), ".openclaw", "agents");
-  const ids = await listDirectories(agentsRoot);
-
-  const teamIds = new Set(teams.map((t) => t.id));
-
-  const agents: Agent[] = ids.map((id) => {
-    // Team agents are conventionally named <teamId>-<role>
-    const teamMatch = teams.find((t) => id.startsWith(`${t.id}-`));
-
-    const teamId = teamMatch ? teamMatch.id : null;
-    const role = teamId ? id.slice(teamId.length + 1) : null;
-
-    return {
-      id,
-      teamId: teamId && teamIds.has(teamId) ? teamId : null,
-      role,
-    };
-  });
-
-  agents.sort((a, b) => a.id.localeCompare(b.id));
-  return agents;
-}
 
 export async function GET() {
   try {
-    const teams = await getInstalledTeams();
-    const agents = await getInstalledAgents(teams);
+    const { stdout, stderr } = await runOpenClaw(["agents", "list", "--json"]);
 
-    return NextResponse.json({ teams, agents });
+    const agents = JSON.parse(stdout) as AgentListItem[];
+
+    return NextResponse.json({ agents, stderr: stderr || undefined });
   } catch (err) {
     return NextResponse.json(
       {
-        error: "Failed to list installed agents",
+        error: "Failed to list agents",
         message: err instanceof Error ? err.message : String(err),
       },
       { status: 500 },

--- a/src/app/api/agents/skills/route.ts
+++ b/src/app/api/agents/skills/route.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { runOpenClaw } from "@/lib/openclaw";
+
+type AgentListItem = { id: string; workspace?: string };
+
+async function resolveAgentWorkspace(agentId: string) {
+  const { stdout } = await runOpenClaw(["agents", "list", "--json"]);
+  const list = JSON.parse(stdout) as AgentListItem[];
+  const agent = list.find((a) => a.id === agentId);
+  if (!agent?.workspace) throw new Error(`Agent workspace not found for ${agentId}`);
+  return agent.workspace;
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const agentId = String(searchParams.get("agentId") ?? "").trim();
+  if (!agentId) return NextResponse.json({ ok: false, error: "agentId is required" }, { status: 400 });
+
+  const ws = await resolveAgentWorkspace(agentId);
+  const skillsDir = path.join(ws, "skills");
+
+  try {
+    const entries = await fs.readdir(skillsDir, { withFileTypes: true });
+    const skills = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort((a, b) => a.localeCompare(b));
+
+    return NextResponse.json({ ok: true, agentId, workspace: ws, skillsDir, skills });
+  } catch (e: unknown) {
+    return NextResponse.json({ ok: true, agentId, workspace: ws, skillsDir, skills: [], note: e instanceof Error ? e.message : String(e) });
+  }
+}

--- a/src/app/api/agents/update/route.ts
+++ b/src/app/api/agents/update/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { gatewayConfigGet, gatewayConfigPatch } from "@/lib/gateway";
+
+function normalizeAgentId(id: string) {
+  const s = id.trim();
+  if (!s) throw new Error("agentId is required");
+  return s;
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json()) as {
+    agentId?: string;
+    patch?: {
+      workspace?: string;
+      model?: string;
+      identity?: { name?: string; theme?: string; emoji?: string; avatar?: string };
+    };
+  };
+
+  const agentId = normalizeAgentId(String(body.agentId ?? ""));
+  const patch = body.patch ?? {};
+
+  const { raw } = await gatewayConfigGet();
+  const cfg = JSON.parse(raw) as { agents?: { list?: Array<Record<string, unknown>> } };
+
+  const list = Array.isArray(cfg.agents?.list) ? (cfg.agents?.list as Array<Record<string, unknown>>) : [];
+  const idx = list.findIndex((a) => String(a.id ?? "").toLowerCase() === agentId.toLowerCase());
+  if (idx === -1) return NextResponse.json({ ok: false, error: `Agent not found in config: ${agentId}` }, { status: 404 });
+
+  const current = list[idx] ?? {};
+  const currentIdentity = (current.identity ?? {}) as Record<string, unknown>;
+
+  const next: Record<string, unknown> = {
+    ...current,
+    ...(typeof patch.workspace === "string" && patch.workspace.trim() ? { workspace: patch.workspace.trim() } : {}),
+    ...(typeof patch.model === "string" && patch.model.trim() ? { model: patch.model.trim() } : {}),
+    identity: {
+      ...currentIdentity,
+      ...(typeof patch.identity?.name === "string" ? { name: patch.identity.name } : {}),
+      ...(typeof patch.identity?.theme === "string" ? { theme: patch.identity.theme } : {}),
+      ...(typeof patch.identity?.emoji === "string" ? { emoji: patch.identity.emoji } : {}),
+      ...(typeof patch.identity?.avatar === "string" ? { avatar: patch.identity.avatar } : {}),
+    },
+  };
+
+  const nextList = list.slice();
+  nextList[idx] = next;
+
+  await gatewayConfigPatch({ agents: { list: nextList } }, `ClawKitchen: update agent ${agentId}`);
+
+  return NextResponse.json({ ok: true, agentId });
+}

--- a/src/app/api/recipes/team-agents/route.ts
+++ b/src/app/api/recipes/team-agents/route.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import YAML from "yaml";
+import { NextResponse } from "next/server";
+import { getWorkspaceRecipesDir } from "@/lib/paths";
+
+function splitFrontmatter(md: string) {
+  if (!md.startsWith("---\n")) throw new Error("Recipe markdown must start with YAML frontmatter (---)");
+  const end = md.indexOf("\n---\n", 4);
+  if (end === -1) throw new Error("Recipe frontmatter not terminated (---)");
+  const yamlText = md.slice(4, end + 1);
+  const rest = md.slice(end + 5);
+  return { yamlText, rest };
+}
+
+function normalizeRole(role: string) {
+  const r = role.trim();
+  if (!r) throw new Error("role is required");
+  if (!/^[a-z][a-z0-9-]{0,62}$/i.test(r)) throw new Error("role must be alphanumeric/dash");
+  return r;
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json()) as {
+    recipeId?: string;
+    op?: "add" | "remove";
+    role?: string;
+    name?: string;
+  };
+
+  const recipeId = String(body.recipeId ?? "").trim();
+  const op = body.op;
+  if (!recipeId) return NextResponse.json({ ok: false, error: "recipeId is required" }, { status: 400 });
+  if (op !== "add" && op !== "remove") {
+    return NextResponse.json({ ok: false, error: "op must be add|remove" }, { status: 400 });
+  }
+
+  const role = normalizeRole(String(body.role ?? ""));
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+
+  const dir = await getWorkspaceRecipesDir();
+  const filePath = path.join(dir, `${recipeId}.md`);
+
+  const md = await fs.readFile(filePath, "utf8");
+  const { yamlText, rest } = splitFrontmatter(md);
+  const fm = (YAML.parse(yamlText) ?? {}) as Record<string, unknown>;
+
+  const kind = String(fm.kind ?? "");
+  if (kind && kind !== "team") {
+    return NextResponse.json({ ok: false, error: `recipe kind must be team (got ${kind})` }, { status: 400 });
+  }
+
+  const agentsRaw = fm.agents;
+  const agents: Array<Record<string, unknown>> = Array.isArray(agentsRaw)
+    ? (agentsRaw as Array<Record<string, unknown>>)
+    : [];
+
+  let nextAgents = agents.slice();
+
+  if (op === "remove") {
+    nextAgents = nextAgents.filter((a) => String(a.role ?? "") !== role);
+  } else {
+    // add or update by role
+    const next = {
+      ...agents.find((a) => String(a.role ?? "") === role),
+      role,
+      ...(name ? { name } : {}),
+    };
+    const idx = nextAgents.findIndex((a) => String(a.role ?? "") === role);
+    if (idx === -1) nextAgents.push(next);
+    else nextAgents[idx] = next;
+  }
+
+  // Keep stable order by role.
+  nextAgents.sort((a, b) => String(a.role ?? "").localeCompare(String(b.role ?? "")));
+
+  const nextFm = { ...fm, agents: nextAgents };
+  const nextYaml = YAML.stringify(nextFm).trimEnd();
+  const nextMd = `---\n${nextYaml}\n---\n${rest}`;
+
+  await fs.writeFile(filePath, nextMd, "utf8");
+
+  return NextResponse.json({ ok: true, recipeId, filePath, agents: nextAgents, content: nextMd });
+}

--- a/src/app/api/teams/file/route.ts
+++ b/src/app/api/teams/file/route.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { readOpenClawConfig } from "@/lib/paths";
+
+function teamDirFromTeamId(baseWorkspace: string, teamId: string) {
+  return path.resolve(baseWorkspace, "..", `workspace-${teamId}`);
+}
+
+function assertSafeRelative(name: string) {
+  const n = name.replace(/\\/g, "/");
+  if (!n || n.startsWith("/") || n.includes("..")) throw new Error("Invalid file name");
+  return n;
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const teamId = String(searchParams.get("teamId") ?? "").trim();
+  const name = String(searchParams.get("name") ?? "").trim();
+  if (!teamId) return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
+  if (!name) return NextResponse.json({ ok: false, error: "name is required" }, { status: 400 });
+
+  const cfg = await readOpenClawConfig();
+  const baseWorkspace = String(cfg.agents?.defaults?.workspace ?? "").trim();
+  if (!baseWorkspace) {
+    return NextResponse.json({ ok: false, error: "agents.defaults.workspace not set" }, { status: 500 });
+  }
+
+  const safe = assertSafeRelative(name);
+  const teamDir = teamDirFromTeamId(baseWorkspace, teamId);
+  const filePath = path.join(teamDir, safe);
+
+  try {
+    const content = await fs.readFile(filePath, "utf8");
+    return NextResponse.json({ ok: true, teamId, name: safe, filePath, content });
+  } catch (e: unknown) {
+    return NextResponse.json(
+      { ok: false, error: e instanceof Error ? e.message : String(e) },
+      { status: 404 }
+    );
+  }
+}
+
+export async function PUT(req: Request) {
+  const body = (await req.json()) as { teamId?: string; name?: string; content?: string };
+  const teamId = String(body.teamId ?? "").trim();
+  const name = String(body.name ?? "").trim();
+  const content = typeof body.content === "string" ? body.content : null;
+
+  if (!teamId) return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
+  if (!name) return NextResponse.json({ ok: false, error: "name is required" }, { status: 400 });
+  if (content === null) return NextResponse.json({ ok: false, error: "content is required" }, { status: 400 });
+
+  const cfg = await readOpenClawConfig();
+  const baseWorkspace = String(cfg.agents?.defaults?.workspace ?? "").trim();
+  if (!baseWorkspace) {
+    return NextResponse.json({ ok: false, error: "agents.defaults.workspace not set" }, { status: 500 });
+  }
+
+  const safe = assertSafeRelative(name);
+  const teamDir = teamDirFromTeamId(baseWorkspace, teamId);
+  const filePath = path.join(teamDir, safe);
+
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, "utf8");
+  return NextResponse.json({ ok: true, teamId, name: safe, filePath });
+}

--- a/src/app/api/teams/files/route.ts
+++ b/src/app/api/teams/files/route.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { readOpenClawConfig } from "@/lib/paths";
+
+function teamDirFromTeamId(baseWorkspace: string, teamId: string) {
+  return path.resolve(baseWorkspace, "..", `workspace-${teamId}`);
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const teamId = String(searchParams.get("teamId") ?? "").trim();
+  if (!teamId) return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
+
+  const cfg = await readOpenClawConfig();
+  const baseWorkspace = String(cfg.agents?.defaults?.workspace ?? "").trim();
+  if (!baseWorkspace) {
+    return NextResponse.json({ ok: false, error: "agents.defaults.workspace not set" }, { status: 500 });
+  }
+
+  const teamDir = teamDirFromTeamId(baseWorkspace, teamId);
+
+  const candidates = [
+    "SOUL.md",
+    "USER.md",
+    "TEAM.md",
+    "TICKETS.md",
+    "AGENTS.md",
+    "MEMORY.md",
+    "TOOLS.md",
+    "notes/QA_CHECKLIST.md",
+  ];
+
+  const files = await Promise.all(
+    candidates.map(async (name) => {
+      const p = path.join(teamDir, name);
+      try {
+        const st = await fs.stat(p);
+        return { name, path: p, missing: false, size: st.size, updatedAtMs: st.mtimeMs };
+      } catch {
+        return { name, path: p, missing: true };
+      }
+    })
+  );
+
+  return NextResponse.json({ ok: true, teamId, teamDir, files });
+}

--- a/src/app/api/teams/skills/route.ts
+++ b/src/app/api/teams/skills/route.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { readOpenClawConfig } from "@/lib/paths";
+
+function teamDirFromTeamId(baseWorkspace: string, teamId: string) {
+  return path.resolve(baseWorkspace, "..", `workspace-${teamId}`);
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const teamId = String(searchParams.get("teamId") ?? "").trim();
+  if (!teamId) return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
+
+  const cfg = await readOpenClawConfig();
+  const baseWorkspace = String(cfg.agents?.defaults?.workspace ?? "").trim();
+  if (!baseWorkspace) {
+    return NextResponse.json({ ok: false, error: "agents.defaults.workspace not set" }, { status: 500 });
+  }
+
+  const teamDir = teamDirFromTeamId(baseWorkspace, teamId);
+  const skillsDir = path.join(teamDir, "skills");
+
+  try {
+    const entries = await fs.readdir(skillsDir, { withFileTypes: true });
+    const skills = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort((a, b) => a.localeCompare(b));
+
+    return NextResponse.json({ ok: true, teamId, skillsDir, skills });
+  } catch (e: unknown) {
+    // skills dir may not exist
+    return NextResponse.json({ ok: true, teamId, skillsDir, skills: [], note: e instanceof Error ? e.message : String(e) });
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "Claw Kitchen",
-  description: "Local-first UI for authoring Clawcipes recipes and scaffolding agents/teams.",
+  description: "Local-first UI for authoring ClawRecipes recipes and scaffolding agents/teams.",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,44 +1,20 @@
-import Link from "next/link";
+import { runOpenClaw } from "@/lib/openclaw";
+import HomeClient from "./HomeClient";
 
-export default function Home() {
-  return (
-    <div className="ck-glass mx-auto max-w-3xl p-6 sm:p-8">
-      <h1 className="text-3xl font-semibold tracking-tight">
-        Claw Kitchen{" "}
-        <span className="text-sm align-middle text-[color:var(--ck-text-secondary)]">
-          (Phase 1)
-        </span>
-      </h1>
-      <p className="mt-3 max-w-prose text-[color:var(--ck-text-secondary)]">
-        Local-first UI for authoring ClawRecipes recipes and scaffolding agents/teams.
-      </p>
+type AgentListItem = {
+  id: string;
+  identityName?: string;
+  workspace?: string;
+  model?: string;
+  isDefault?: boolean;
+};
 
-      <div className="mt-6 flex flex-wrap gap-3">
-        <Link
-          href="/recipes"
-          className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-4 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[var(--ck-accent-red-hover)] active:bg-[var(--ck-accent-red-active)]"
-        >
-          Recipes
-        </Link>
-        <Link
-          href="/tickets"
-          className="rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] px-4 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[color:var(--ck-bg-glass-strong)]"
-        >
-          Tickets
-        </Link>
-        <Link
-          href="/settings"
-          className="rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] px-4 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[color:var(--ck-bg-glass-strong)]"
-        >
-          Settings
-        </Link>
-        <Link
-          href="/cron-jobs"
-          className="rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] px-4 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[color:var(--ck-bg-glass-strong)]"
-        >
-          Cron jobs
-        </Link>
-      </div>
-    </div>
-  );
+async function getAgents(): Promise<AgentListItem[]> {
+  const { stdout } = await runOpenClaw(["agents", "list", "--json"]);
+  return JSON.parse(stdout) as AgentListItem[];
+}
+
+export default async function Home() {
+  const agents = await getAgents();
+  return <HomeClient agents={agents} />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ export default function Home() {
         </span>
       </h1>
       <p className="mt-3 max-w-prose text-[color:var(--ck-text-secondary)]">
-        Local-first UI for authoring Clawcipes recipes and scaffolding agents/teams.
+        Local-first UI for authoring ClawRecipes recipes and scaffolding agents/teams.
       </p>
 
       <div className="mt-6 flex flex-wrap gap-3">

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -50,6 +50,9 @@ export default async function RecipesPage() {
   const builtin = recipes.filter((r) => r.source === "builtin");
   const workspace = recipes.filter((r) => r.source === "workspace");
 
+  const customTeams = workspace.filter((r) => r.kind === "team" && r.id.startsWith("custom-"));
+  const workspaceOther = workspace.filter((r) => !(r.kind === "team" && r.id.startsWith("custom-")));
+
   return (
     <div className="ck-glass mx-auto max-w-4xl p-6 sm:p-8">
       <div className="flex items-baseline justify-between gap-4">
@@ -63,7 +66,8 @@ export default async function RecipesPage() {
       </div>
 
       <RecipesSection title={`Builtin (${builtin.length})`} items={builtin} />
-      <RecipesSection title={`Workspace (${workspace.length})`} items={workspace} />
+      <RecipesSection title={`Custom team recipes (${customTeams.length})`} items={customTeams} />
+      <RecipesSection title={`Workspace (${workspaceOther.length})`} items={workspaceOther} />
 
       <p className="mt-10 text-xs text-[color:var(--ck-text-tertiary)]">
         Note: editing builtin recipes will modify the recipes plugin install path on this machine.

--- a/src/app/teams/[teamId]/page.tsx
+++ b/src/app/teams/[teamId]/page.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import TeamEditor from "./team-editor";
+
+export default async function TeamPage({ params }: { params: Promise<{ teamId: string }> }) {
+  const { teamId } = await params;
+
+  return (
+    <main className="min-h-screen p-8">
+      <div className="mx-auto mb-4 flex max-w-6xl items-center justify-between gap-4">
+        <Link
+          href="/"
+          className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
+        >
+          ← Home
+        </Link>
+        <div className="text-xs text-[color:var(--ck-text-tertiary)]">Team: {teamId}</div>
+      </div>
+
+      <TeamEditor teamId={teamId} />
+    </main>
+  );
+}

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type RecipeListItem = {
+  id: string;
+  name: string;
+  kind: "agent" | "team";
+  source: "builtin" | "workspace";
+};
+
+type RecipeDetail = RecipeListItem & {
+  content: string;
+  filePath: string | null;
+};
+
+function downloadTextFile(filename: string, text: string) {
+  const blob = new Blob([text], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function TeamEditor({ teamId }: { teamId: string }) {
+  const [recipes, setRecipes] = useState<RecipeListItem[]>([]);
+  const [fromId, setFromId] = useState<string>("");
+  const [toId, setToId] = useState<string>(`custom-${teamId}`);
+  const [toName, setToName] = useState<string>(`Custom ${teamId}`);
+  const [content, setContent] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string>("");
+
+  const teamRecipes = useMemo(
+    () => recipes.filter((r) => r.kind === "team"),
+    [recipes]
+  );
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      setMessage("");
+      try {
+        const res = await fetch("/api/recipes", { cache: "no-store" });
+        const json = await res.json();
+        const list = (json.recipes ?? []) as RecipeListItem[];
+        setRecipes(list);
+
+        // Prefer a recipe with id matching the teamId; fallback to first team recipe.
+        const preferred = list.find((r) => r.kind === "team" && r.id === teamId);
+        const fallback = list.find((r) => r.kind === "team");
+        const pick = preferred ?? fallback;
+        if (pick) setFromId(pick.id);
+      } catch (e: unknown) {
+        setMessage(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [teamId]);
+
+  async function onLoadSource() {
+    if (!fromId) return;
+    setMessage("");
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/recipes/${encodeURIComponent(fromId)}`, { cache: "no-store" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Failed to load recipe");
+      const r = json.recipe as RecipeDetail;
+      setContent(r.content);
+      setMessage(`Loaded source recipe: ${r.id}`);
+    } catch (e: unknown) {
+      setMessage(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onSaveCustom(overwrite: boolean) {
+    const f = fromId.trim();
+    const id = toId.trim();
+    if (!f) return setMessage("Source recipe id is required");
+    if (!id) return setMessage("Custom recipe id is required");
+
+    setSaving(true);
+    setMessage("");
+    try {
+      const res = await fetch("/api/recipes/clone", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ fromId: f, toId: id, toName: toName.trim() || undefined, overwrite }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Save failed");
+      setContent(json.content as string);
+      setMessage(`Saved custom team recipe to workspace recipes: ${json.filePath}`);
+    } catch (e: unknown) {
+      setMessage(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) return <div className="ck-glass mx-auto max-w-4xl p-6">Loading…</div>;
+
+  return (
+    <div className="ck-glass mx-auto max-w-6xl p-6 sm:p-8">
+      <h1 className="text-2xl font-semibold tracking-tight">Team editor</h1>
+      <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+        Phase v2 (thin slice): bootstrap a <strong>custom team recipe</strong> for this installed team, without
+        modifying builtin recipes.
+      </p>
+
+      <div className="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="ck-glass-strong p-4">
+          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Source team recipe</div>
+          <label className="mt-3 block text-xs font-medium text-[color:var(--ck-text-secondary)]">From</label>
+          <select
+            className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+            value={fromId}
+            onChange={(e) => setFromId(e.target.value)}
+          >
+            {teamRecipes.map((r) => (
+              <option key={`${r.source}:${r.id}`} value={r.id}>
+                {r.id} ({r.source})
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={onLoadSource}
+            className="mt-3 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-white/10 active:bg-white/15"
+          >
+            Load source markdown
+          </button>
+        </div>
+
+        <div className="ck-glass-strong p-4">
+          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Custom recipe target</div>
+          <label className="mt-3 block text-xs font-medium text-[color:var(--ck-text-secondary)]">To id</label>
+          <input
+            value={toId}
+            onChange={(e) => setToId(e.target.value)}
+            className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+          />
+
+          <label className="mt-3 block text-xs font-medium text-[color:var(--ck-text-secondary)]">To name</label>
+          <input
+            value={toName}
+            onChange={(e) => setToName(e.target.value)}
+            className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+          />
+
+          <div className="mt-4 grid grid-cols-1 gap-2">
+            <button
+              disabled={saving}
+              onClick={() => onSaveCustom(false)}
+              className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[var(--ck-accent-red-hover)] active:bg-[var(--ck-accent-red-active)] disabled:opacity-50"
+            >
+              {saving ? "Saving…" : "Save (create)"}
+            </button>
+            <button
+              disabled={saving}
+              onClick={() => onSaveCustom(true)}
+              className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-white/10 active:bg-white/15 disabled:opacity-50"
+            >
+              Save (overwrite)
+            </button>
+            <button
+              disabled={!content}
+              onClick={() => downloadTextFile(`${toId || "custom-team"}.md`, content)}
+              className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-white/10 active:bg-white/15 disabled:opacity-50"
+            >
+              Export recipe (download)
+            </button>
+          </div>
+        </div>
+
+        <div className="ck-glass-strong p-4">
+          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Next sub-areas (not yet)</div>
+          <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-[color:var(--ck-text-secondary)]">
+            <li>Agents add/remove</li>
+            <li>Skills</li>
+            <li>Cron jobs</li>
+            <li>Edit team-created files (SOUL.md, etc.)</li>
+          </ul>
+        </div>
+      </div>
+
+      {message ? (
+        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-sm text-[color:var(--ck-text-primary)]">
+          {message}
+        </div>
+      ) : null}
+
+      <div className="mt-6 ck-glass-strong p-4">
+        <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Recipe markdown</div>
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          className="mt-2 h-[55vh] w-full resize-none rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 p-3 font-mono text-xs text-[color:var(--ck-text-primary)]"
+          spellCheck={false}
+        />
+        <p className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
+          This editor currently bootstraps the custom recipe by cloning a source team recipe and patching frontmatter
+          (id/name). Next: make edits to the body and write it back to the workspace recipe file.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Derive a human-readable ticket title from the markdown header slug (e.g. ) and Title-Case it for display. This replaces the current UX where the only readable line is the Created timestamp.

- Lint/build: ✅
- Scope: display-only (no ticket file format changes)