### PR TITLE
Home: show friendly team names (not ids)

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -19,7 +19,7 @@ function inferTeamIdFromWorkspace(workspace: string | undefined) {
   return team || null;
 }
 
-export default function HomeClient({ agents }: { agents: AgentListItem[] }) {
+export default function HomeClient({ agents, teamNames }: { agents: AgentListItem[]; teamNames: Record<string, string> }) {
   const teamIds = useMemo(() => {
     const s = new Set<string>();
     for (const a of agents) {
@@ -50,13 +50,17 @@ export default function HomeClient({ agents }: { agents: AgentListItem[] }) {
       return a.localeCompare(b);
     });
 
-    return keys.map((k) => ({
-      key: k,
-      title: k === "personal" ? "Personal / Unassigned" : k,
-      agents: (groups.get(k) ?? []).slice().sort((a, b) => a.id.localeCompare(b.id)),
-      isTeam: k !== "personal",
-    }));
-  }, [agents, teamFilter]);
+    return keys.map((k) => {
+      const display = k === "personal" ? "Personal / Unassigned" : teamNames[k] || k;
+      return {
+        key: k,
+        title: display,
+        subtitle: k === "personal" ? null : k,
+        agents: (groups.get(k) ?? []).slice().sort((a, b) => a.id.localeCompare(b.id)),
+        isTeam: k !== "personal",
+      };
+    });
+  }, [agents, teamFilter, teamNames]);
 
   return (
     <div className="ck-glass mx-auto max-w-5xl p-6 sm:p-8">
@@ -116,7 +120,12 @@ export default function HomeClient({ agents }: { agents: AgentListItem[] }) {
         {grouped.map((g) => (
           <section key={g.key}>
             <div className="flex items-center justify-between gap-4">
-              <h2 className="text-lg font-semibold tracking-tight text-[color:var(--ck-text-primary)]">{g.title}</h2>
+              <div className="min-w-0">
+                <h2 className="truncate text-lg font-semibold tracking-tight text-[color:var(--ck-text-primary)]">{g.title}</h2>
+                {g.subtitle ? (
+                  <div className="mt-0.5 truncate text-xs text-[color:var(--ck-text-secondary)]">{g.subtitle}</div>
+                ) : null}
+              </div>
               {g.isTeam ? (
                 <Link
                   href={`/teams/${encodeURIComponent(g.key)}`}

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -19,7 +19,15 @@ function inferTeamIdFromWorkspace(workspace: string | undefined) {
   return team || null;
 }
 
-export default function HomeClient({ agents, teamNames }: { agents: AgentListItem[]; teamNames: Record<string, string> }) {
+export default function HomeClient({
+  agents,
+  teamNames,
+  customTeams,
+}: {
+  agents: AgentListItem[];
+  teamNames: Record<string, string>;
+  customTeams: Array<{ teamId: string; name: string; recipeId: string }>;
+}) {
   const teamIds = useMemo(() => {
     const s = new Set<string>();
     for (const a of agents) {
@@ -114,6 +122,28 @@ export default function HomeClient({ agents, teamNames }: { agents: AgentListIte
             <option value="personal">Personal / Unassigned</option>
           </select>
         </div>
+      ) : null}
+
+      {customTeams.length ? (
+        <section className="mt-8">
+          <h2 className="text-lg font-semibold tracking-tight text-[color:var(--ck-text-primary)]">Teams</h2>
+          <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {customTeams.map((t) => (
+              <Link
+                key={t.teamId}
+                href={`/teams/${encodeURIComponent(t.teamId)}`}
+                className="ck-glass block px-4 py-3 transition-colors hover:bg-[color:var(--ck-bg-glass-strong)]"
+              >
+                <div className="truncate font-medium text-[color:var(--ck-text-primary)]">{t.name}</div>
+                <div className="mt-1 truncate text-xs text-[color:var(--ck-text-secondary)]">{t.teamId}</div>
+                <div className="mt-1 truncate text-xs text-[color:var(--ck-text-tertiary)]">Recipe: {t.recipeId}</div>
+              </Link>
+            ))}
+          </div>
+          <p className="mt-3 text-xs text-[color:var(--ck-text-tertiary)]">
+            Teams appear here when you have a workspace custom team recipe (custom-*), even before you scaffold the team.
+          </p>
+        </section>
       ) : null}
 
       <div className="mt-8 space-y-8">

--- a/src/app/api/recipes/[id]/route.ts
+++ b/src/app/api/recipes/[id]/route.ts
@@ -50,6 +50,10 @@ export async function PUT(
   const item = recipes.find((r) => r.id === id);
   if (!item) return NextResponse.json({ error: `Recipe not found: ${id}` }, { status: 404 });
 
+  if (item.source === "builtin") {
+    return NextResponse.json({ error: `Recipe ${id} is builtin and cannot be modified` }, { status: 403 });
+  }
+
   const filePath = await resolveRecipePath(item);
   await writeRecipeFile(filePath, body.content);
 

--- a/src/app/api/recipes/clone/route.ts
+++ b/src/app/api/recipes/clone/route.ts
@@ -31,6 +31,12 @@ export async function POST(req: Request) {
 
   if (!fromId) return NextResponse.json({ ok: false, error: "Missing fromId" }, { status: 400 });
   if (!toId) return NextResponse.json({ ok: false, error: "Missing toId" }, { status: 400 });
+  if (!toId.startsWith("custom-")) {
+    return NextResponse.json(
+      { ok: false, error: "Clone target id must start with 'custom-'" },
+      { status: 400 },
+    );
+  }
 
   // Load source markdown from OpenClaw CLI (no HTTP self-call; avoids dev-server deadlocks/timeouts).
   const shown = await runOpenClaw(["recipes", "show", fromId]);

--- a/src/app/api/teams/files/route.ts
+++ b/src/app/api/teams/files/route.ts
@@ -20,25 +20,34 @@ export async function GET(req: Request) {
 
   const teamDir = teamDirFromTeamId(baseWorkspace, teamId);
 
-  const candidates = [
-    "SOUL.md",
-    "USER.md",
-    "TEAM.md",
-    "TICKETS.md",
-    "AGENTS.md",
-    "MEMORY.md",
-    "TOOLS.md",
-    "notes/QA_CHECKLIST.md",
+  const candidates: Array<{ name: string; required: boolean; rationale: string }> = [
+    { name: "TEAM.md", required: true, rationale: "Team workspace overview" },
+    { name: "TICKETS.md", required: true, rationale: "Ticket workflow + format" },
+    { name: "notes/QA_CHECKLIST.md", required: true, rationale: "QA verification checklist" },
+
+    { name: "SOUL.md", required: false, rationale: "Optional team persona (some teams use role SOUL.md only)" },
+    { name: "USER.md", required: false, rationale: "Optional user profile" },
+    { name: "AGENTS.md", required: false, rationale: "Optional team notes (often role-scoped)" },
+    { name: "TOOLS.md", required: false, rationale: "Optional team-local tooling notes" },
+    { name: "MEMORY.md", required: false, rationale: "Optional curated memory" },
   ];
 
   const files = await Promise.all(
-    candidates.map(async (name) => {
-      const p = path.join(teamDir, name);
+    candidates.map(async (c) => {
+      const p = path.join(teamDir, c.name);
       try {
         const st = await fs.stat(p);
-        return { name, path: p, missing: false, size: st.size, updatedAtMs: st.mtimeMs };
+        return {
+          name: c.name,
+          required: c.required,
+          rationale: c.rationale,
+          path: p,
+          missing: false,
+          size: st.size,
+          updatedAtMs: st.mtimeMs,
+        };
       } catch {
-        return { name, path: p, missing: true };
+        return { name: c.name, required: c.required, rationale: c.rationale, path: p, missing: true };
       }
     })
   );

--- a/src/app/api/teams/remove-team/route.ts
+++ b/src/app/api/teams/remove-team/route.ts
@@ -6,6 +6,25 @@ export async function POST(req: Request) {
   const teamId = String(body.teamId ?? "").trim();
   if (!teamId) return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
 
+  // Server-side guardrail: refuse deletion of builtin teams.
+  // Convention: scaffolded team ids are typically <recipeId>-team.
+  const list = await runOpenClaw(["recipes", "list"]);
+  if (list.ok) {
+    try {
+      const recipes = JSON.parse(list.stdout) as Array<{ id?: string; kind?: string; source?: string }>;
+      const normalized = teamId.endsWith("-team") ? teamId.slice(0, -"-team".length) : teamId;
+      const match = recipes.find((r) => r.kind === "team" && (r.id === teamId || r.id === normalized));
+      if (match?.source === "builtin") {
+        return NextResponse.json(
+          { ok: false, error: `Refusing to delete builtin team: ${teamId}. Clone to a custom team first.` },
+          { status: 403 },
+        );
+      }
+    } catch {
+      // ignore parse issues; best-effort guard
+    }
+  }
+
   const args = ["recipes", "remove-team", "--team-id", teamId, "--yes", "--json"];
   if (body.includeAmbiguous) args.push("--include-ambiguous");
 

--- a/src/app/api/teams/remove-team/route.ts
+++ b/src/app/api/teams/remove-team/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { runOpenClaw } from "@/lib/openclaw";
+
+export async function POST(req: Request) {
+  const body = (await req.json()) as { teamId?: string; includeAmbiguous?: boolean };
+  const teamId = String(body.teamId ?? "").trim();
+  if (!teamId) return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
+
+  const args = ["recipes", "remove-team", "--team-id", teamId, "--yes", "--json"];
+  if (body.includeAmbiguous) args.push("--include-ambiguous");
+
+  const res = await runOpenClaw(args);
+  if (!res.ok) {
+    return NextResponse.json(
+      { ok: false, error: res.stderr.trim() || `openclaw ${args.join(" ")} failed (exit=${res.exitCode})`, stdout: res.stdout, stderr: res.stderr },
+      { status: 500 },
+    );
+  }
+
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(res.stdout);
+  } catch {
+    parsed = { raw: res.stdout };
+  }
+
+  return NextResponse.json({ ok: true, result: parsed, stderr: res.stderr });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,12 +9,44 @@ type AgentListItem = {
   isDefault?: boolean;
 };
 
+type RecipeListItem = {
+  id: string;
+  name: string;
+  kind: "agent" | "team";
+  source: "builtin" | "workspace";
+};
+
 async function getAgents(): Promise<AgentListItem[]> {
-  const { stdout } = await runOpenClaw(["agents", "list", "--json"]);
-  return JSON.parse(stdout) as AgentListItem[];
+  const res = await runOpenClaw(["agents", "list", "--json"]);
+  if (!res.ok) return [];
+  return JSON.parse(res.stdout) as AgentListItem[];
+}
+
+async function getTeamNameMap(): Promise<Record<string, string>> {
+  const res = await runOpenClaw(["recipes", "list"]);
+  if (!res.ok) return {};
+
+  let items: RecipeListItem[] = [];
+  try {
+    items = JSON.parse(res.stdout) as RecipeListItem[];
+  } catch {
+    return {};
+  }
+
+  const map: Record<string, string> = {};
+  for (const r of items) {
+    if (r.kind !== "team") continue;
+    const name = String(r.name ?? "").trim();
+    if (!name) continue;
+
+    // Support both conventions: <id> and <id>-team.
+    map[r.id] = name;
+    map[`${r.id}-team`] = name;
+  }
+  return map;
 }
 
 export default async function Home() {
-  const agents = await getAgents();
-  return <HomeClient agents={agents} />;
+  const [agents, teamNames] = await Promise.all([getAgents(), getTeamNameMap()]);
+  return <HomeClient agents={agents} teamNames={teamNames} />;
 }

--- a/src/app/recipes/[id]/page.tsx
+++ b/src/app/recipes/[id]/page.tsx
@@ -1,8 +1,35 @@
 import Link from "next/link";
+import { redirect } from "next/navigation";
+import { runOpenClaw } from "@/lib/openclaw";
 import RecipeEditor from "./RecipeEditor";
+
+type RecipeListItem = {
+  id: string;
+  name: string;
+  kind: "agent" | "team";
+  source: "builtin" | "workspace";
+};
+
+async function getKind(id: string): Promise<"agent" | "team" | null> {
+  const res = await runOpenClaw(["recipes", "list"]);
+  if (!res.ok) return null;
+  try {
+    const items = JSON.parse(res.stdout) as RecipeListItem[];
+    return items.find((r) => r.id === id)?.kind ?? null;
+  } catch {
+    return null;
+  }
+}
 
 export default async function RecipePage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  const kind = await getKind(id);
+
+  // Team recipes should use the Team editor UI.
+  if (kind === "team") {
+    redirect(`/teams/${encodeURIComponent(id)}-team`);
+  }
+
   return (
     <main className="min-h-screen p-8">
       <div className="mx-auto mb-4 max-w-6xl">

--- a/src/app/teams/[teamId]/page.tsx
+++ b/src/app/teams/[teamId]/page.tsx
@@ -1,8 +1,30 @@
 import Link from "next/link";
+import { runOpenClaw } from "@/lib/openclaw";
 import TeamEditor from "./team-editor";
+
+type RecipeListItem = {
+  id: string;
+  name: string;
+  kind: "agent" | "team";
+  source: "builtin" | "workspace";
+};
+
+async function getTeamDisplayName(teamId: string) {
+  const res = await runOpenClaw(["recipes", "list"]);
+  if (!res.ok) return null;
+  try {
+    const items = JSON.parse(res.stdout) as RecipeListItem[];
+    const normalized = teamId.endsWith("-team") ? teamId.slice(0, -"-team".length) : teamId;
+    const match = items.find((r) => r.kind === "team" && (r.id === teamId || r.id === normalized));
+    return match?.name ?? null;
+  } catch {
+    return null;
+  }
+}
 
 export default async function TeamPage({ params }: { params: Promise<{ teamId: string }> }) {
   const { teamId } = await params;
+  const name = await getTeamDisplayName(teamId);
 
   return (
     <main className="min-h-screen p-8">
@@ -13,7 +35,10 @@ export default async function TeamPage({ params }: { params: Promise<{ teamId: s
         >
           ← Home
         </Link>
-        <div className="text-xs text-[color:var(--ck-text-tertiary)]">Team: {teamId}</div>
+        <div className="text-right">
+          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">{name || teamId}</div>
+          <div className="text-xs text-[color:var(--ck-text-tertiary)]">{teamId}</div>
+        </div>
       </div>
 
       <TeamEditor teamId={teamId} />

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -80,10 +80,13 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
   const [newRoleName, setNewRoleName] = useState<string>("");
   const [skillsList, setSkillsList] = useState<string[]>([]);
 
-  const teamRecipes = useMemo(
-    () => recipes.filter((r) => r.kind === "team"),
-    [recipes]
-  );
+  const teamRecipes = useMemo(() => recipes.filter((r) => r.kind === "team"), [recipes]);
+
+  const toRecipe = useMemo(() => recipes.find((r) => r.id === toId) ?? null, [recipes, toId]);
+
+  const teamIdValid = teamId.endsWith("-team");
+  const targetIdValid = toId.trim().startsWith("custom-");
+  const targetIsBuiltin = toRecipe?.source === "builtin";
 
   useEffect(() => {
     (async () => {
@@ -367,26 +370,84 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
 
             <div className="mt-4 grid grid-cols-1 gap-2">
               <button
-                disabled={saving}
-                onClick={() => onSaveCustom(false)}
+                disabled={saving || !teamIdValid || !targetIdValid || targetIsBuiltin}
+                onClick={() => onSaveCustom(true)}
                 className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[var(--ck-accent-red-hover)] active:bg-[var(--ck-accent-red-active)] disabled:opacity-50"
               >
-                {saving ? "Saving…" : "Save (create)"}
+                {saving ? "Saving…" : "Save (overwrite)"}
               </button>
+
               <button
-                disabled={saving}
-                onClick={() => onSaveCustom(true)}
+                disabled={saving || !teamIdValid || !targetIdValid || targetIsBuiltin}
+                onClick={() => onSaveCustom(false)}
                 className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-white/10 active:bg-white/15 disabled:opacity-50"
               >
-                Save (overwrite)
+                Clone Team (create custom copy)
               </button>
+
               <button
-                disabled={!content || saving}
+                disabled={!content || saving || !targetIdValid || targetIsBuiltin}
                 onClick={onSaveMarkdown}
                 className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-white/10 active:bg-white/15 disabled:opacity-50"
               >
                 Save markdown
               </button>
+
+              <button
+                disabled={saving || !teamIdValid}
+                onClick={async () => {
+                  setSaving(true);
+                  flashMessage("");
+                  try {
+                    const res = await fetch("/api/scaffold", {
+                      method: "POST",
+                      headers: { "content-type": "application/json" },
+                      body: JSON.stringify({ kind: "team", recipeId: fromId.trim(), teamId, applyConfig: true, overwrite: false }),
+                    });
+                    const json = await res.json();
+                    if (!res.ok || !json.ok) throw new Error(json.error || "Publish failed");
+                    flashMessage("Published (scaffold-team) successfully");
+                  } catch (e: unknown) {
+                    flashMessage(e instanceof Error ? e.message : String(e));
+                  } finally {
+                    setSaving(false);
+                  }
+                }}
+                className="rounded-[var(--ck-radius-sm)] border border-emerald-400/30 bg-emerald-500/10 px-3 py-2 text-sm font-medium text-emerald-200 shadow-[var(--ck-shadow-1)] transition-colors hover:bg-emerald-500/20 active:bg-emerald-500/25 disabled:opacity-50"
+              >
+                Publish
+              </button>
+
+              <button
+                disabled={saving}
+                onClick={async () => {
+                  const ok = window.confirm(
+                    `Delete team ${teamId}? This will remove the team workspace, agents, and stamped cron jobs.`,
+                  );
+                  if (!ok) return;
+                  setSaving(true);
+                  flashMessage("");
+                  try {
+                    const res = await fetch("/api/teams/remove-team", {
+                      method: "POST",
+                      headers: { "content-type": "application/json" },
+                      body: JSON.stringify({ teamId }),
+                    });
+                    const json = await res.json();
+                    if (!res.ok || !json.ok) throw new Error(json.error || "Delete failed");
+                    flashMessage("Deleted team successfully");
+                    setTimeout(() => router.push("/"), 250);
+                  } catch (e: unknown) {
+                    flashMessage(e instanceof Error ? e.message : String(e));
+                  } finally {
+                    setSaving(false);
+                  }
+                }}
+                className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-white/10 active:bg-white/15 disabled:opacity-50"
+              >
+                Delete Team
+              </button>
+
               <button
                 disabled={!content}
                 onClick={() => downloadTextFile(`${toId || "custom-team"}.md`, content)}
@@ -402,13 +463,19 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
             <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-[color:var(--ck-text-secondary)]">
               <li>Builtin recipes are treated as read-only; edits should be saved to a custom clone.</li>
               <li>
-                <strong>Save (create)</strong> creates a new custom recipe file (fails if it already exists).
+                <strong>Save (overwrite)</strong> overwrites the existing custom recipe file (workspace/custom only).
               </li>
               <li>
-                <strong>Save (overwrite)</strong> overwrites the existing custom recipe file.
+                <strong>Clone Team</strong> creates a custom recipe copy (fails if it already exists).
               </li>
               <li>
                 <strong>Save markdown</strong> writes the current editor content to the custom recipe file.
+              </li>
+              <li>
+                <strong>Publish</strong> runs scaffold-team for this team id.
+              </li>
+              <li>
+                <strong>Delete Team</strong> runs the safe uninstall command (<code>openclaw recipes remove-team</code>).
               </li>
             </ul>
           </div>


### PR DESCRIPTION
Use recipe name as the primary label for teams on Home, including the team filter dropdown; normalize legacy teamIds ending with -team when looking up display names.