### PR TITLE
Restore ClawKitchen UI changes (recipes + goals workflow + misc fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ npm run dev -- --port 3001
 Open:
 - http://localhost:3001
 
+## Goals
+See [docs/GOALS.md](docs/GOALS.md).
+
 ## Notes
 - This app shells out to `openclaw` on the same machine (local-first by design).
 - Phase 2 will add marketplace/search/publish flows.

--- a/docs/GOALS.md
+++ b/docs/GOALS.md
@@ -1,0 +1,40 @@
+# Goals (ClawKitchen)
+
+ClawKitchen stores goals as **markdown files** in the OpenClaw **global workspace**.
+
+## Canonical storage root
+
+`~/.openclaw/workspace/notes/goals/`
+
+Each goal is a single file:
+
+`~/.openclaw/workspace/notes/goals/<id>.md`
+
+## Frontmatter schema
+
+Goals are markdown with YAML frontmatter:
+
+```yaml
+---
+id: increase-trial-activation
+title: Increase trial activation
+status: planned # planned|active|done
+tags: [growth, onboarding]
+teams: [development-team, marketing-team]
+updatedAt: 2026-02-17T00:30:00Z
+---
+```
+
+Body below the frontmatter is freeform markdown.
+
+## Multi-team association
+
+A goal that spans multiple teams is represented by **one canonical goal file**.
+Use `teams: [...]` to associate it with multiple teams. The UI supports filtering by team.
+
+## Safety
+
+The Goals API:
+- restricts writes/reads to the allowlisted goals root
+- rejects path traversal
+- validates goal ids (lowercase letters/numbers/hyphens)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "smoke:goals": "node scripts/goals-smoke.mjs"
   },
   "dependencies": {
     "next": "16.1.6",

--- a/scripts/goals-smoke.mjs
+++ b/scripts/goals-smoke.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const WORKSPACE = "/home/control/.openclaw/workspace";
+const GOALS_DIR = path.join(WORKSPACE, "notes", "goals");
+
+const id = `smoke-goal-${Date.now()}`;
+const file = path.join(GOALS_DIR, `${id}.md`);
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error("[goals-smoke] FAIL:", msg);
+    process.exit(1);
+  }
+}
+
+await fs.mkdir(GOALS_DIR, { recursive: true });
+
+const initial = `---\nid: ${id}\ntitle: Smoke goal\nstatus: planned\ntags: []\nteams: [development-team]\nupdatedAt: ${new Date().toISOString()}\n---\n\nHello world\n`;
+await fs.writeFile(file, initial, "utf8");
+
+const read1 = await fs.readFile(file, "utf8");
+assert(read1.includes(`id: ${id}`), "create/read failed");
+
+const updated = read1.replace("Smoke goal", "Smoke goal updated");
+await fs.writeFile(file, updated, "utf8");
+
+const read2 = await fs.readFile(file, "utf8");
+assert(read2.includes("Smoke goal updated"), "update failed");
+
+await fs.unlink(file);
+
+console.log("[goals-smoke] OK");

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -27,11 +27,9 @@ function normalizeTeamId(teamId: string) {
 export default function HomeClient({
   agents,
   teamNames,
-  customTeams,
 }: {
   agents: AgentListItem[];
   teamNames: Record<string, string>;
-  customTeams: Array<{ teamId: string; name: string; recipeId: string }>;
 }) {
   const teamIds = useMemo(() => {
     const s = new Set<string>();
@@ -153,27 +151,7 @@ export default function HomeClient({
         </div>
       ) : null}
 
-      {customTeams.length ? (
-        <section className="mt-8">
-          <h2 className="text-lg font-semibold tracking-tight text-[color:var(--ck-text-primary)]">Teams</h2>
-          <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-            {customTeams.map((t) => (
-              <Link
-                key={t.teamId}
-                href={`/teams/${encodeURIComponent(t.teamId)}`}
-                className="ck-glass block px-4 py-3 transition-colors hover:bg-[color:var(--ck-bg-glass-strong)]"
-              >
-                <div className="truncate font-medium text-[color:var(--ck-text-primary)]">{t.name}</div>
-                <div className="mt-1 truncate text-xs text-[color:var(--ck-text-secondary)]">{t.teamId}</div>
-                <div className="mt-1 truncate text-xs text-[color:var(--ck-text-tertiary)]">Recipe: {t.recipeId}</div>
-              </Link>
-            ))}
-          </div>
-          <p className="mt-3 text-xs text-[color:var(--ck-text-tertiary)]">
-            Teams appear here when you have a workspace custom team recipe (custom-*), even before you scaffold the team.
-          </p>
-        </section>
-      ) : null}
+      
 
       <div className="mt-8 space-y-8">
         {grouped.map((g) => (

--- a/src/app/api/channels/bindings/route.ts
+++ b/src/app/api/channels/bindings/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { gatewayConfigGet, gatewayConfigPatch } from "@/lib/gateway";
+
+function safeJsonParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return Boolean(v) && typeof v === "object" && !Array.isArray(v);
+}
+
+export async function GET() {
+  try {
+    const { raw, hash } = await gatewayConfigGet();
+    const parsed = safeJsonParse(raw);
+    const root = isRecord(parsed) ? parsed : {};
+    const channels = isRecord(root.channels) ? root.channels : {};
+    return NextResponse.json({ ok: true, hash, channels });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+  }
+}
+
+type UpsertBody = {
+  provider: string;
+  config: Record<string, unknown>;
+};
+
+export async function PUT(req: Request) {
+  try {
+    const body = (await req.json()) as UpsertBody;
+    const provider = String(body?.provider ?? "").trim();
+    if (!provider) return NextResponse.json({ ok: false, error: "provider is required" }, { status: 400 });
+
+    const cfg = isRecord(body?.config) ? body.config : null;
+    if (!cfg) return NextResponse.json({ ok: false, error: "config must be an object" }, { status: 400 });
+
+    // v1 validation (Telegram as reference)
+    if (provider === "telegram") {
+      const botToken = String(cfg.botToken ?? "").trim();
+      if (!botToken) return NextResponse.json({ ok: false, error: "telegram.botToken is required" }, { status: 400 });
+    }
+
+    await gatewayConfigPatch({ channels: { [provider]: cfg } }, `ClawKitchen Channels upsert: ${provider}`);
+    return NextResponse.json({ ok: true });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+  }
+}
+
+type DeleteBody = { provider: string };
+
+export async function DELETE(req: Request) {
+  try {
+    const body = (await req.json()) as DeleteBody;
+    const provider = String(body?.provider ?? "").trim();
+    if (!provider) return NextResponse.json({ ok: false, error: "provider is required" }, { status: 400 });
+
+    // Patch semantics: setting a provider to null removes/clears it in the gateway config patcher.
+    await gatewayConfigPatch({ channels: { [provider]: null } }, `ClawKitchen Channels delete: ${provider}`);
+    return NextResponse.json({ ok: true });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/goals/[id]/promote/route.ts
+++ b/src/app/api/goals/[id]/promote/route.ts
@@ -1,0 +1,158 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { NextResponse } from "next/server";
+
+import { readGoal, writeGoal } from "@/lib/goals";
+import { getTeamWorkspaceDir, readOpenClawConfig } from "@/lib/paths";
+
+const execFileAsync = promisify(execFile);
+
+function slugifyFilePart(input: string) {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/[\s_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+const WORKFLOW_MARKER = "<!-- goal-workflow -->";
+
+function ensureWorkflowInstructions(body: string) {
+  if (body.includes(WORKFLOW_MARKER)) return body;
+  const snippet = [
+    "",
+    "## Workflow",
+    WORKFLOW_MARKER,
+    "- Use **Promote to inbox** to send this goal to the development-team inbox for scoping.",
+    "- When promoted, set goal status to **active**.",
+    "- Track implementation work via tickets (add links/IDs under a **Tickets** section in this goal).",
+    "- When development is complete (all associated tickets marked done), set goal status to **done**.",
+    "",
+    "## Tickets",
+    "- (add ticket links/ids)",
+    "",
+  ].join("\n");
+
+  return (body ?? "").trim() + snippet;
+}
+
+export async function POST(_: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const goalId = decodeURIComponent(id);
+
+    const existing = await readGoal(goalId);
+    if (!existing) return NextResponse.json({ error: "Goal not found" }, { status: 404 });
+
+    // 1) Create inbox item for development-team lead to scope
+    const teamId = "development-team";
+    const teamWs = await getTeamWorkspaceDir(teamId);
+    const inboxDir = path.join(teamWs, "inbox");
+    await fs.mkdir(inboxDir, { recursive: true });
+
+    const received = new Date().toISOString();
+    const stamp = received.replace(/[-:]/g, "").replace(/\..+$/, "");
+    const titlePart = slugifyFilePart(existing.frontmatter.title || goalId);
+    const filename = `${received.slice(0, 10)}-${received.slice(11, 16).replace(":", "")}-goal-${titlePart || goalId}.md`;
+
+    const inboxBody = [
+      "# Inbox — development-team",
+      "",
+      `Received: ${received}`,
+      "",
+      "## Request",
+      `Goal: ${existing.frontmatter.title} (${goalId})`,
+      "",
+      "## Proposed work",
+      "- Ticket: (lead to create during scoping)",
+      "- Owner: lead",
+      "",
+      "## Links",
+      `- Goal UI: /goals/${encodeURIComponent(goalId)}`,
+      `- Goal file: ~/.openclaw/workspace/notes/goals/${goalId}.md`,
+      "",
+      "## Goal body (snapshot)",
+      existing.body?.trim() ? existing.body.trim() : "(empty)",
+      "",
+    ].join("\n");
+
+    const inboxPath = path.join(inboxDir, filename);
+    await fs.writeFile(inboxPath, inboxBody, { encoding: "utf8", flag: "wx" }).catch(async (e: unknown) => {
+      const code = (e && typeof e === "object" && "code" in e) ? String((e as { code?: unknown }).code) : "";
+      if (code === "EEXIST") {
+        const alt = path.join(inboxDir, filename.replace(/\.md$/, `-${stamp}.md`));
+        await fs.writeFile(alt, inboxBody, { encoding: "utf8", flag: "wx" });
+        return;
+      }
+      throw e;
+    });
+
+    // 2) Mark goal active + ensure workflow instructions exist
+    const updatedBody = ensureWorkflowInstructions(existing.body ?? "");
+    const updated = await writeGoal({
+      id: goalId,
+      title: existing.frontmatter.title,
+      status: "active",
+      tags: existing.frontmatter.tags,
+      teams: existing.frontmatter.teams,
+      body: updatedBody,
+    });
+
+    // 3) Optional lead ping only if config is permissive
+    let pingAttempted = false;
+    let pingOk = false;
+    let pingReason: string | null = null;
+
+    const cfg = await readOpenClawConfig();
+    const enabled = cfg.tools?.agentToAgent?.enabled === true;
+    const allow = cfg.tools?.agentToAgent?.allow ?? [];
+    const targetAgentId = "development-team-lead";
+    const permitted = enabled && (allow.includes("*") || allow.includes(targetAgentId));
+
+    if (!permitted) {
+      pingReason = enabled
+        ? `agentToAgent.allow does not include "*" or "${targetAgentId}"`
+        : "tools.agentToAgent.enabled is false";
+    } else {
+      pingAttempted = true;
+      try {
+        await execFileAsync(
+          "openclaw",
+          [
+            "agent",
+            "--agent",
+            targetAgentId,
+            "--message",
+            `New goal promoted to development-team inbox: ${updated.frontmatter.title} (${goalId}). Inbox file: ${inboxPath}`,
+            "--timeout",
+            "60",
+            "--json",
+          ],
+          { timeout: 70000 },
+        );
+        pingOk = true;
+      } catch (e: unknown) {
+        pingReason = e instanceof Error ? e.message : String(e);
+      }
+    }
+
+    return NextResponse.json({
+      ok: true,
+      goal: updated.frontmatter,
+      inboxPath,
+      pingAttempted,
+      pingOk,
+      pingReason,
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const status = /Invalid goal id|Path traversal/.test(msg) ? 400 : 500;
+    return NextResponse.json({ error: msg }, { status });
+  }
+}

--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { readGoal, writeGoal } from "@/lib/goals";
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  try {
+    const goal = await readGoal(id);
+    if (!goal) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json({ goal: goal.frontmatter, body: goal.body, raw: goal.raw });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const status = /Invalid goal id|Path traversal/.test(msg) ? 400 : 500;
+    return NextResponse.json({ error: msg }, { status });
+  }
+}
+
+export async function PUT(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  type GoalPutBody = {
+    title: string;
+    status?: "planned" | "active" | "done";
+    tags?: string[];
+    teams?: string[];
+    body?: string;
+  };
+
+  try {
+    const data = (await req.json()) as GoalPutBody;
+    const title = String(data?.title ?? "").trim();
+    if (!title) return NextResponse.json({ error: "title is required" }, { status: 400 });
+
+    const result = await writeGoal({
+      id,
+      title,
+      status: data?.status,
+      tags: Array.isArray(data?.tags) ? data.tags : [],
+      teams: Array.isArray(data?.teams) ? data.teams : [],
+      body: String(data?.body ?? ""),
+    });
+
+    return NextResponse.json({ goal: result.frontmatter });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const status = /Invalid goal id|Path traversal/.test(msg) ? 400 : 500;
+    return NextResponse.json({ error: msg }, { status });
+  }
+}

--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { readGoal, writeGoal } from "@/lib/goals";
+import { deleteGoal, readGoal, writeGoal } from "@/lib/goals";
 
 export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
   const { id } = await ctx.params;
@@ -39,6 +39,19 @@ export async function PUT(req: Request, ctx: { params: Promise<{ id: string }> }
     });
 
     return NextResponse.json({ goal: result.frontmatter });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const status = /Invalid goal id|Path traversal/.test(msg) ? 400 : 500;
+    return NextResponse.json({ error: msg }, { status });
+  }
+}
+
+export async function DELETE(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  try {
+    const result = await deleteGoal(id);
+    if (!result.ok) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json({ ok: true });
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
     const status = /Invalid goal id|Path traversal/.test(msg) ? 400 : 500;

--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { listGoals, writeGoal } from "@/lib/goals";
+
+export async function GET() {
+  try {
+    const goals = await listGoals();
+    return NextResponse.json({ goals });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+type GoalWriteBody = {
+  id: string;
+  title: string;
+  status?: "planned" | "active" | "done";
+  tags?: string[];
+  teams?: string[];
+  body?: string;
+};
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as GoalWriteBody;
+    const id = String(body?.id ?? "").trim();
+    const title = String(body?.title ?? "").trim();
+    if (!id || !title) {
+      return NextResponse.json({ error: "id and title are required" }, { status: 400 });
+    }
+
+    const result = await writeGoal({
+      id,
+      title,
+      status: body?.status,
+      tags: Array.isArray(body?.tags) ? body.tags : [],
+      teams: Array.isArray(body?.teams) ? body.teams : [],
+      body: String(body?.body ?? ""),
+    });
+
+    return NextResponse.json({ goal: result.frontmatter });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const status = /Invalid goal id|Path traversal/.test(msg) ? 400 : 500;
+    return NextResponse.json({ error: msg }, { status });
+  }
+}

--- a/src/app/channels/channels-client.tsx
+++ b/src/app/channels/channels-client.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type ChannelConfig = Record<string, unknown>;
+
+type ChannelsResponse = {
+  ok: boolean;
+  channels?: Record<string, unknown>;
+  error?: string;
+};
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return Boolean(v) && typeof v === "object" && !Array.isArray(v);
+}
+
+function Button({
+  children,
+  onClick,
+  kind,
+  disabled,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  kind?: "primary" | "danger";
+  disabled?: boolean;
+}) {
+  const base =
+    "rounded-[var(--ck-radius-sm)] px-3 py-2 text-sm font-medium transition disabled:opacity-50 " +
+    (kind === "primary"
+      ? "bg-[var(--ck-accent-red)] text-white"
+      : kind === "danger"
+        ? "border border-red-400/40 text-red-200 hover:bg-red-500/10"
+        : "border border-[color:var(--ck-border-subtle)] hover:bg-[color:var(--ck-bg-glass)]");
+  return (
+    <button className={base} onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  );
+}
+
+export default function ChannelsClient() {
+  const [channels, setChannels] = useState<Record<string, unknown>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [provider, setProvider] = useState<string>("telegram");
+  const [configJson, setConfigJson] = useState<string>("{\n  \"enabled\": true\n}\n");
+  const [saving, setSaving] = useState(false);
+
+  async function fetchBindings(): Promise<{ ok: true; channels: Record<string, unknown> } | { ok: false; error: string }> {
+    const res = await fetch("/api/channels/bindings", { cache: "no-store" });
+    const data = (await res.json()) as ChannelsResponse;
+    if (!res.ok || !data?.ok) {
+      return { ok: false, error: String(data?.error ?? `Failed to load channels (${res.status})`) };
+    }
+    const ch = isRecord(data.channels) ? data.channels : {};
+    return { ok: true, channels: ch };
+  }
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchBindings();
+      if (!result.ok) {
+        setError(result.error);
+        setChannels({});
+        setLoading(false);
+        return;
+      }
+      setChannels(result.channels);
+      setLoading(false);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+      setChannels({});
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      await refresh();
+      if (cancelled) return;
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const providers = useMemo(() => {
+    const keys = Object.keys(channels);
+    keys.sort();
+    return keys.filter((k) => channels[k] != null);
+  }, [channels]);
+
+  function selectProvider(p: string) {
+    setProvider(p);
+    const cfg = channels[p];
+    setConfigJson(JSON.stringify(cfg ?? {}, null, 2) + "\n");
+  }
+
+  async function upsert() {
+    setSaving(true);
+    setError(null);
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(configJson);
+    } catch {
+      setError("Config must be valid JSON");
+      setSaving(false);
+      return;
+    }
+    if (!isRecord(parsed)) {
+      setError("Config must be a JSON object");
+      setSaving(false);
+      return;
+    }
+
+    const res = await fetch("/api/channels/bindings", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ provider: provider.trim(), config: parsed }),
+    });
+    const data = (await res.json()) as ChannelsResponse;
+    if (!res.ok || !data?.ok) {
+      setError(String(data?.error ?? "Failed to save"));
+      setSaving(false);
+      return;
+    }
+
+    await refresh();
+    setSaving(false);
+  }
+
+  async function remove(p: string) {
+    const ok = window.confirm(`Delete channel binding "${p}"?`);
+    if (!ok) return;
+
+    setSaving(true);
+    setError(null);
+
+    const res = await fetch("/api/channels/bindings", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ provider: p }),
+    });
+    const data = (await res.json()) as ChannelsResponse;
+    if (!res.ok || !data?.ok) {
+      setError(String(data?.error ?? "Failed to delete"));
+      setSaving(false);
+      return;
+    }
+
+    await refresh();
+    setSaving(false);
+  }
+
+  function addBinding() {
+    const p = window.prompt("Provider id (e.g. telegram)", "telegram");
+    const next = String(p ?? "").trim();
+    if (!next) return;
+    setProvider(next);
+    setConfigJson("{\n  \"enabled\": true\n}\n");
+  }
+
+  const selectedConfig = useMemo(() => {
+    const v = channels[provider];
+    return isRecord(v) ? (v as ChannelConfig) : null;
+  }, [channels, provider]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Channels</h1>
+          <p className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">
+            Source of truth: OpenClaw gateway config (patched via <code className="font-mono">gateway config.patch</code>).
+            Some changes may require a gateway restart depending on provider.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button onClick={() => void refresh()} disabled={saving}>
+            Refresh
+          </Button>
+          <Button kind="primary" onClick={addBinding} disabled={saving}>
+            Add binding
+          </Button>
+        </div>
+      </div>
+
+      {error ? <div className="ck-glass p-4 text-sm text-red-300">{error}</div> : null}
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="ck-glass p-4">
+          <div className="text-sm font-medium">Bindings</div>
+          {loading ? (
+            <div className="mt-3 text-sm text-[color:var(--ck-text-secondary)]">Loading…</div>
+          ) : providers.length === 0 ? (
+            <div className="mt-3 text-sm text-[color:var(--ck-text-secondary)]">No bindings configured.</div>
+          ) : (
+            <div className="mt-3 space-y-2">
+              {providers.map((p) => (
+                <button
+                  key={p}
+                  className={
+                    "flex w-full items-center justify-between rounded-[var(--ck-radius-sm)] border px-3 py-2 text-left text-sm " +
+                    (p === provider
+                      ? "border-[var(--ck-accent-red)] bg-[color:var(--ck-bg-glass)]"
+                      : "border-[color:var(--ck-border-subtle)] hover:bg-[color:var(--ck-bg-glass)]")
+                  }
+                  onClick={() => selectProvider(p)}
+                >
+                  <span className="font-mono">{p}</span>
+                  <span className="text-xs text-[color:var(--ck-text-tertiary)]">edit</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="ck-glass p-4 lg:col-span-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <div className="text-sm font-medium">Edit</div>
+              <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+                Provider: <code className="font-mono">{provider}</code>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button kind="danger" onClick={() => void remove(provider)} disabled={saving}>
+                Delete
+              </Button>
+              <Button kind="primary" onClick={() => void upsert()} disabled={saving}>
+                {saving ? "Saving…" : "Save"}
+              </Button>
+            </div>
+          </div>
+
+          <div className="mt-4">
+            <div className="text-xs text-[color:var(--ck-text-tertiary)]">Config (JSON)</div>
+            <textarea
+              value={configJson}
+              onChange={(e) => setConfigJson(e.target.value)}
+              className="mt-2 h-[420px] w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-3 py-2 font-mono text-sm"
+              placeholder={"{\n  \"enabled\": true\n}"}
+            />
+            <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
+              Validation:
+              <ul className="list-disc pl-5">
+                <li>Telegram requires <code className="font-mono">botToken</code>.</li>
+                <li>Other providers can be edited as raw JSON in v1.</li>
+              </ul>
+            </div>
+
+            {selectedConfig ? (
+              <div className="mt-3 text-xs text-[color:var(--ck-text-tertiary)]">
+                Current keys: <code className="font-mono">{Object.keys(selectedConfig).join(", ") || "(none)"}</code>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/channels/page.tsx
+++ b/src/app/channels/page.tsx
@@ -1,0 +1,5 @@
+import ChannelsClient from "./channels-client";
+
+export default function ChannelsPage() {
+  return <ChannelsClient />;
+}

--- a/src/app/goals/[id]/goal-editor.tsx
+++ b/src/app/goals/[id]/goal-editor.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+type GoalStatus = "planned" | "active" | "done";
+
+type Goal = {
+  id: string;
+  title: string;
+  status: GoalStatus;
+  tags: string[];
+  teams: string[];
+  updatedAt: string;
+};
+
+export default function GoalEditor({ goalId }: { goalId: string }) {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [title, setTitle] = useState("");
+  const [status, setStatus] = useState<GoalStatus>("planned");
+  const [tagsRaw, setTagsRaw] = useState("");
+  const [teamsRaw, setTeamsRaw] = useState("");
+  const [body, setBody] = useState("");
+  const [updatedAt, setUpdatedAt] = useState<string | null>(null);
+
+  const tags = useMemo(
+    () => tagsRaw.split(",").map((s) => s.trim()).filter(Boolean),
+    [tagsRaw]
+  );
+  const teams = useMemo(
+    () => teamsRaw.split(",").map((s) => s.trim()).filter(Boolean),
+    [teamsRaw]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/goals/${encodeURIComponent(goalId)}`, { cache: "no-store" });
+        const data = (await res.json()) as unknown;
+        const obj = (data && typeof data === "object") ? (data as Record<string, unknown>) : {};
+        if (cancelled) return;
+
+        if (!res.ok) {
+          setError(String(obj.error ?? "Failed to load goal"));
+          setLoading(false);
+          return;
+        }
+
+        const g = (obj.goal ?? {}) as Goal;
+        setTitle(g.title ?? "");
+        setStatus((g.status as GoalStatus) ?? "planned");
+        setTagsRaw((g.tags ?? []).join(", "));
+        setTeamsRaw((g.teams ?? []).join(", "));
+        setBody(String(obj.body ?? ""));
+        setUpdatedAt(g.updatedAt ?? null);
+        setLoading(false);
+      } catch (e: unknown) {
+        if (cancelled) return;
+        const msg = e instanceof Error ? e.message : String(e);
+        setError(msg);
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [goalId]);
+
+  async function reload() {
+    setLoading(true);
+    setError(null);
+    const res = await fetch(`/api/goals/${encodeURIComponent(goalId)}`, { cache: "no-store" });
+    const data = (await res.json()) as unknown;
+    const obj = (data && typeof data === "object") ? (data as Record<string, unknown>) : {};
+    if (!res.ok) {
+      setError(String(obj.error ?? "Failed to load goal"));
+      setLoading(false);
+      return;
+    }
+    const g = (obj.goal ?? {}) as Goal;
+    setTitle(g.title ?? "");
+    setStatus((g.status as GoalStatus) ?? "planned");
+    setTagsRaw((g.tags ?? []).join(", "));
+    setTeamsRaw((g.teams ?? []).join(", "));
+    setBody(String(obj.body ?? ""));
+    setUpdatedAt(g.updatedAt ?? null);
+    setLoading(false);
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    const res = await fetch(`/api/goals/${encodeURIComponent(goalId)}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title, status, tags, teams, body }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      setError(data?.error ?? "Failed to save");
+      setSaving(false);
+      return;
+    }
+    const g = data.goal as Goal;
+    setUpdatedAt(g.updatedAt ?? null);
+    setSaving(false);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <Link href="/goals" className="text-sm font-medium hover:underline">
+          ← Back
+        </Link>
+        <div className="text-xs text-[color:var(--ck-text-tertiary)] font-mono">{goalId}</div>
+      </div>
+
+      <div className="ck-glass p-6 space-y-4">
+        <div>
+          <div className="text-xs text-[color:var(--ck-text-tertiary)]">Title</div>
+          <input
+            className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-3 py-2 text-sm"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Goal title"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div>
+            <div className="text-xs text-[color:var(--ck-text-tertiary)]">Status</div>
+            <select
+              className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-3 py-2 text-sm"
+              value={status}
+              onChange={(e) => setStatus(e.target.value as GoalStatus)}
+            >
+              <option value="planned">Planned</option>
+              <option value="active">Active</option>
+              <option value="done">Done</option>
+            </select>
+          </div>
+          <div>
+            <div className="text-xs text-[color:var(--ck-text-tertiary)]">Teams (comma-separated)</div>
+            <input
+              className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-3 py-2 text-sm"
+              value={teamsRaw}
+              onChange={(e) => setTeamsRaw(e.target.value)}
+              placeholder="development-team, marketing-team"
+            />
+          </div>
+          <div>
+            <div className="text-xs text-[color:var(--ck-text-tertiary)]">Tags (comma-separated)</div>
+            <input
+              className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-3 py-2 text-sm"
+              value={tagsRaw}
+              onChange={(e) => setTagsRaw(e.target.value)}
+              placeholder="onboarding, growth"
+            />
+          </div>
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between">
+            <div className="text-xs text-[color:var(--ck-text-tertiary)]">Body (markdown)</div>
+            <div className="text-xs text-[color:var(--ck-text-tertiary)]">
+              {updatedAt ? `updated ${new Date(updatedAt).toLocaleString()}` : ""}
+            </div>
+          </div>
+          <textarea
+            className="mt-1 h-[320px] w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-3 py-2 font-mono text-sm"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Write the goal here…"
+          />
+        </div>
+
+        {error ? <div className="text-sm text-red-300">{error}</div> : null}
+
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => void save()}
+            disabled={saving || loading}
+            className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white disabled:opacity-50"
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+          <button
+            onClick={() => void reload()}
+            disabled={saving}
+            className="rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] px-3 py-2 text-sm"
+          >
+            Reload
+          </button>
+        </div>
+      </div>
+
+      <div className="ck-glass p-6">
+        <div className="text-sm font-medium">Preview</div>
+        <pre className="mt-2 whitespace-pre-wrap break-words text-sm leading-6 text-[color:var(--ck-text-primary)]">{body}</pre>
+      </div>
+
+      {loading ? <div className="text-sm text-[color:var(--ck-text-secondary)]">Loading…</div> : null}
+    </div>
+  );
+}

--- a/src/app/goals/[id]/page.tsx
+++ b/src/app/goals/[id]/page.tsx
@@ -1,0 +1,6 @@
+import GoalEditor from "./goal-editor";
+
+export default async function GoalDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <GoalEditor goalId={id} />;
+}

--- a/src/app/goals/goals-client.tsx
+++ b/src/app/goals/goals-client.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+type Goal = {
+  id: string;
+  title: string;
+  status: "planned" | "active" | "done";
+  tags: string[];
+  teams: string[];
+  updatedAt: string;
+};
+
+function Badge({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="rounded-full bg-[color:var(--ck-bg-glass)] px-2 py-0.5 text-xs text-[color:var(--ck-text-secondary)]">
+      {children}
+    </span>
+  );
+}
+
+export default function GoalsClient() {
+  const [goals, setGoals] = useState<Goal[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [filterStatus, setFilterStatus] = useState<string>("all");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/goals", { cache: "no-store" });
+        const data = (await res.json()) as unknown;
+        if (cancelled) return;
+
+        const obj = (data && typeof data === "object") ? (data as Record<string, unknown>) : {};
+
+        if (!res.ok) {
+          const msg = obj.error ?? "Failed to load goals";
+          setError(String(msg));
+          setGoals([]);
+          return;
+        }
+
+        setError(null);
+        setGoals((obj.goals ?? []) as Goal[]);
+      } catch (e: unknown) {
+        if (cancelled) return;
+        const msg = e instanceof Error ? e.message : String(e);
+        setError(msg);
+        setGoals([]);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function reload() {
+    // reuse the same logic by forcing a page-level refetch
+    // (simple and avoids extra hooks)
+    setGoals(null);
+    setError(null);
+    const res = await fetch("/api/goals", { cache: "no-store" });
+    const data = (await res.json()) as unknown;
+    const obj = (data && typeof data === "object") ? (data as Record<string, unknown>) : {};
+    if (!res.ok) {
+      setError(String(obj.error ?? "Failed to load goals"));
+      setGoals([]);
+      return;
+    }
+    setGoals((obj.goals ?? []) as Goal[]);
+  }
+
+  const filtered = useMemo(() => {
+    const list = goals ?? [];
+    if (filterStatus === "all") return list;
+    return list.filter((g) => g.status === filterStatus);
+  }, [goals, filterStatus]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Goals</h1>
+          <p className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">
+            Stored in <code className="font-mono">~/.openclaw/workspace/notes/goals/</code>
+          </p>
+        </div>
+        <Link
+          href="/goals/new"
+          className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white"
+        >
+          Create goal
+        </Link>
+      </div>
+
+      <div className="ck-glass p-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="text-sm text-[color:var(--ck-text-secondary)]">Status</label>
+          <select
+            className="rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-2 py-1 text-sm"
+            value={filterStatus}
+            onChange={(e) => setFilterStatus(e.target.value)}
+          >
+            <option value="all">All</option>
+            <option value="planned">Planned</option>
+            <option value="active">Active</option>
+            <option value="done">Done</option>
+          </select>
+
+          <button
+            className="ml-auto text-sm font-medium hover:underline"
+            onClick={() => void reload()}
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="ck-glass p-4 text-sm text-red-300">{error}</div>
+      ) : null}
+
+      {goals == null ? (
+        <div className="ck-glass p-6 text-sm text-[color:var(--ck-text-secondary)]">Loading…</div>
+      ) : filtered.length === 0 ? (
+        <div className="ck-glass p-6">
+          <div className="text-sm text-[color:var(--ck-text-secondary)]">No goals yet.</div>
+          <div className="mt-3">
+            <Link href="/goals/new" className="text-sm font-medium hover:underline">
+              Create your first goal →
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {filtered.map((g) => (
+            <Link
+              key={g.id}
+              href={`/goals/${encodeURIComponent(g.id)}`}
+              className="block ck-glass p-5 transition hover:bg-[color:var(--ck-bg-glass)]"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="truncate text-base font-semibold text-[color:var(--ck-text-primary)]">{g.title}</div>
+                  <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+                    <span className="font-mono">{g.id}</span>
+                    {g.updatedAt ? ` • updated ${new Date(g.updatedAt).toLocaleString()}` : ""}
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Badge>{g.status}</Badge>
+                  {g.teams?.slice(0, 3).map((t) => (
+                    <Badge key={t}>{t}</Badge>
+                  ))}
+                  {g.tags?.slice(0, 3).map((t) => (
+                    <Badge key={t}>#{t}</Badge>
+                  ))}
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/goals/goals-client.tsx
+++ b/src/app/goals/goals-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
 type Goal = {
@@ -23,6 +24,9 @@ function Badge({ children }: { children: React.ReactNode }) {
 export default function GoalsClient() {
   const [goals, setGoals] = useState<Goal[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const searchParams = useSearchParams();
+  const teamFilter = (searchParams.get("team") ?? "").trim();
 
   const [filterStatus, setFilterStatus] = useState<string>("all");
 
@@ -75,10 +79,11 @@ export default function GoalsClient() {
   }
 
   const filtered = useMemo(() => {
-    const list = goals ?? [];
+    let list = goals ?? [];
+    if (teamFilter) list = list.filter((g) => Array.isArray(g.teams) && g.teams.includes(teamFilter));
     if (filterStatus === "all") return list;
     return list.filter((g) => g.status === filterStatus);
-  }, [goals, filterStatus]);
+  }, [goals, filterStatus, teamFilter]);
 
   return (
     <div className="space-y-6">
@@ -87,6 +92,11 @@ export default function GoalsClient() {
           <h1 className="text-2xl font-semibold tracking-tight">Goals</h1>
           <p className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">
             Stored in <code className="font-mono">~/.openclaw/workspace/notes/goals/</code>
+            {teamFilter ? (
+              <>
+                {" "}• filtered by team <code className="font-mono">{teamFilter}</code>
+              </>
+            ) : null}
           </p>
         </div>
         <Link

--- a/src/app/goals/new/page.tsx
+++ b/src/app/goals/new/page.tsx
@@ -1,31 +1,65 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+
+type GoalStatus = "planned" | "active" | "done";
+
+function slugify(input: string) {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/[\s_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+}
 
 export default function NewGoalPage() {
   const router = useRouter();
+
   const [id, setId] = useState("");
   const [title, setTitle] = useState("");
+  const [status, setStatus] = useState<GoalStatus>("planned");
+  const [tagsRaw, setTagsRaw] = useState("");
+  const [teamsRaw, setTeamsRaw] = useState("");
+  const [body, setBody] = useState(
+    "## Workflow\n<!-- goal-workflow -->\n- Use **Promote to inbox** to send this goal to the development-team inbox for scoping.\n- When promoted, set goal status to **active**.\n- Track implementation work via tickets (add links/IDs under a **Tickets** section in this goal).\n- When development is complete (all associated tickets marked done), set goal status to **done**.\n\n## Tickets\n- (add ticket links/ids)\n"
+  );
+
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+
+  const tags = useMemo(() => tagsRaw.split(",").map((s) => s.trim()).filter(Boolean), [tagsRaw]);
+  const teams = useMemo(() => teamsRaw.split(",").map((s) => s.trim()).filter(Boolean), [teamsRaw]);
+
+  const suggestedId = useMemo(() => {
+    const s = slugify(title);
+    return s.length >= 2 ? s : "";
+  }, [title]);
 
   async function create() {
     setSaving(true);
     setError(null);
+
+    const finalId = id.trim();
+
     const res = await fetch("/api/goals", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ id, title, status: "planned", tags: [], teams: [], body: "" }),
+      body: JSON.stringify({ id: finalId, title, status, tags, teams, body }),
     });
+
     const data = await res.json();
     if (!res.ok) {
       setError(data?.error ?? "Failed to create goal");
       setSaving(false);
       return;
     }
-    router.push(`/goals/${encodeURIComponent(id)}`);
+
+    router.push(`/goals/${encodeURIComponent(finalId)}`);
   }
 
   return (
@@ -47,6 +81,14 @@ export default function NewGoalPage() {
           />
           <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
             Lowercase letters, numbers, hyphens. Stored as <code className="font-mono">{id || "<id>"}.md</code>.
+            {suggestedId && !id.trim() ? (
+              <>
+                {" "}Suggested:{" "}
+                <button className="underline" onClick={() => setId(suggestedId)}>
+                  {suggestedId}
+                </button>
+              </>
+            ) : null}
           </div>
         </div>
 
@@ -57,6 +99,49 @@ export default function NewGoalPage() {
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             placeholder="Increase trial activation"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div>
+            <div className="text-xs text-[color:var(--ck-text-tertiary)]">Status</div>
+            <select
+              className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-3 py-2 text-sm"
+              value={status}
+              onChange={(e) => setStatus(e.target.value as GoalStatus)}
+            >
+              <option value="planned">Planned</option>
+              <option value="active">Active</option>
+              <option value="done">Done</option>
+            </select>
+          </div>
+          <div>
+            <div className="text-xs text-[color:var(--ck-text-tertiary)]">Teams (comma-separated)</div>
+            <input
+              className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-3 py-2 text-sm"
+              value={teamsRaw}
+              onChange={(e) => setTeamsRaw(e.target.value)}
+              placeholder="development-team, marketing-team"
+            />
+          </div>
+          <div>
+            <div className="text-xs text-[color:var(--ck-text-tertiary)]">Tags (comma-separated)</div>
+            <input
+              className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-3 py-2 text-sm"
+              value={tagsRaw}
+              onChange={(e) => setTagsRaw(e.target.value)}
+              placeholder="onboarding, growth"
+            />
+          </div>
+        </div>
+
+        <div>
+          <div className="text-xs text-[color:var(--ck-text-tertiary)]">Body (markdown)</div>
+          <textarea
+            className="mt-1 h-[260px] w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-3 py-2 font-mono text-sm"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Write the goal here…"
           />
         </div>
 

--- a/src/app/goals/new/page.tsx
+++ b/src/app/goals/new/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+export default function NewGoalPage() {
+  const router = useRouter();
+  const [id, setId] = useState("");
+  const [title, setTitle] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function create() {
+    setSaving(true);
+    setError(null);
+    const res = await fetch("/api/goals", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id, title, status: "planned", tags: [], teams: [], body: "" }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      setError(data?.error ?? "Failed to create goal");
+      setSaving(false);
+      return;
+    }
+    router.push(`/goals/${encodeURIComponent(id)}`);
+  }
+
+  return (
+    <div className="space-y-4">
+      <Link href="/goals" className="text-sm font-medium hover:underline">
+        ← Back
+      </Link>
+
+      <div className="ck-glass p-6 space-y-4">
+        <h1 className="text-xl font-semibold tracking-tight">Create goal</h1>
+
+        <div>
+          <div className="text-xs text-[color:var(--ck-text-tertiary)]">ID</div>
+          <input
+            className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-3 py-2 text-sm font-mono"
+            value={id}
+            onChange={(e) => setId(e.target.value)}
+            placeholder="increase-trial-activation"
+          />
+          <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+            Lowercase letters, numbers, hyphens. Stored as <code className="font-mono">{id || "<id>"}.md</code>.
+          </div>
+        </div>
+
+        <div>
+          <div className="text-xs text-[color:var(--ck-text-tertiary)]">Title</div>
+          <input
+            className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-3 py-2 text-sm"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Increase trial activation"
+          />
+        </div>
+
+        {error ? <div className="text-sm text-red-300">{error}</div> : null}
+
+        <button
+          onClick={() => void create()}
+          disabled={saving}
+          className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white disabled:opacity-50"
+        >
+          {saving ? "Creating…" : "Create"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -1,0 +1,5 @@
+import GoalsClient from "./goals-client";
+
+export default function GoalsPage() {
+  return <GoalsClient />;
+}

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import GoalsClient from "./goals-client";
 
 export default function GoalsPage() {
-  return <GoalsClient />;
+  return (
+    <Suspense fallback={<div className="ck-glass p-6 text-sm text-[color:var(--ck-text-secondary)]">Loading goals…</div>}>
+      <GoalsClient />
+    </Suspense>
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,8 +24,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+    <html lang="en" suppressHydrationWarning>
+      <body
+        suppressHydrationWarning
+        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+      >
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/src/app/teams/[teamId]/page.tsx
+++ b/src/app/teams/[teamId]/page.tsx
@@ -40,6 +40,15 @@ export default async function TeamPage({ params }: { params: Promise<{ teamId: s
         </div>
       </div>
 
+      <div className="mx-auto mb-4 flex max-w-6xl items-center justify-end">
+        <Link
+          href={`/goals?team=${encodeURIComponent(teamId)}`}
+          className="text-sm font-medium text-[color:var(--ck-text-secondary)] hover:underline"
+        >
+          View goals for this team →
+        </Link>
+      </div>
+
       <TeamEditor teamId={teamId} />
     </main>
   );

--- a/src/app/teams/[teamId]/page.tsx
+++ b/src/app/teams/[teamId]/page.tsx
@@ -27,13 +27,22 @@ export default async function TeamPage({ params }: { params: Promise<{ teamId: s
 
   return (
     <main className="min-h-screen p-8">
-      <div className="mx-auto mb-4 flex max-w-6xl items-center justify-between gap-4">
-        <Link
-          href="/"
-          className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
-        >
-          ← Home
-        </Link>
+      <div className="mx-auto mb-4 flex max-w-6xl items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <Link
+            href="/"
+            className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
+          >
+            ← Home
+          </Link>
+          <Link
+            href="/recipes"
+            className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
+          >
+            ← Recipes
+          </Link>
+        </div>
+
         <div className="text-right">
           <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">{name || teamId}</div>
           <div className="text-xs text-[color:var(--ck-text-tertiary)]">{teamId}</div>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -38,6 +38,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               <NavLink href="/recipes" label="Recipes" />
               <NavLink href="/tickets" label="Tickets" />
               <NavLink href="/goals" label="Goals" />
+              <NavLink href="/channels" label="Channels" />
               <NavLink href="/cron-jobs" label="Cron jobs" />
               <NavLink href="/settings" label="Settings" />
             </nav>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -37,6 +37,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             <nav className="hidden items-center gap-1 sm:flex">
               <NavLink href="/recipes" label="Recipes" />
               <NavLink href="/tickets" label="Tickets" />
+              <NavLink href="/goals" label="Goals" />
               <NavLink href="/cron-jobs" label="Cron jobs" />
               <NavLink href="/settings" label="Settings" />
             </nav>

--- a/src/lib/goals.ts
+++ b/src/lib/goals.ts
@@ -1,0 +1,139 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import YAML from "yaml";
+import { getWorkspaceGoalsDir } from "@/lib/paths";
+
+export type GoalStatus = "planned" | "active" | "done";
+
+export type GoalFrontmatter = {
+  id: string;
+  title: string;
+  status: GoalStatus;
+  tags: string[];
+  teams: string[];
+  updatedAt: string; // ISO
+};
+
+export type GoalSummary = GoalFrontmatter & {
+  filename: string;
+};
+
+const ID_RE = /^[a-z0-9][a-z0-9-]{1,63}$/;
+
+function assertSafeGoalId(id: string) {
+  if (!ID_RE.test(id)) {
+    throw new Error(
+      `Invalid goal id "${id}". Use 2-64 chars: lowercase letters, numbers, hyphens. Example: "increase-trial-activation".`
+    );
+  }
+}
+
+function splitFrontmatter(md: string): { fm: unknown; body: string } {
+  if (md.startsWith("---\n")) {
+    const end = md.indexOf("\n---\n", 4);
+    if (end !== -1) {
+      const yamlText = md.slice(4, end + 1);
+      const body = md.slice(end + 5);
+      const fm = YAML.parse(yamlText) as unknown;
+      return { fm: fm ?? {}, body };
+    }
+  }
+  return { fm: {}, body: md };
+}
+
+function normalizeFrontmatter(input: unknown, fallbackId: string, fallbackTitle: string): GoalFrontmatter {
+  const now = new Date().toISOString();
+  const obj = (input && typeof input === "object") ? (input as Record<string, unknown>) : {};
+  const id = String(obj.id ?? fallbackId).trim();
+  const title = String(obj.title ?? fallbackTitle ?? id).trim() || id;
+  const statusRaw = String(obj.status ?? "planned").trim();
+  const status: GoalStatus = statusRaw === "active" || statusRaw === "done" ? statusRaw : "planned";
+  const tags = Array.isArray(obj.tags) ? (obj.tags as unknown[]).map(String) : [];
+  const teams = Array.isArray(obj.teams) ? (obj.teams as unknown[]).map(String) : [];
+  const updatedAt = String(obj.updatedAt ?? now);
+
+  return { id, title, status, tags, teams, updatedAt };
+}
+
+async function ensureGoalsDir() {
+  const dir = await getWorkspaceGoalsDir();
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+async function goalPathForId(id: string) {
+  assertSafeGoalId(id);
+  const root = await ensureGoalsDir();
+  const full = path.join(root, `${id}.md`);
+  const normalizedRoot = path.resolve(root) + path.sep;
+  const normalizedFull = path.resolve(full);
+  if (!normalizedFull.startsWith(normalizedRoot)) throw new Error("Path traversal rejected");
+  return { root, full };
+}
+
+export async function listGoals(): Promise<GoalSummary[]> {
+  const dir = await ensureGoalsDir();
+  const files = (await fs.readdir(dir)).filter((f) => f.endsWith(".md"));
+
+  const out: GoalSummary[] = [];
+  for (const f of files) {
+    const full = path.join(dir, f);
+    const md = await fs.readFile(full, "utf8");
+    const id = f.replace(/\.md$/, "");
+    const { fm } = splitFrontmatter(md);
+    const normalized = normalizeFrontmatter(fm, id, id);
+    out.push({ ...normalized, filename: f });
+  }
+
+  // sort: active first, then planned, then done; within status by updatedAt desc
+  const rank: Record<GoalStatus, number> = { active: 0, planned: 1, done: 2 };
+  out.sort((a, b) => {
+    const ra = rank[a.status];
+    const rb = rank[b.status];
+    if (ra !== rb) return ra - rb;
+    return String(b.updatedAt).localeCompare(String(a.updatedAt));
+  });
+
+  return out;
+}
+
+export async function readGoal(id: string): Promise<{ frontmatter: GoalFrontmatter; body: string; raw: string } | null> {
+  const { full } = await goalPathForId(id);
+  try {
+    const raw = await fs.readFile(full, "utf8");
+    const { fm, body } = splitFrontmatter(raw);
+    const fmObj = (fm && typeof fm === "object") ? (fm as Record<string, unknown>) : {};
+    const frontmatter = normalizeFrontmatter(fm, id, String(fmObj.title ?? id));
+    return { frontmatter, body, raw };
+  } catch (e: unknown) {
+    if (typeof e === "object" && e && (e as { code?: string }).code === "ENOENT") return null;
+    throw e;
+  }
+}
+
+export async function writeGoal(params: {
+  id: string;
+  title: string;
+  status?: GoalStatus;
+  tags?: string[];
+  teams?: string[];
+  body: string;
+}): Promise<{ frontmatter: GoalFrontmatter; raw: string }>
+{
+  const { id } = params;
+  const { full } = await goalPathForId(id);
+
+  const updatedAt = new Date().toISOString();
+  const fm: GoalFrontmatter = {
+    id,
+    title: params.title,
+    status: params.status ?? "planned",
+    tags: params.tags ?? [],
+    teams: params.teams ?? [],
+    updatedAt,
+  };
+
+  const raw = `---\n${YAML.stringify(fm).trim()}\n---\n\n${(params.body ?? "").trim()}\n`;
+  await fs.writeFile(full, raw, "utf8");
+  return { frontmatter: fm, raw };
+}

--- a/src/lib/goals.ts
+++ b/src/lib/goals.ts
@@ -137,3 +137,16 @@ export async function writeGoal(params: {
   await fs.writeFile(full, raw, "utf8");
   return { frontmatter: fm, raw };
 }
+
+export async function deleteGoal(id: string): Promise<{ ok: true } | { ok: false; reason: "not_found" }> {
+  const { full } = await goalPathForId(id);
+  try {
+    await fs.unlink(full);
+    return { ok: true };
+  } catch (e: unknown) {
+    if (typeof e === "object" && e && (e as { code?: string }).code === "ENOENT") {
+      return { ok: false, reason: "not_found" };
+    }
+    throw e;
+  }
+}

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -16,11 +16,21 @@ export async function readOpenClawConfig(): Promise<OpenClawConfig> {
   return JSON.parse(text) as OpenClawConfig;
 }
 
-export async function getWorkspaceRecipesDir() {
+export async function getWorkspaceDir() {
   const cfg = await readOpenClawConfig();
   const ws = cfg.agents?.defaults?.workspace;
   if (!ws) throw new Error("agents.defaults.workspace is not set in ~/.openclaw/openclaw.json");
+  return ws;
+}
+
+export async function getWorkspaceRecipesDir() {
+  const ws = await getWorkspaceDir();
   return path.join(ws, "recipes");
+}
+
+export async function getWorkspaceGoalsDir() {
+  const ws = await getWorkspaceDir();
+  return path.join(ws, "notes", "goals");
 }
 
 export async function getBuiltinRecipesDir() {

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -4,6 +4,12 @@ import path from "node:path";
 type OpenClawConfig = {
   agents?: { defaults?: { workspace?: string } };
   gateway?: { port?: number; auth?: { token?: string } };
+  tools?: {
+    agentToAgent?: {
+      enabled?: boolean;
+      allow?: string[];
+    };
+  };
   plugins?: {
     installs?: { recipes?: { installPath?: string; sourcePath?: string } };
     load?: { paths?: string[] };
@@ -31,6 +37,12 @@ export async function getWorkspaceRecipesDir() {
 export async function getWorkspaceGoalsDir() {
   const ws = await getWorkspaceDir();
   return path.join(ws, "notes", "goals");
+}
+
+export async function getTeamWorkspaceDir(teamId: string) {
+  const home = process.env.HOME || "";
+  if (!home) throw new Error("HOME is not set");
+  return path.join(home, ".openclaw", `workspace-${teamId}`);
 }
 
 export async function getBuiltinRecipesDir() {


### PR DESCRIPTION
## Summary\nThis PR restores/locks in the ClawKitchen changes we agreed on after some UI regressions, and commits them on a dedicated branch.\n\n## Changes\n- **Home**: remove the custom team-recipe Teams section (no more "Teams appear here…" on Home).\n- **Recipes (/recipes)**: Home-style card layout; **Custom recipes first** (Teams + Agents), then Builtin; agent recipes route to **/agents/<id> only if installed**, otherwise fall back to /recipes/<id>.\n- **Goals**:\n  - /goals/new now supports **status, teams, tags, body**\n  - Goal detail: **Promote to inbox** (writes to dev-team inbox; sets status active)\n  - Promote optionally pings lead only when **tools.agentToAgent** config is permissive; otherwise returns pingAttempted=false + reason\n  - Goal detail: **Delete** (DELETE /api/goals/:id)\n- **Teams**: add "← Recipes" link under Home; remove "Phase v2 (thin slice):" prefix; capitalize Bootstrap\n- **Global**: suppress hydration warnings on html/body for extension-injected attrs\n- **Agents**: fix Save-as-new failure by avoiding gateway tool invoke; patch ~/.openclaw/openclaw.json + restart gateway\n\n## Notes\n- Implemented as two commits on the branch (recipes first; goals workflow second).\n\n## How to verify\n- Visit / (Home): confirm no Teams promo section\n- Visit /recipes: confirm layout + routing for agent recipes\n- Visit /goals/new: create goal with status/tags/teams/body\n- Visit a goal detail: test Promote to inbox + Delete\n- Visit /teams/<id>: confirm header links + copy