### PR TITLE
Fix theme flash; add agent delete

### DIFF
--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { createPortal } from "react-dom";
 import { useEffect, useState } from "react";
 
 type AgentListItem = {
@@ -14,12 +15,75 @@ type FileListResponse = { ok?: boolean; files?: unknown[] };
 
 type FileEntry = { name: string; missing: boolean };
 
+function DeleteAgentModal({
+  open,
+  agentId,
+  busy,
+  error,
+  onClose,
+  onConfirm,
+}: {
+  open: boolean;
+  agentId: string;
+  busy?: boolean;
+  error?: string | null;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[200]">
+      <div className="fixed inset-0 bg-black/60" onClick={onClose} />
+      <div className="fixed inset-0 overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center p-4">
+          <div className="w-full max-w-lg rounded-2xl border border-white/10 bg-[color:var(--ck-bg-glass-strong)] p-5 shadow-[var(--ck-shadow-2)]">
+            <div className="text-lg font-semibold text-[color:var(--ck-text-primary)]">Delete agent</div>
+            <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+              Delete agent <code className="font-mono">{agentId}</code>? This will remove its workspace/state.
+            </p>
+
+            {error ? (
+              <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">
+                {error}
+              </div>
+            ) : null}
+
+            <div className="mt-6 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={onConfirm}
+                className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] hover:bg-[var(--ck-accent-red-hover)] disabled:opacity-50"
+              >
+                {busy ? "Deleting…" : "Delete"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
 export default function AgentEditor({ agentId }: { agentId: string }) {
   const [agent, setAgent] = useState<AgentListItem | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [loadingFile, setLoadingFile] = useState(false);
   const [message, setMessage] = useState<string>("");
+
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const [activeTab, setActiveTab] = useState<"identity" | "config" | "skills" | "files">("identity");
 
@@ -207,16 +271,48 @@ export default function AgentEditor({ agentId }: { agentId: string }) {
     }
   }
 
+  async function onDeleteAgent() {
+    setDeleteBusy(true);
+    setDeleteError(null);
+    setMessage("");
+
+    try {
+      const res = await fetch(`/api/agents/${encodeURIComponent(agentId)}`, { method: "DELETE" });
+      const json = (await res.json()) as { ok?: boolean; error?: string; message?: string; stderr?: string };
+      if (!res.ok || !json.ok) throw new Error(json.error || json.message || json.stderr || "Delete failed");
+
+      window.location.href = "/";
+    } catch (e: unknown) {
+      setDeleteError(e instanceof Error ? e.message : String(e));
+      setDeleteBusy(false);
+    }
+  }
+
   if (loading) return <div className="ck-glass mx-auto max-w-4xl p-6">Loading…</div>;
   if (!agent) return <div className="ck-glass mx-auto max-w-4xl p-6">Agent not found: {agentId}</div>;
 
   return (
     <div className="ck-glass mx-auto max-w-4xl p-6 sm:p-8">
-      <h1 className="text-2xl font-semibold tracking-tight">Agent editor</h1>
-      <div className="mt-1 text-xs text-[color:var(--ck-text-secondary)]">
-        {agent.id}
-        {agent.isDefault ? " • default" : ""}
-        {agent.model ? ` • ${agent.model}` : ""}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Agent editor</h1>
+          <div className="mt-1 text-xs text-[color:var(--ck-text-secondary)]">
+            {agent.id}
+            {agent.isDefault ? " • default" : ""}
+            {agent.model ? ` • ${agent.model}` : ""}
+          </div>
+        </div>
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => {
+            setDeleteError(null);
+            setDeleteOpen(true);
+          }}
+          className="rounded-[var(--ck-radius-sm)] border border-red-400/40 bg-red-500/10 px-3 py-2 text-sm font-medium text-red-100 shadow-[var(--ck-shadow-1)] hover:bg-red-500/15 disabled:opacity-50"
+        >
+          Delete agent
+        </button>
       </div>
       {agent.workspace ? (
         <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Workspace: {agent.workspace}</div>
@@ -436,6 +532,15 @@ export default function AgentEditor({ agentId }: { agentId: string }) {
           </div>
         ) : null}
       </div>
+
+      <DeleteAgentModal
+        open={deleteOpen}
+        agentId={agentId}
+        busy={deleteBusy}
+        error={deleteError}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={() => void onDeleteAgent()}
+      />
     </div>
   );
 }

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+
+import { runOpenClaw } from "@/lib/openclaw";
+
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const agentId = String(id ?? "").trim();
+    if (!agentId) return NextResponse.json({ ok: false, error: "agent id is required" }, { status: 400 });
+
+    const result = await runOpenClaw(["agents", "delete", agentId, "--force", "--json"]);
+    if (!result.ok) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: `Failed to delete agent: ${agentId}`,
+          stderr: result.stderr || undefined,
+          stdout: result.stdout || undefined,
+        },
+        { status: 500 },
+      );
+    }
+
+    let parsed: unknown = null;
+    try {
+      parsed = JSON.parse(result.stdout);
+    } catch {
+      parsed = null;
+    }
+
+    return NextResponse.json({ ok: true, result: parsed ?? result.stdout });
+  } catch (err: unknown) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Failed to delete agent",
+        message: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,15 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Prevent theme flash: set data-theme before first paint */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              "(function(){try{var t=localStorage.getItem('ck-theme');if(t==='dark'){document.documentElement.dataset.theme='dark';}}catch(e){}})();",
+          }}
+        />
+      </head>
       <body
         suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}


### PR DESCRIPTION
- Prevent light→dark flash by applying saved theme (ck-theme) in a pre-paint script in RootLayout.
- Add agent delete flow with modal confirmation and DELETE /api/agents/[id] (runs: openclaw agents delete <id> --force --json).

QA:
- Load /recipes in dark mode: should not flash light first.
- Visit /agents/<id>: Delete agent opens modal and deletes via OpenClaw.