### PR TITLE
Teams: persist parent recipe provenance + lock Source recipe

### DIFF
--- a/src/app/api/teams/meta/route.ts
+++ b/src/app/api/teams/meta/route.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { readOpenClawConfig } from "@/lib/paths";
+
+function teamDirFromTeamId(baseWorkspace: string, teamId: string) {
+  return path.resolve(baseWorkspace, "..", `workspace-${teamId}`);
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const teamId = String(searchParams.get("teamId") ?? "").trim();
+  if (!teamId) return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
+
+  const cfg = await readOpenClawConfig();
+  const baseWorkspace = String(cfg.agents?.defaults?.workspace ?? "").trim();
+  if (!baseWorkspace) {
+    return NextResponse.json({ ok: false, error: "agents.defaults.workspace not set" }, { status: 500 });
+  }
+
+  const teamDir = teamDirFromTeamId(baseWorkspace, teamId);
+  const metaPath = path.join(teamDir, "team.json");
+
+  try {
+    const raw = await fs.readFile(metaPath, "utf8");
+    const meta = JSON.parse(raw) as Record<string, unknown>;
+    return NextResponse.json({ ok: true, teamId, teamDir, metaPath, meta });
+  } catch {
+    return NextResponse.json({ ok: true, teamId, teamDir, metaPath, meta: null, missing: true });
+  }
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json()) as { teamId?: string; recipeId?: string; recipeName?: string };
+  const teamId = String(body.teamId ?? "").trim();
+  const recipeId = String(body.recipeId ?? "").trim();
+  const recipeName = typeof body.recipeName === "string" ? body.recipeName : "";
+
+  if (!teamId) return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
+  if (!recipeId) return NextResponse.json({ ok: false, error: "recipeId is required" }, { status: 400 });
+
+  const cfg = await readOpenClawConfig();
+  const baseWorkspace = String(cfg.agents?.defaults?.workspace ?? "").trim();
+  if (!baseWorkspace) {
+    return NextResponse.json({ ok: false, error: "agents.defaults.workspace not set" }, { status: 500 });
+  }
+
+  const teamDir = teamDirFromTeamId(baseWorkspace, teamId);
+  const metaPath = path.join(teamDir, "team.json");
+
+  const meta = {
+    teamId,
+    recipeId,
+    recipeName,
+    attachedAt: new Date().toISOString(),
+  };
+
+  await fs.mkdir(teamDir, { recursive: true });
+  await fs.writeFile(metaPath, JSON.stringify(meta, null, 2) + "\n", "utf8");
+
+  return NextResponse.json({ ok: true, teamId, teamDir, metaPath, meta });
+}

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -50,6 +50,9 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
   const router = useRouter();
   const [recipes, setRecipes] = useState<RecipeListItem[]>([]);
   const [fromId, setFromId] = useState<string>("");
+  const [lockedFromId, setLockedFromId] = useState<string | null>(null);
+  const [lockedFromName, setLockedFromName] = useState<string | null>(null);
+  const [provenanceMissing, setProvenanceMissing] = useState(false);
   const [toId, setToId] = useState<string>(`custom-${teamId}`);
   const [toName, setToName] = useState<string>(`Custom ${teamId}`);
   const [content, setContent] = useState<string>("");
@@ -84,7 +87,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
 
   const toRecipe = useMemo(() => recipes.find((r) => r.id === toId) ?? null, [recipes, toId]);
 
-  const teamIdValid = teamId.endsWith("-team");
+  const teamIdValid = Boolean(teamId.trim());
   const targetIdValid = toId.trim().startsWith("custom-");
   const targetIsBuiltin = toRecipe?.source === "builtin";
 
@@ -93,32 +96,46 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
       setLoading(true);
       setMessage("");
       try {
-        const res = await fetch("/api/recipes", { cache: "no-store" });
-        const json = await res.json();
+        const [recipesRes, metaRes] = await Promise.all([
+          fetch("/api/recipes", { cache: "no-store" }),
+          fetch(`/api/teams/meta?teamId=${encodeURIComponent(teamId)}`, { cache: "no-store" }),
+        ]);
+
+        const json = await recipesRes.json();
         const list = (json.recipes ?? []) as RecipeListItem[];
         setRecipes(list);
 
         // Prefer a recipe that corresponds to this teamId.
-        // Heuristics:
-        // - exact match (teamId)
-        // - normalized legacy "-team" suffix
-        // - smoke prefix mapping: smoke-<id> -> <id> (e.g., smoke-product-team -> product-team)
-        const normalizedTeamId = teamId.endsWith("-team") ? teamId.slice(0, -"-team".length) : teamId;
-        const candidates = Array.from(
-          new Set([
-            teamId,
-            normalizedTeamId,
-            teamId.replace(/^smoke-/, ""),
-            normalizedTeamId.replace(/^smoke-/, ""),
-          ]),
-        ).filter(Boolean);
+        // Primary source of truth: provenance stored in the team workspace.
+        // Fallback: heuristic matching (legacy teams without provenance).
+        let locked: { recipeId: string; recipeName?: string } | null = null;
+        try {
+          const metaJson = await metaRes.json();
+          if (metaRes.ok && metaJson.ok && metaJson.meta?.recipeId) {
+            locked = {
+              recipeId: String(metaJson.meta.recipeId),
+              recipeName: typeof metaJson.meta.recipeName === "string" ? metaJson.meta.recipeName : undefined,
+            };
+          }
+        } catch {
+          // ignore
+        }
 
-        const preferred = candidates
-          .map((id) => list.find((r) => r.kind === "team" && r.id === id))
-          .find(Boolean);
-        const fallback = list.find((r) => r.kind === "team");
-        const pick = preferred ?? fallback;
-        if (pick) setFromId(pick.id);
+        if (locked) {
+          setLockedFromId(locked.recipeId);
+          setLockedFromName(locked.recipeName ?? null);
+          setProvenanceMissing(false);
+          setFromId(locked.recipeId);
+        } else {
+          setLockedFromId(null);
+          setLockedFromName(null);
+          setProvenanceMissing(true);
+
+          const preferred = list.find((r) => r.kind === "team" && r.id === teamId);
+          const fallback = list.find((r) => r.kind === "team");
+          const pick = preferred ?? fallback;
+          if (pick) setFromId(pick.id);
+        }
 
         // Load ancillary data for sub-areas.
         const [filesRes, cronRes, agentsRes, skillsRes] = await Promise.all([
@@ -350,7 +367,8 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
             <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Source team recipe</div>
             <label className="mt-3 block text-xs font-medium text-[color:var(--ck-text-secondary)]">From</label>
             <select
-              className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+              disabled={Boolean(lockedFromId)}
+              className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)] disabled:opacity-70"
               value={fromId}
               onChange={(e) => setFromId(e.target.value)}
             >
@@ -360,12 +378,58 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                 </option>
               ))}
             </select>
