### PR TITLE
Cron jobs: delete-confirm + disabled-only delete + show owning team/agent

### DIFF
--- a/src/app/api/cron/delete/route.ts
+++ b/src/app/api/cron/delete/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { toolsInvoke } from "@/lib/gateway";
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+type MappingStateV1 = {
+  version: 1;
+  entries: Record<string, { installedCronId: string; orphaned?: boolean }>;
+};
+
+export async function POST(req: Request) {
+  const body = (await req.json()) as { id?: string };
+  const id = String(body.id ?? "").trim();
+  if (!id) return NextResponse.json({ ok: false, error: "id is required" }, { status: 400 });
+
+  const result = await toolsInvoke({ tool: "cron", args: { action: "remove", jobId: id } });
+
+  // Best-effort provenance cleanup: mark any mapping entry that references this cron id as orphaned.
+  // Source of truth is team workspaces' notes/cron-jobs.json written at scaffold time.
+  const orphanedIn: Array<{ teamId: string; mappingPath: string; keys: string[] }> = [];
+
+  try {
+    // Find base workspace path via gateway config.
+    const cfg = await toolsInvoke<{ content: Array<{ type: string; text?: string }> }>({
+      tool: "gateway",
+      args: { action: "config.get", raw: "{}" },
+    });
+    const cfgText = cfg?.content?.find((c) => c.type === "text")?.text ?? "";
+    const env = cfgText ? (JSON.parse(cfgText) as { result?: { raw?: string } }) : null;
+    const raw = String(env?.result?.raw ?? "");
+    const parsedRaw = raw ? (JSON.parse(raw) as { agents?: { defaults?: { workspace?: string } } }) : null;
+    const baseWorkspace = String(parsedRaw?.agents?.defaults?.workspace ?? "").trim();
+
+    if (baseWorkspace) {
+      const baseHome = path.resolve(baseWorkspace, "..");
+      const entries = await fs.readdir(baseHome, { withFileTypes: true });
+
+      for (const ent of entries) {
+        if (!ent.isDirectory()) continue;
+        if (!ent.name.startsWith("workspace-")) continue;
+
+        const teamId = ent.name.replace(/^workspace-/, "");
+        const teamJsonPath = path.join(baseHome, ent.name, "team.json");
+        const mappingPath = path.join(baseHome, ent.name, "notes", "cron-jobs.json");
+
+        try {
+          await fs.stat(teamJsonPath);
+        } catch {
+          continue;
+        }
+
+        let changed = false;
+        const keys: string[] = [];
+        try {
+          const rawMapping = await fs.readFile(mappingPath, "utf8");
+          const mapping = JSON.parse(rawMapping) as MappingStateV1;
+          if (!mapping || mapping.version !== 1 || !mapping.entries) continue;
+
+          for (const [k, v] of Object.entries(mapping.entries)) {
+            if (String(v?.installedCronId ?? "").trim() === id && !v.orphaned) {
+              mapping.entries[k] = { ...v, orphaned: true };
+              changed = true;
+              keys.push(k);
+            }
+          }
+
+          if (changed) {
+            await fs.writeFile(mappingPath, JSON.stringify(mapping, null, 2) + "\n", "utf8");
+            orphanedIn.push({ teamId, mappingPath, keys });
+          }
+        } catch {
+          // ignore
+        }
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  return NextResponse.json({ ok: true, id, result, orphanedIn });
+}

--- a/src/app/api/cron/jobs/route.ts
+++ b/src/app/api/cron/jobs/route.ts
@@ -8,6 +8,11 @@ type CronToolResult = {
 import fs from "node:fs/promises";
 import path from "node:path";
 import { getTeamWorkspaceDir } from "@/lib/paths";
+import { runOpenClaw } from "@/lib/openclaw";
+
+function hrefForScope(scope: { kind: "team" | "agent"; id: string }) {
+  return scope.kind === "team" ? `/teams/${encodeURIComponent(scope.id)}` : `/agents/${encodeURIComponent(scope.id)}`;
+}
 
 export async function GET(req: Request) {
   try {
@@ -27,8 +32,86 @@ export async function GET(req: Request) {
     const parsed = JSON.parse(text) as { jobs?: unknown[] };
     const jobs = Array.isArray(parsed.jobs) ? parsed.jobs : [];
 
+    // Enrich: map installed cron IDs → scope (team/agent) using provenance files.
+    // This is best-effort; if anything fails, we still return raw jobs.
+    const idToScope = new Map<string, { kind: "team" | "agent"; id: string; label: string; href: string }>();
+
+    try {
+      // Teams: scan known workspace-* directories for notes/cron-jobs.json
+      // NOTE: This is not intended to be ultra-fast; cron-jobs page is admin tooling.
+      const baseWorkspace = String((await (await import("@/lib/paths")).readOpenClawConfig()).agents?.defaults?.workspace ?? "").trim();
+      const baseHome = path.resolve(baseWorkspace, "..");
+      const entries = await fs.readdir(baseHome, { withFileTypes: true });
+
+      for (const ent of entries) {
+        if (!ent.isDirectory()) continue;
+        if (!ent.name.startsWith("workspace-")) continue;
+        const scopeId = ent.name.replace(/^workspace-/, "");
+        const teamJsonPath = path.join(baseHome, ent.name, "team.json");
+        const teamNotesCronPath = path.join(baseHome, ent.name, "notes", "cron-jobs.json");
+
+        // If team.json exists, treat as a team workspace.
+        try {
+          await fs.stat(teamJsonPath);
+        } catch {
+          continue;
+        }
+
+        try {
+          const raw = await fs.readFile(teamNotesCronPath, "utf8");
+          const json = JSON.parse(raw) as { entries?: Record<string, { installedCronId?: unknown; orphaned?: unknown }> };
+          const map = json.entries ?? {};
+          for (const v of Object.values(map)) {
+            if (v && !Boolean(v.orphaned)) {
+              const id = String(v.installedCronId ?? "").trim();
+              if (id) idToScope.set(id, { kind: "team", id: scopeId, label: scopeId, href: hrefForScope({ kind: "team", id: scopeId }) });
+            }
+          }
+        } catch {
+          // ignore
+        }
+      }
+
+      // Agents: use OpenClaw config list to map agent workspaces and check for notes/cron-jobs.json
+      try {
+        const cfgText = await runOpenClaw(["config", "get", "agents.list", "--no-color"]);
+        if (cfgText.ok) {
+          const list = JSON.parse(String(cfgText.stdout ?? "[]")) as Array<{ id?: unknown; workspace?: unknown }>;
+          for (const a of list) {
+            const agentId = String(a.id ?? "");
+            const workspace = String(a.workspace ?? "");
+            if (!agentId || !workspace) continue;
+            const cronPath = path.join(workspace, "notes", "cron-jobs.json");
+            try {
+              const raw = await fs.readFile(cronPath, "utf8");
+              const json = JSON.parse(raw) as { entries?: Record<string, { installedCronId?: unknown; orphaned?: unknown }> };
+              const map = json.entries ?? {};
+              for (const v of Object.values(map)) {
+                if (v && !Boolean(v.orphaned)) {
+                  const id = String(v.installedCronId ?? "").trim();
+                  if (id) idToScope.set(id, { kind: "agent", id: agentId, label: agentId, href: hrefForScope({ kind: "agent", id: agentId }) });
+                }
+              }
+            } catch {
+              // ignore
+            }
+          }
+        }
+      } catch {
+        // ignore
+      }
+    } catch {
+      // ignore
+    }
+
+    const enriched = jobs.map((j) => {
+      const id = String((j as { id?: unknown }).id ?? "");
+      const scope = id ? idToScope.get(id) : undefined;
+      return scope ? { ...(j as object), scope } : j;
+    });
+
     if (!teamId) {
-      return NextResponse.json({ ok: true, jobs });
+      return NextResponse.json({ ok: true, jobs: enriched });
     }
 
     // If a teamId is provided, filter to only cron jobs installed for that team.
@@ -46,11 +129,10 @@ export async function GET(req: Request) {
         .map((e) => String(e.installedCronId ?? "").trim())
         .filter(Boolean);
     } catch {
-      // If the file is missing, treat as no installed cron jobs.
       installedIds = [];
     }
 
-    const filtered = jobs.filter((j) => installedIds.includes(String((j as { id?: unknown }).id ?? "")));
+    const filtered = enriched.filter((j) => installedIds.includes(String((j as { id?: unknown }).id ?? "")));
     return NextResponse.json({ ok: true, jobs: filtered, teamId, provenancePath, installedIds });
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/src/app/cron-jobs/DeleteCronJobModal.tsx
+++ b/src/app/cron-jobs/DeleteCronJobModal.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { createPortal } from "react-dom";
+
+export function DeleteCronJobModal({
+  open,
+  jobLabel,
+  onClose,
+  onConfirm,
+  busy,
+  error,
+}: {
+  open: boolean;
+  jobLabel: string;
+  busy?: boolean;
+  error?: string | null;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[200]">
+      <div className="fixed inset-0 bg-black/60" onClick={onClose} />
+      <div className="fixed inset-0 overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center p-4">
+          <div className="w-full max-w-lg rounded-2xl border border-white/10 bg-[color:var(--ck-bg-glass-strong)] p-5 shadow-[var(--ck-shadow-2)]">
+            <div className="text-lg font-semibold text-[color:var(--ck-text-primary)]">Delete cron job</div>
+            <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+              Delete cron job <code className="font-mono">{jobLabel}</code>? This removes it from the Gateway scheduler.
+              You can recreate it later.
+            </p>
+
+            {error ? (
+              <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">
+                {error}
+              </div>
+            ) : null}
+
+            <div className="mt-6 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={onConfirm}
+                className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] hover:bg-[var(--ck-accent-red-hover)] disabled:opacity-50"
+              >
+                {busy ? "Deleting…" : "Delete"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}


### PR DESCRIPTION
Changes on /cron-jobs:
- Add Delete button (only enabled when job is disabled)
- Add modal confirm before deletion
- Use ToastProvider notifications for success/error
- Enrich cron jobs with related team/agent scope + link
- Best-effort: when deleting a cron, mark matching provenance entries (notes/cron-jobs.json) as orphaned

This helps diagnose/cleanup cron jobs that should be removed when removing teams.

Tests:
- npm run lint
- tsc --noEmit