### PR TITLE
Fix clone team: patch teamId and scaffold workspace

### DIFF
--- a/src/app/api/cron/jobs/route.ts
+++ b/src/app/api/cron/jobs/route.ts
@@ -5,8 +5,15 @@ type CronToolResult = {
   content: Array<{ type: string; text?: string }>;
 };
 
-export async function GET() {
+import fs from "node:fs/promises";
+import path from "node:path";
+import { getTeamWorkspaceDir } from "@/lib/paths";
+
+export async function GET(req: Request) {
   try {
+    const url = new URL(req.url);
+    const teamId = String(url.searchParams.get("teamId") ?? "").trim();
+
     const result = await toolsInvoke<CronToolResult>({
       tool: "cron",
       args: { action: "list", includeDisabled: true },
@@ -18,7 +25,33 @@ export async function GET() {
     }
 
     const parsed = JSON.parse(text) as { jobs?: unknown[] };
-    return NextResponse.json({ ok: true, jobs: parsed.jobs ?? [] });
+    const jobs = Array.isArray(parsed.jobs) ? parsed.jobs : [];
+
+    if (!teamId) {
+      return NextResponse.json({ ok: true, jobs });
+    }
+
+    // If a teamId is provided, filter to only cron jobs installed for that team.
+    // Source of truth is the team workspace provenance file written by scaffold-team.
+    const teamDir = await getTeamWorkspaceDir(teamId);
+    const provenancePath = path.join(teamDir, "notes", "cron-jobs.json");
+
+    let installedIds: string[] = [];
+    try {
+      const text = await fs.readFile(provenancePath, "utf8");
+      const json = JSON.parse(text) as { entries?: Record<string, { installedCronId?: unknown; orphaned?: unknown }> };
+      const entries = json.entries ?? {};
+      installedIds = Object.values(entries)
+        .filter((e) => !Boolean(e.orphaned))
+        .map((e) => String(e.installedCronId ?? "").trim())
+        .filter(Boolean);
+    } catch {
+      // If the file is missing, treat as no installed cron jobs.
+      installedIds = [];
+    }
+
+    const filtered = jobs.filter((j) => installedIds.includes(String((j as { id?: unknown }).id ?? "")));
+    return NextResponse.json({ ok: true, jobs: filtered, teamId, provenancePath, installedIds });
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
     return NextResponse.json({ ok: false, error: msg }, { status: 500 });

--- a/src/app/goals/[id]/goal-editor.tsx
+++ b/src/app/goals/[id]/goal-editor.tsx
@@ -113,6 +113,9 @@ export default function GoalEditor({ goalId }: { goalId: string }) {
     const g = data.goal as Goal;
     setUpdatedAt(g.updatedAt ?? null);
     setSaving(false);
+
+    // Save should behave like an editor "submit": return to the list.
+    router.push("/goals");
   }
 
   async function promoteToInbox() {

--- a/src/app/teams/[teamId]/CloneTeamModal.tsx
+++ b/src/app/teams/[teamId]/CloneTeamModal.tsx
@@ -86,6 +86,29 @@ export function CloneTeamModal({
               {availability.state === "taken" ? "That id is already taken." : availability.state === "available" ? "Id is available." : ""}
             </div>
 
+            {availability.state === "taken" ? (
+              <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3">
+                <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Try one of these ids</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {[`custom-${effectiveId.trim()}`, `my-${effectiveId.trim()}`, `${effectiveId.trim()}-2`, `${effectiveId.trim()}-alt`]
+                    .filter((x) => x && x !== effectiveId.trim())
+                    .map((x) => (
+                      <button
+                        key={x}
+                        type="button"
+                        onClick={() => {
+                          setIdTouched(true);
+                          setId(x);
+                        }}
+                        className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-2.5 py-1.5 text-xs font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+                      >
+                        {x}
+                      </button>
+                    ))}
+                </div>
+              </div>
+            ) : null}
+
             <label className="mt-5 flex items-start gap-2 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-sm text-[color:var(--ck-text-secondary)]">
               <input
                 type="checkbox"

--- a/src/app/teams/[teamId]/CloneTeamModal.tsx
+++ b/src/app/teams/[teamId]/CloneTeamModal.tsx
@@ -29,11 +29,12 @@ export function CloneTeamModal({
   open: boolean;
   onClose: () => void;
   recipes: RecipeListItem[];
-  onConfirm: (args: { id: string; name: string }) => void;
+  onConfirm: (args: { id: string; name: string; scaffold: boolean }) => void;
 }) {
   const [name, setName] = useState("");
   const [id, setId] = useState("");
   const [idTouched, setIdTouched] = useState(false);
+  const [scaffold, setScaffold] = useState(true);
 
   const derivedId = useMemo(() => slugifyId(name), [name]);
   const effectiveId = idTouched ? id : derivedId;
@@ -85,6 +86,21 @@ export function CloneTeamModal({
               {availability.state === "taken" ? "That id is already taken." : availability.state === "available" ? "Id is available." : ""}
             </div>
 
+            <label className="mt-5 flex items-start gap-2 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-sm text-[color:var(--ck-text-secondary)]">
+              <input
+                type="checkbox"
+                checked={scaffold}
+                onChange={(e) => setScaffold(e.target.checked)}
+                className="mt-1"
+              />
+              <span>
+                Also scaffold workspace files (recommended).<br />
+                <span className="text-xs text-[color:var(--ck-text-tertiary)]">
+                  Creates the team workspace + standard file tree immediately so the cloned team is usable.
+                </span>
+              </span>
+            </label>
+
             <div className="mt-6 flex items-center justify-end gap-2">
               <button
                 type="button"
@@ -96,7 +112,7 @@ export function CloneTeamModal({
               <button
                 type="button"
                 disabled={!name.trim() || !effectiveId.trim() || availability.state === "taken"}
-                onClick={() => onConfirm({ id: effectiveId.trim(), name: name.trim() })}
+                onClick={() => onConfirm({ id: effectiveId.trim(), name: name.trim(), scaffold })}
                 className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] hover:bg-[var(--ck-accent-red-hover)] disabled:opacity-50"
               >
                 Clone

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -574,7 +574,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
         <div className="mt-6 ck-glass-strong p-4">
           <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Installed skills (team workspace)</div>
           <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-[color:var(--ck-text-secondary)]">
-            {skillsList.length ? skillsList.map((s) => <li key={s}>{s}</li>) : <li>None detected (or skills dir missing).</li>}
+            {skillsList.length ? skillsList.map((s) => <li key={s}>{s}</li>) : <li>No skills installed.</li>}
           </ul>
         </div>
       ) : null}


### PR DESCRIPTION
- Fix /api/recipes/clone to patch frontmatter id/name and (for team recipes) team.teamId -> new id
- Add optional `scaffold` flag to clone API to run `openclaw recipes scaffold-team|scaffold` immediately
- Team editor: prefer workspace recipe when both builtin+workspace entries exist (don't disable Save/Clone incorrectly)
- Team editor: show cron jobs via scaffold provenance (notes/cron-jobs.json) instead of name-matching
- Skills tab: show "No skills installed" when none
- Clone UX: if target recipe id already exists, return 409 w/ suggestions + show one-click id suggestions in modal

Local verification:
- `npm run build`
- `POST /api/recipes/clone` with existing toId returns 409 + suggestions
- Team page shows cron jobs for scaffolded team