+            {lockedFromId ? (
+              <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
+                Locked to parent recipe: <code>{lockedFromId}</code>
+                {lockedFromName ? ` (${lockedFromName})` : ""}
+              </div>
+            ) : provenanceMissing ? (
+              <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
+                Provenance not found for this team. The source recipe above is a best-guess.
+              </div>
+            ) : null}
             <button
               onClick={onLoadSource}
               className="mt-3 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-white/10 active:bg-white/15"
             >
               Load source markdown
             </button>
+
+            {provenanceMissing ? (
+              <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-sm text-[color:var(--ck-text-secondary)]">
+                <div className="font-medium text-[color:var(--ck-text-primary)]">Provenance missing</div>
+                <div className="mt-1">
+                  This team workspace is missing <code>team.json</code>, so ClawKitchen is guessing the source recipe.
+                </div>
+                <button
+                  disabled={saving || !fromId}
+                  onClick={async () => {
+                    setSaving(true);
+                    flashMessage("");
+                    try {
+                      const match = teamRecipes.find((r) => r.id === fromId);
+                      const res = await fetch("/api/teams/meta", {
+                        method: "POST",
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify({ teamId, recipeId: fromId, recipeName: match?.name ?? "" }),
+                      });
+                      const json = await res.json();
+                      if (!res.ok || !json.ok) throw new Error(json.error || "Attach provenance failed");
+                      setLockedFromId(fromId);
+                      setProvenanceMissing(false);
+                      flashMessage("Attached provenance (team.json)");
+                    } catch (e: unknown) {
+                      flashMessage(e instanceof Error ? e.message : String(e));
+                    } finally {
+                      setSaving(false);
+                    }
+                  }}
+                  className="mt-3 rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] hover:bg-white/10 disabled:opacity-50"
+                >
+                  Attach provenance
+                </button>
+              </div>
+            ) : null}
           </div>
 
           <div className="ck-glass-strong p-4">

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -111,10 +111,11 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
         let locked: { recipeId: string; recipeName?: string } | null = null;
         try {
           const metaJson = await metaRes.json();
-          if (metaRes.ok && metaJson.ok && metaJson.meta?.recipeId) {
+          if (metaRes.ok && metaJson.ok && metaJson.meta && (metaJson.meta as { recipeId?: unknown }).recipeId) {
+            const m = metaJson.meta as { recipeId?: unknown; recipeName?: unknown };
             locked = {
-              recipeId: String(metaJson.meta.recipeId),
-              recipeName: typeof metaJson.meta.recipeName === "string" ? metaJson.meta.recipeName : undefined,
+              recipeId: String(m.recipeId),
+              recipeName: typeof m.recipeName === "string" ? m.recipeName : undefined,
             };
           }
         } catch {


### PR DESCRIPTION
Fixes the root cause behind ‘wrong team loaded’ in the Team editor when teamId != recipeId.

What this does (system-wide; no smoke-only hacks):
- Persists team provenance in the scaffolded team workspace (team.json) when creating a team via Kitchen scaffold (/api/scaffold).
  - Fields: teamId, recipeId (parent recipe), optional recipeName snapshot, timestamps.
- Adds /api/teams/meta to read (and attach, for legacy teams) the provenance metadata.
- Updates the Team editor to load the parent recipeId from team meta and LOCK the Source recipe selector to it.
  - If meta is missing, falls back to the previous heuristic and shows a warning.

Why:
- Any team created from a recipe must know its parent recipe. The Team editor should not guess based on ids.

Testing:
- Scaffold a team with an arbitrary teamId from product-team.
- Visit /teams/<teamId> and confirm Source recipe is locked to product-team.

Notes:
- This replaces the earlier ‘smoke-*’ mapping idea; that was a stopgap and is not the intended approach.