### PR TITLE
fix: QA_CHECKLIST required only for test role or qaChecklist opt-in

### DIFF
--- a/src/app/api/teams/files/route.ts
+++ b/src/app/api/teams/files/route.ts
@@ -20,10 +20,49 @@ export async function GET(req: Request) {
 
   const teamDir = teamDirFromTeamId(baseWorkspace, teamId);
 
+  // QA checklist should only be required when:
+  // - the team has a test role, and/or
+  // - the recipe opts in via frontmatter (qaChecklist: true)
+  const hasTestRole = await (async () => {
+    try {
+      const st = await fs.stat(path.join(teamDir, "roles", "test"));
+      return st.isDirectory();
+    } catch {
+      return false;
+    }
+  })();
+
+  const recipeOptsIn = await (async () => {
+    try {
+      const teamJsonPath = path.join(teamDir, "team.json");
+      const raw = await fs.readFile(teamJsonPath, "utf8");
+      const parsed = JSON.parse(raw) as { recipeId?: unknown };
+      const recipeId = String(parsed.recipeId ?? "").trim();
+      if (!recipeId) return false;
+
+      // Load recipe frontmatter via OpenClaw CLI and check for qaChecklist: true
+      const { runOpenClaw } = await import("@/lib/openclaw");
+      const shown = await runOpenClaw(["recipes", "show", recipeId]);
+      if (!shown.ok) return false;
+      const md = String(shown.stdout ?? "");
+      if (!md.startsWith("---\n")) return false;
+      const end = md.indexOf("\n---\n", 4);
+      if (end === -1) return false;
+      const yamlText = md.slice(4, end);
+      const { default: YAML } = await import("yaml");
+      const fm = (YAML.parse(yamlText) ?? {}) as { qaChecklist?: unknown };
+      return Boolean(fm.qaChecklist);
+    } catch {
+      return false;
+    }
+  })();
+
+  const qaChecklistRequired = hasTestRole || recipeOptsIn;
+
   const candidates: Array<{ name: string; required: boolean; rationale: string }> = [
     { name: "TEAM.md", required: true, rationale: "Team workspace overview" },
     { name: "TICKETS.md", required: true, rationale: "Ticket workflow + format" },
-    { name: "notes/QA_CHECKLIST.md", required: true, rationale: "QA verification checklist" },
+    { name: "notes/QA_CHECKLIST.md", required: qaChecklistRequired, rationale: "QA verification checklist" },
 
     { name: "SOUL.md", required: false, rationale: "Optional team persona (some teams use role SOUL.md only)" },
     { name: "USER.md", required: false, rationale: "Optional user profile" },


### PR DESCRIPTION
ClawKitchen Team Files API previously always marked notes/QA_CHECKLIST.md as required.

This PR makes it required only when:
- the team has a roles/test directory, and/or
- the team recipe opts in via frontmatter (qaChecklist: true)

This matches our intended shared-context / QA workflow: lightweight teams shouldn't be forced to carry QA checklist requirements.

How to verify:
- Team without test role + no opt-in → QA_CHECKLIST not required
- Team with test role OR qaChecklist: true → QA_CHECKLIST required