### PR TITLE
UI follow-ups: auto-load agent file + hide missing MEMORY.md

### DIFF
--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -158,6 +158,27 @@ export default function AgentEditor({ agentId }: { agentId: string }) {
     }
   }
 
+  // When entering the Files tab, load the current file immediately (default: IDENTITY.md).
+  useEffect(() => {
+    if (activeTab !== "files") return;
+    if (!agentFiles.length) return;
+
+    const exists = agentFiles.some((f) => f.name === fileName);
+    const fallback = agentFiles[0]?.name;
+    const target = exists ? fileName : fallback;
+    if (!target) return;
+
+    if (target !== fileName) {
+      setFileName(target);
+      setFileContent("");
+    }
+
+    if (!fileContent) {
+      onLoadAgentFile(target);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab, agentId, agentFiles.length]);
+
   async function onSaveAgentFile() {
     setSaving(true);
     setMessage("");

--- a/src/app/api/agents/files/route.ts
+++ b/src/app/api/agents/files/route.ts
@@ -24,7 +24,9 @@ export async function GET(req: Request) {
 
   const ws = await resolveAgentWorkspace(agentId);
 
-  const candidates = ["IDENTITY.md", "SOUL.md", "USER.md", "AGENTS.md", "TOOLS.md", "HEARTBEAT.md", "MEMORY.md"];
+  // Keep the default agent files list focused. MEMORY.md is a main-agent convention
+  // and may not exist in team workspaces, so only show it when present.
+  const candidates = ["IDENTITY.md", "SOUL.md", "USER.md", "AGENTS.md", "TOOLS.md", "HEARTBEAT.md"];
 
   const files = await Promise.all(
     candidates.map(async (name) => {
@@ -37,6 +39,15 @@ export async function GET(req: Request) {
       }
     })
   );
+
+  // Optional: MEMORY.md
+  try {
+    const p = path.join(ws, "MEMORY.md");
+    const st = await fs.stat(p);
+    files.push({ name: "MEMORY.md", path: p, missing: false, size: st.size, updatedAtMs: st.mtimeMs });
+  } catch {
+    // ignore
+  }
 
   return NextResponse.json({ ok: true, agentId, workspace: ws, files });
 }


### PR DESCRIPTION
Follow-ups that were mistakenly pushed after PR #5 had already merged:

- Agent editor: entering the Files tab auto-loads the selected file content (default IDENTITY.md).
- Agent files list: treat MEMORY.md as optional and only show it when present (keeps team workspaces clean).

Lint/build: ✅