### PR TITLE
ClawKitchen UX v2: publish changes, id guards, faster loading, cron job expand

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -13,9 +13,12 @@ type AgentListItem = {
 
 function inferTeamIdFromWorkspace(workspace: string | undefined) {
   if (!workspace) return null;
-  const base = workspace.split("/").filter(Boolean).pop() ?? "";
-  if (!base.startsWith("workspace-")) return null;
-  const team = base.slice("workspace-".length);
+  const parts = workspace.split("/").filter(Boolean);
+  // Team workspaces are typically ~/.openclaw/workspace-<teamId>/..., so the workspace- segment
+  // is not always the last path component.
+  const wsPart = parts.find((p) => p.startsWith("workspace-")) ?? "";
+  if (!wsPart) return null;
+  const team = wsPart.slice("workspace-".length);
   return team || null;
 }
 

--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -2,6 +2,7 @@
 
 import { createPortal } from "react-dom";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 
 type AgentListItem = {
   id: string;
@@ -74,7 +75,8 @@ function DeleteAgentModal({
   );
 }
 
-export default function AgentEditor({ agentId }: { agentId: string }) {
+export default function AgentEditor({ agentId, returnTo }: { agentId: string; returnTo?: string }) {
+  const router = useRouter();
   const [agent, setAgent] = useState<AgentListItem | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -388,6 +390,18 @@ export default function AgentEditor({ agentId }: { agentId: string }) {
               >
                 {saving ? "Saving…" : "Save"}
               </button>
+              {returnTo ? (
+                <button
+                  disabled={saving}
+                  onClick={async () => {
+                    await onSaveIdentity();
+                    router.push(returnTo);
+                  }}
+                  className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-white/10 active:bg-white/15 disabled:opacity-50"
+                >
+                  Save & return
+                </button>
+              ) : null}
             </div>
           </div>
         ) : null}

--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -101,7 +101,9 @@ export default function AgentEditor({ agentId }: { agentId: string }) {
   const [fileName, setFileName] = useState<string>("IDENTITY.md");
   const [fileContent, setFileContent] = useState<string>("");
 
-  const [saveAsNewId, setSaveAsNewId] = useState<string>("");
+
+
+  const teamId = agentId.includes("-") ? agentId.split("-").slice(0, -1).join("-") : "";
 
   useEffect(() => {
     (async () => {
@@ -190,27 +192,6 @@ export default function AgentEditor({ agentId }: { agentId: string }) {
     }
   }
 
-  async function onSaveAsNew() {
-    const newAgentId = saveAsNewId.trim();
-    if (!newAgentId) return setMessage("New agent id is required");
-
-    setSaving(true);
-    setMessage("");
-    try {
-      const res = await fetch("/api/agents/add", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ newAgentId, name, emoji, theme, avatar, model: agent?.model }),
-      });
-      const json = (await res.json()) as { message?: string; error?: string };
-      if (!res.ok) throw new Error(json.message || json.error || "Save As New failed");
-      setMessage(`Created new agent: ${newAgentId}`);
-    } catch (e: unknown) {
-      setMessage(e instanceof Error ? e.message : String(e));
-    } finally {
-      setSaving(false);
-    }
-  }
 
   async function onLoadAgentFile(nextName: string) {
     setLoadingFile(true);
@@ -317,6 +298,9 @@ export default function AgentEditor({ agentId }: { agentId: string }) {
       {agent.workspace ? (
         <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Workspace: {agent.workspace}</div>
       ) : null}
+      {teamId ? (
+        <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Team: {teamId}</div>
+      ) : null}
 
       <div className="mt-6 flex flex-wrap gap-2">
         {(
@@ -391,28 +375,6 @@ export default function AgentEditor({ agentId }: { agentId: string }) {
               >
                 {saving ? "Saving…" : "Save"}
               </button>
-            </div>
-
-            <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3">
-              <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Save As New (new agent id)</div>
-              <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
-                <input
-                  value={saveAsNewId}
-                  onChange={(e) => setSaveAsNewId(e.target.value)}
-                  placeholder={`${agentId}-copy`}
-                  className="w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
-                />
-                <button
-                  disabled={saving}
-                  onClick={onSaveAsNew}
-                  className="shrink-0 rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-white/10 active:bg-white/15 disabled:opacity-50"
-                >
-                  {saving ? "Saving…" : "Save As New"}
-                </button>
-              </div>
-              <p className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
-                This adds a new agent entry to OpenClaw config and restarts the gateway.
-              </p>
             </div>
           </div>
         ) : null}

--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -106,8 +106,6 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
   const [fileName, setFileName] = useState<string>("IDENTITY.md");
   const [fileContent, setFileContent] = useState<string>("");
 
-
-
   const teamId = agentId.includes("-") ? agentId.split("-").slice(0, -1).join("-") : "";
 
   useEffect(() => {
@@ -207,13 +205,11 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
     }
   }
 
-
   async function onLoadAgentFile(nextName: string) {
     setLoadingFile(true);
     setMessage("");
     try {
-      const res = await fetch(
-        `/api/agents/file?agentId=${encodeURIComponent(agentId)}&name=${encodeURIComponent(nextName)}`,
+      const res = await fetch(`/api/agents/file?agentId=${encodeURIComponent(agentId)}&name=${encodeURIComponent(nextName)}`,
         { cache: "no-store" },
       );
       const json = (await res.json()) as { ok?: boolean; error?: string; content?: string };
@@ -313,9 +309,7 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
       {agent.workspace ? (
         <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Workspace: {agent.workspace}</div>
       ) : null}
-      {teamId ? (
-        <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Team: {teamId}</div>
-      ) : null}
+      {teamId ? <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Team: {teamId}</div> : null}
 
       <div className="mt-6 flex flex-wrap gap-2">
         {(
@@ -495,6 +489,19 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
                   {installingSkill ? "Adding…" : "Add"}
                 </button>
               </div>
+
+              {message ? (
+                <div
+                  className={
+                    message.startsWith("Installed skill:")
+                      ? "mt-3 rounded-[var(--ck-radius-sm)] border border-emerald-400/30 bg-emerald-500/10 p-3 text-sm text-emerald-100"
+                      : "mt-3 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100"
+                  }
+                >
+                  {message}
+                </div>
+              ) : null}
+
               <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
                 This uses <code>openclaw recipes install-skill &lt;skill&gt; --agent-id {agentId} --yes</code>.
               </div>
@@ -508,40 +515,34 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
               <div className="flex items-center justify-between gap-3">
                 <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Agent files</div>
                 <label className="flex items-center gap-2 text-xs text-[color:var(--ck-text-secondary)]">
-                  <input
-                    type="checkbox"
-                    checked={showOptionalFiles}
-                    onChange={(e) => setShowOptionalFiles(e.target.checked)}
-                  />
+                  <input type="checkbox" checked={showOptionalFiles} onChange={(e) => setShowOptionalFiles(e.target.checked)} />
                   Show optional
                 </label>
               </div>
-              <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
-                Default view hides optional missing files to reduce noise.
-              </div>
+              <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">Default view hides optional missing files to reduce noise.</div>
               <ul className="mt-3 space-y-1">
                 {agentFiles
                   .filter((f) => (showOptionalFiles ? true : Boolean(f.required) || !f.missing))
                   .map((f) => (
-                  <li key={f.name}>
-                    <button
-                      onClick={() => onLoadAgentFile(f.name)}
-                      className={
-                        fileName === f.name
-                          ? "w-full rounded-[var(--ck-radius-sm)] bg-white/10 px-3 py-2 text-left text-sm text-[color:var(--ck-text-primary)]"
-                          : "w-full rounded-[var(--ck-radius-sm)] px-3 py-2 text-left text-sm text-[color:var(--ck-text-secondary)] hover:bg-white/5"
-                      }
-                    >
-                      <span className={f.required ? "text-[color:var(--ck-text-primary)]" : "text-[color:var(--ck-text-secondary)]"}>
-                        {f.name}
-                      </span>
-                      <span className="ml-2 text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">
-                        {f.required ? "required" : "optional"}
-                      </span>
-                      {f.missing ? <span className="ml-2 text-xs text-[color:var(--ck-text-tertiary)]">missing</span> : null}
-                    </button>
-                  </li>
-                ))}
+                    <li key={f.name}>
+                      <button
+                        onClick={() => onLoadAgentFile(f.name)}
+                        className={
+                          fileName === f.name
+                            ? "w-full rounded-[var(--ck-radius-sm)] bg-white/10 px-3 py-2 text-left text-sm text-[color:var(--ck-text-primary)]"
+                            : "w-full rounded-[var(--ck-radius-sm)] px-3 py-2 text-left text-sm text-[color:var(--ck-text-secondary)] hover:bg-white/5"
+                        }
+                      >
+                        <span className={f.required ? "text-[color:var(--ck-text-primary)]" : "text-[color:var(--ck-text-secondary)]"}>
+                          {f.name}
+                        </span>
+                        <span className="ml-2 text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">
+                          {f.required ? "required" : "optional"}
+                        </span>
+                        {f.missing ? <span className="ml-2 text-xs text-[color:var(--ck-text-tertiary)]">missing</span> : null}
+                      </button>
+                    </li>
+                  ))}
               </ul>
             </div>
 
@@ -549,9 +550,7 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
               <div className="flex items-center justify-between gap-3">
                 <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Edit: {fileName}</div>
                 <div className="flex items-center gap-3">
-                  {loadingFile ? (
-                    <span className="text-xs text-[color:var(--ck-text-tertiary)]">Loading…</span>
-                  ) : null}
+                  {loadingFile ? <span className="text-xs text-[color:var(--ck-text-tertiary)]">Loading…</span> : null}
                   <button
                     disabled={saving}
                     onClick={onSaveAgentFile}
@@ -568,12 +567,6 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
                 spellCheck={false}
               />
             </div>
-          </div>
-        ) : null}
-
-        {message ? (
-          <div className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-sm text-[color:var(--ck-text-primary)]">
-            {message}
           </div>
         ) : null}
       </div>

--- a/src/app/agents/[agentId]/page.tsx
+++ b/src/app/agents/[agentId]/page.tsx
@@ -1,22 +1,32 @@
 import Link from "next/link";
 import AgentEditor from "./agent-editor";
 
-export default async function AgentPage({ params }: { params: Promise<{ agentId: string }> }) {
+export default async function AgentPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ agentId: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
   const { agentId } = await params;
+  const sp = (await searchParams) ?? {};
+  const returnToRaw = sp.returnTo;
+  const returnTo = Array.isArray(returnToRaw) ? returnToRaw[0] : returnToRaw;
+  const backHref = typeof returnTo === "string" && returnTo.trim() ? returnTo : "/";
 
   return (
     <main className="min-h-screen p-8">
       <div className="mx-auto mb-4 flex max-w-6xl items-center justify-between gap-4">
         <Link
-          href="/"
+          href={backHref}
           className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
         >
-          ← Home
+          ← Back
         </Link>
         <div className="text-xs text-[color:var(--ck-text-tertiary)]">Agent: {agentId}</div>
       </div>
 
-      <AgentEditor agentId={agentId} />
+      <AgentEditor agentId={agentId} returnTo={typeof returnTo === "string" ? returnTo : undefined} />
     </main>
   );
 }

--- a/src/app/api/agents/skills/install/route.ts
+++ b/src/app/api/agents/skills/install/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { runOpenClaw } from "@/lib/openclaw";
+
+export async function POST(req: Request) {
+  const body = (await req.json()) as { agentId?: string; skill?: string };
+  const agentId = String(body.agentId ?? "").trim();
+  const skill = String(body.skill ?? "").trim();
+
+  if (!agentId) return NextResponse.json({ ok: false, error: "agentId is required" }, { status: 400 });
+  if (!skill) return NextResponse.json({ ok: false, error: "skill is required" }, { status: 400 });
+
+  const args = ["recipes", "install-skill", skill, "--agent-id", agentId, "--yes"];
+  const res = await runOpenClaw(args);
+  if (!res.ok) {
+    return NextResponse.json(
+      { ok: false, error: res.stderr.trim() || `openclaw ${args.join(" ")} failed (exit=${res.exitCode})`, stdout: res.stdout, stderr: res.stderr },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ ok: true, agentId, skill, stdout: res.stdout, stderr: res.stderr });
+}

--- a/src/app/api/ids/check/route.ts
+++ b/src/app/api/ids/check/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { runOpenClaw } from "@/lib/openclaw";
+import { readOpenClawConfig } from "@/lib/paths";
+
+type Kind = "team" | "agent";
+
+function normalizeId(v: unknown) {
+  return String(v ?? "").trim();
+}
+
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url);
+    const kind = normalizeId(url.searchParams.get("kind")) as Kind;
+    const id = normalizeId(url.searchParams.get("id"));
+
+    if (kind !== "team" && kind !== "agent") {
+      return NextResponse.json({ ok: false, error: "kind must be team|agent" }, { status: 400 });
+    }
+    if (!id) {
+      return NextResponse.json({ ok: true, available: false, reason: "empty" });
+    }
+
+    // Disallow collisions with any recipe id.
+    const recipesRes = await runOpenClaw(["recipes", "list"]);
+    if (recipesRes.ok) {
+      try {
+        const items = JSON.parse(recipesRes.stdout) as Array<{ id?: unknown }>;
+        const ids = new Set(items.map((r) => normalizeId(r.id)).filter(Boolean));
+        if (ids.has(id)) {
+          return NextResponse.json({ ok: true, available: false, reason: "recipe-id-collision" });
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    if (kind === "agent") {
+      const agentsRes = await runOpenClaw(["agents", "list", "--json"]);
+      if (agentsRes.ok) {
+        try {
+          const agents = JSON.parse(agentsRes.stdout) as Array<{ id?: unknown }>;
+          const exists = agents.some((a) => normalizeId(a.id) === id);
+          if (exists) return NextResponse.json({ ok: true, available: false, reason: "agent-exists" });
+        } catch {
+          // ignore
+        }
+      }
+
+      return NextResponse.json({ ok: true, available: true });
+    }
+
+    // Team id: check team workspace dir and any team agents prefix.
+    try {
+      const cfg = await readOpenClawConfig();
+      const baseWorkspace = normalizeId(cfg.agents?.defaults?.workspace);
+      if (baseWorkspace) {
+        const teamDir = path.resolve(baseWorkspace, "..", `workspace-${id}`);
+        const hasDir = await fs
+          .stat(teamDir)
+          .then(() => true)
+          .catch(() => false);
+        if (hasDir) return NextResponse.json({ ok: true, available: false, reason: "team-workspace-exists" });
+      }
+    } catch {
+      // ignore
+    }
+
+    const agentsRes = await runOpenClaw(["agents", "list", "--json"]);
+    if (agentsRes.ok) {
+      try {
+        const agents = JSON.parse(agentsRes.stdout) as Array<{ id?: unknown }>;
+        const hasAgents = agents.some((a) => normalizeId(a.id).startsWith(`${id}-`));
+        if (hasAgents) return NextResponse.json({ ok: true, available: false, reason: "team-agents-exist" });
+      } catch {
+        // ignore
+      }
+    }
+
+    return NextResponse.json({ ok: true, available: true });
+  } catch (e: unknown) {
+    return NextResponse.json(
+      { ok: false, error: e instanceof Error ? e.message : String(e) },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/recipes/[id]/route.ts
+++ b/src/app/api/recipes/[id]/route.ts
@@ -1,6 +1,11 @@
+import crypto from "node:crypto";
 import { NextResponse } from "next/server";
 import { runOpenClaw } from "@/lib/openclaw";
 import { parseFrontmatterId, resolveRecipePath, type RecipeListItem, writeRecipeFile } from "@/lib/recipes";
+
+function sha256(text: string) {
+  return crypto.createHash("sha256").update(text, "utf8").digest("hex");
+}
 
 export async function GET(
   _req: Request,
@@ -17,7 +22,9 @@ export async function GET(
   const shown = await runOpenClaw(["recipes", "show", id]);
   const filePath = await resolveRecipePath(item).catch(() => null);
 
-  return NextResponse.json({ recipe: { ...item, content: shown.stdout, filePath }, stderr: shown.stderr });
+  const recipeHash = sha256(shown.stdout);
+
+  return NextResponse.json({ recipe: { ...item, content: shown.stdout, filePath }, recipeHash, stderr: shown.stderr });
 }
 
 export async function PUT(

--- a/src/app/api/recipes/delete/route.ts
+++ b/src/app/api/recipes/delete/route.ts
@@ -41,33 +41,78 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: `Refusing to delete non-workspace recipe path: ${resolved}` }, { status: 403 });
   }
 
-  // Block deletion if this is a team recipe and the team appears installed.
-  if ((item.kind ?? "team") === "team") {
-    const teamId = id;
-    const teamDir = path.resolve(workspaceRoot, "..", `workspace-${teamId}`);
-    const hasWorkspace = await fs
-      .stat(teamDir)
-      .then(() => true)
-      .catch(() => false);
+  const kind = (item.kind ?? "team") as "team" | "agent";
 
-    // Agents check (prefix match)
+  // Block deletion if this recipe appears in use.
+  if (kind === "team") {
+    // A team recipe can scaffold many teams with different teamIds.
+    // We treat any workspace-*/team.json referencing this recipe as "in use".
+    const teamsRoot = path.resolve(workspaceRoot, "..");
+    const attachedTeams: string[] = [];
+
+    try {
+      const entries = await fs.readdir(teamsRoot, { withFileTypes: true });
+      const workspaceDirs = entries.filter((e) => e.isDirectory() && e.name.startsWith("workspace-"));
+      for (const dirent of workspaceDirs) {
+        const metaPath = path.join(teamsRoot, dirent.name, "team.json");
+        try {
+          const raw = await fs.readFile(metaPath, "utf8");
+          const meta = JSON.parse(raw) as { recipeId?: unknown; teamId?: unknown };
+          if (String(meta.recipeId ?? "").trim() === id) {
+            attachedTeams.push(String(meta.teamId ?? dirent.name.replace(/^workspace-/, "")).trim() || dirent.name);
+          }
+        } catch {
+          // ignore missing/unparseable
+        }
+      }
+    } catch {
+      // ignore
+    }
+
+    if (attachedTeams.length) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: `Team ${id} is in use by installed team(s): ${attachedTeams.join(", ")}. Remove the team(s) first, then delete the recipe. If no team is shown, you still have a .openclaw/workspace-${id} folder. Please remove the folder to delete this recipe.`, 
+          details: { attachedTeams },
+        },
+        { status: 409 },
+      );
+    }
+  }
+
+  if (kind === "agent") {
+    // Agent recipes can scaffold many agents with different agentIds.
+    // We treat any agents/<agentId>/agent.json referencing this recipe as "in use".
     const agentsRes = await runOpenClaw(["agents", "list", "--json"]);
-    let hasAgents = false;
+    const attachedAgents: string[] = [];
+
     if (agentsRes.ok) {
       try {
-        const agents = JSON.parse(agentsRes.stdout) as Array<{ id?: string }>;
-        hasAgents = agents.some((a) => String(a.id ?? "").startsWith(`${teamId}-`));
+        const agents = JSON.parse(agentsRes.stdout) as Array<{ id?: unknown }>;
+        for (const a of agents) {
+          const agentId = String(a.id ?? "").trim();
+          if (!agentId) continue;
+          const metaPath = path.join(workspaceRoot, "agents", agentId, "agent.json");
+          try {
+            const raw = await fs.readFile(metaPath, "utf8");
+            const meta = JSON.parse(raw) as { recipeId?: unknown };
+            if (String(meta.recipeId ?? "").trim() === id) attachedAgents.push(agentId);
+          } catch {
+            // ignore missing/unparseable
+          }
+        }
       } catch {
         // ignore
       }
     }
 
-    if (hasWorkspace || hasAgents) {
+    if (attachedAgents.length) {
       return NextResponse.json(
         {
           ok: false,
-          error: `Team appears installed for ${teamId}. Remove the team first, then delete the recipe.`,
-          details: { hasWorkspace, hasAgents, teamDir },
+          error: `Agent recipe ${id} is in use by active agent(s): ${attachedAgents.join(", ")}. Delete the agent(s) first, then delete the recipe.`,
+          details: { attachedAgents },
         },
         { status: 409 },
       );

--- a/src/app/api/scaffold/route.ts
+++ b/src/app/api/scaffold/route.ts
@@ -73,8 +73,9 @@ export async function POST(req: Request) {
   try {
     // Collision guards: site-wide rules.
     // 1) Do not allow creating a team/agent with an id that collides with ANY recipe id.
+    //    (BUT allow when overwrite=true, which is used for re-scaffolding/publish flows.)
     // 2) Do not allow creating a team/agent that already exists unless overwrite was explicitly set.
-    {
+    if (!body.overwrite) {
       const recipesRes = await runOpenClaw(["recipes", "list"]);
       if (recipesRes.ok) {
         try {

--- a/src/app/api/skills/available/route.ts
+++ b/src/app/api/skills/available/route.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const home = os.homedir();
+  const globalSkillsDir = path.join(home, ".openclaw", "skills");
+
+  try {
+    const entries = await fs.readdir(globalSkillsDir, { withFileTypes: true });
+    const skills = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort((a, b) => a.localeCompare(b));
+
+    return NextResponse.json({ ok: true, skillsDir: globalSkillsDir, skills });
+  } catch (e: unknown) {
+    // If missing, treat as empty.
+    return NextResponse.json({ ok: true, skillsDir: globalSkillsDir, skills: [], note: e instanceof Error ? e.message : String(e) });
+  }
+}

--- a/src/app/api/teams/skills/install/route.ts
+++ b/src/app/api/teams/skills/install/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { runOpenClaw } from "@/lib/openclaw";
+
+export async function POST(req: Request) {
+  const body = (await req.json()) as { teamId?: string; skill?: string };
+  const teamId = String(body.teamId ?? "").trim();
+  const skill = String(body.skill ?? "").trim();
+
+  if (!teamId) return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
+  if (!skill) return NextResponse.json({ ok: false, error: "skill is required" }, { status: 400 });
+
+  const args = ["recipes", "install-skill", skill, "--team-id", teamId, "--yes"];
+  const res = await runOpenClaw(args);
+  if (!res.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: res.stderr.trim() || `openclaw ${args.join(" ")} failed (exit=${res.exitCode})`,
+        stdout: res.stdout,
+        stderr: res.stderr,
+      },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ ok: true, teamId, skill, stdout: res.stdout, stderr: res.stderr });
+}

--- a/src/app/cron-jobs/cron-jobs-client.tsx
+++ b/src/app/cron-jobs/cron-jobs-client.tsx
@@ -39,7 +39,12 @@ export default function CronJobsClient() {
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const sorted = useMemo(() => {
-    return [...jobs].sort((a, b) => String(a.name ?? "").localeCompare(String(b.name ?? "")));
+    return [...jobs].sort((a, b) => {
+      const ae = Boolean(a.enabled);
+      const be = Boolean(b.enabled);
+      if (ae !== be) return ae ? -1 : 1; // enabled first
+      return String(a.name ?? "").localeCompare(String(b.name ?? ""));
+    });
   }, [jobs]);
 
   async function refresh() {

--- a/src/app/recipes/CreateAgentModal.tsx
+++ b/src/app/recipes/CreateAgentModal.tsx
@@ -88,7 +88,7 @@ export function CreateAgentModal({
           setAvailability({ state: "empty" });
         }
       })();
-    }, 250);
+    }, 500);
 
     return () => clearTimeout(t);
   }, [effectiveId, open]);

--- a/src/app/recipes/CreateAgentModal.tsx
+++ b/src/app/recipes/CreateAgentModal.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { createPortal } from "react-dom";
+
+export function CreateAgentModal({
+  open,
+  recipeId,
+  recipeName,
+  agentId,
+  setAgentId,
+  agentName,
+  setAgentName,
+  busy,
+  error,
+  onClose,
+  onConfirm,
+}: {
+  open: boolean;
+  recipeId: string;
+  recipeName: string;
+  agentId: string;
+  setAgentId: (v: string) => void;
+  agentName: string;
+  setAgentName: (v: string) => void;
+  busy?: boolean;
+  error?: string | null;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[200]">
+      <div className="fixed inset-0 bg-black/60" onClick={onClose} />
+      <div className="fixed inset-0 overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center p-4">
+          <div className="w-full max-w-lg rounded-2xl border border-white/10 bg-[color:var(--ck-bg-glass-strong)] p-5 shadow-[var(--ck-shadow-2)]">
+            <div className="text-lg font-semibold text-[color:var(--ck-text-primary)]">Create agent</div>
+            <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+              Create a new agent from recipe <code className="font-mono">{recipeId}</code>
+              {recipeName ? (
+                <>
+                  {" "}(<span className="font-medium">{recipeName}</span>)
+                </>
+              ) : null}
+              .
+            </p>
+
+            <div className="mt-4">
+              <label className="text-sm font-medium text-[color:var(--ck-text-primary)]">Agent id</label>
+              <input
+                value={agentId}
+                onChange={(e) => setAgentId(e.target.value)}
+                placeholder="e.g. my-agent"
+                className="mt-2 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm text-[color:var(--ck-text-primary)] placeholder:text-[color:var(--ck-text-tertiary)]"
+                autoFocus
+              />
+              <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
+                This will scaffold <code className="font-mono">~/.openclaw/workspace/agents/&lt;agentId&gt;</code> and add the agent to config.
+              </div>
+            </div>
+
+            <div className="mt-4">
+              <label className="text-sm font-medium text-[color:var(--ck-text-primary)]">Name (optional)</label>
+              <input
+                value={agentName}
+                onChange={(e) => setAgentName(e.target.value)}
+                placeholder="e.g. My Agent"
+                className="mt-2 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm text-[color:var(--ck-text-primary)] placeholder:text-[color:var(--ck-text-tertiary)]"
+              />
+            </div>
+
+            {error ? (
+              <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">
+                {error}
+              </div>
+            ) : null}
+
+            <div className="mt-6 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={onConfirm}
+                className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] hover:bg-[var(--ck-accent-red-hover)] disabled:opacity-50"
+              >
+                {busy ? "Creating…" : "Create agent"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/app/recipes/CreateAgentModal.tsx
+++ b/src/app/recipes/CreateAgentModal.tsx
@@ -1,6 +1,22 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
+
+function slugifyId(input: string) {
+  return String(input ?? "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/--+/g, "-");
+}
+
+type Availability =
+  | { state: "empty" }
+  | { state: "checking" }
+  | { state: "available" }
+  | { state: "taken"; reason?: string };
 
 export function CreateAgentModal({
   open,
@@ -27,6 +43,56 @@ export function CreateAgentModal({
   onClose: () => void;
   onConfirm: () => void;
 }) {
+  const [idTouched, setIdTouched] = useState(false);
+  const [availability, setAvailability] = useState<Availability>({ state: "empty" });
+
+  const derivedId = useMemo(() => slugifyId(agentName), [agentName]);
+  const effectiveId = idTouched ? agentId : derivedId;
+
+  // Keep parent state in sync so the confirm handler uses the effective id.
+  useEffect(() => {
+    if (!open) return;
+    if (!idTouched) setAgentId(derivedId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [derivedId, open, idTouched]);
+
+  // Reset modal-local state when opened.
+  useEffect(() => {
+    if (!open) return;
+    setIdTouched(false);
+    setAvailability({ state: "empty" });
+    setAgentName("");
+    setAgentId("");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Check id availability (debounced).
+  useEffect(() => {
+    if (!open) return;
+    const v = String(effectiveId ?? "").trim();
+    if (!v) {
+      setAvailability({ state: "empty" });
+      return;
+    }
+
+    const t = setTimeout(() => {
+      void (async () => {
+        setAvailability({ state: "checking" });
+        try {
+          const res = await fetch(`/api/ids/check?kind=agent&id=${encodeURIComponent(v)}`, { cache: "no-store" });
+          const json = (await res.json()) as { ok?: boolean; available?: boolean; reason?: string };
+          if (!res.ok || !json.ok) throw new Error(String((json as { error?: unknown }).error ?? "Failed to check id"));
+          if (json.available) setAvailability({ state: "available" });
+          else setAvailability({ state: "taken", reason: json.reason });
+        } catch {
+          setAvailability({ state: "empty" });
+        }
+      })();
+    }, 250);
+
+    return () => clearTimeout(t);
+  }, [effectiveId, open]);
+
   if (!open) return null;
 
   return createPortal(
@@ -47,16 +113,40 @@ export function CreateAgentModal({
             </p>
 
             <div className="mt-4">
-              <label className="text-sm font-medium text-[color:var(--ck-text-primary)]">Agent id</label>
+              <label className="text-sm font-medium text-[color:var(--ck-text-primary)]">Agent name</label>
               <input
-                value={agentId}
-                onChange={(e) => setAgentId(e.target.value)}
-                placeholder="e.g. my-agent"
+                value={agentName}
+                onChange={(e) => setAgentName(e.target.value)}
+                placeholder="e.g. Crypto Onchain"
                 className="mt-2 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm text-[color:var(--ck-text-primary)] placeholder:text-[color:var(--ck-text-tertiary)]"
                 autoFocus
               />
+            </div>
+
+            <div className="mt-4">
+              <label className="text-sm font-medium text-[color:var(--ck-text-primary)]">Agent id</label>
+              <input
+                value={effectiveId}
+                onChange={(e) => {
+                  setIdTouched(true);
+                  setAgentId(e.target.value);
+                }}
+                placeholder="e.g. crypto-onchain"
+                className={
+                  "mt-2 w-full rounded-[var(--ck-radius-sm)] border bg-white/5 px-3 py-2 text-sm text-[color:var(--ck-text-primary)] placeholder:text-[color:var(--ck-text-tertiary)] " +
+                  (availability.state === "available"
+                    ? "border-emerald-400/50"
+                    : availability.state === "taken"
+                      ? "border-red-400/60"
+                      : "border-white/10")
+                }
+              />
               <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
-                This will scaffold <code className="font-mono">~/.openclaw/workspace/agents/&lt;agentId&gt;</code> and add the agent to config.
+                {availability.state === "taken"
+                  ? "That id is already taken."
+                  : availability.state === "available"
+                    ? "Id is available."
+                    : "This will scaffold ~/.openclaw/workspace/agents/<agentId> and add the agent to config."}
               </div>
             </div>
 
@@ -86,7 +176,7 @@ export function CreateAgentModal({
               </button>
               <button
                 type="button"
-                disabled={busy}
+                disabled={busy || !effectiveId.trim() || availability.state === "taken" || availability.state === "checking"}
                 onClick={onConfirm}
                 className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] hover:bg-[var(--ck-accent-red-hover)] disabled:opacity-50"
               >

--- a/src/app/recipes/CreateTeamModal.tsx
+++ b/src/app/recipes/CreateTeamModal.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { createPortal } from "react-dom";
+
+export function CreateTeamModal({
+  open,
+  recipeId,
+  recipeName,
+  teamId,
+  setTeamId,
+  installCron,
+  setInstallCron,
+  busy,
+  error,
+  onClose,
+  onConfirm,
+}: {
+  open: boolean;
+  recipeId: string;
+  recipeName: string;
+  teamId: string;
+  setTeamId: (v: string) => void;
+  installCron: boolean;
+  setInstallCron: (v: boolean) => void;
+  busy?: boolean;
+  error?: string | null;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[200]">
+      <div className="fixed inset-0 bg-black/60" onClick={onClose} />
+      <div className="fixed inset-0 overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center p-4">
+          <div className="w-full max-w-lg rounded-2xl border border-white/10 bg-[color:var(--ck-bg-glass-strong)] p-5 shadow-[var(--ck-shadow-2)]">
+            <div className="text-lg font-semibold text-[color:var(--ck-text-primary)]">Create team</div>
+            <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+              Create a new team from recipe <code className="font-mono">{recipeId}</code>
+              {recipeName ? (
+                <>
+                  {" "}(<span className="font-medium">{recipeName}</span>)
+                </>
+              ) : null}
+              .
+            </p>
+
+            <div className="mt-4">
+              <label className="text-sm font-medium text-[color:var(--ck-text-primary)]">Team id</label>
+              <input
+                value={teamId}
+                onChange={(e) => setTeamId(e.target.value)}
+                placeholder="e.g. my-team"
+                className="mt-2 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm text-[color:var(--ck-text-primary)] placeholder:text-[color:var(--ck-text-tertiary)]"
+                autoFocus
+              />
+              <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
+                This will scaffold <code className="font-mono">~/.openclaw/workspace-&lt;teamId&gt;</code> and add the team to config.
+              </div>
+            </div>
+
+            <label className="mt-4 flex items-center gap-2 text-sm text-[color:var(--ck-text-secondary)]">
+              <input
+                type="checkbox"
+                checked={installCron}
+                onChange={(e) => setInstallCron(e.target.checked)}
+              />
+              Install cron jobs from this recipe
+            </label>
+
+            {error ? (
+              <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">
+                {error}
+              </div>
+            ) : null}
+
+            <div className="mt-6 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={onConfirm}
+                className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] hover:bg-[var(--ck-accent-red-hover)] disabled:opacity-50"
+              >
+                {busy ? "Creating…" : "Create team"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/app/recipes/CreateTeamModal.tsx
+++ b/src/app/recipes/CreateTeamModal.tsx
@@ -90,7 +90,7 @@ export function CreateTeamModal({
           setAvailability({ state: "empty" });
         }
       })();
-    }, 250);
+    }, 500);
 
     return () => clearTimeout(t);
   }, [effectiveId, open]);

--- a/src/app/recipes/[id]/RecipeEditor.tsx
+++ b/src/app/recipes/[id]/RecipeEditor.tsx
@@ -48,6 +48,16 @@ type TeamRecipeFrontmatter = {
   templates?: Record<string, string>;
 };
 
+type AgentRecipeFrontmatter = {
+  id?: string;
+  name?: string;
+  version?: string;
+  description?: string;
+  kind?: "agent";
+  source?: string;
+  templates?: Record<string, string>;
+};
+
 function parseFrontmatter(raw: string): { fm: TeamRecipeFrontmatter | null; error?: string } {
   // Very small, tolerant frontmatter extractor.
   // Expects:
@@ -65,6 +75,7 @@ function parseFrontmatter(raw: string): { fm: TeamRecipeFrontmatter | null; erro
 }
 
 function templateKeyToFileName(key: string): string {
+  // For team templates, keys are like: <role>.soul, <role>.tools
   const suffix = key.split(".").slice(1).join(".");
   switch (suffix) {
     case "soul":
@@ -79,6 +90,26 @@ function templateKeyToFileName(key: string): string {
       return "INSTALL.md";
     default:
       return suffix ? `${suffix.toUpperCase()}` : key;
+  }
+}
+
+function agentTemplateKeyToFileName(key: string): string {
+  // For agent recipes, keys are usually direct file identifiers (no role prefix).
+  switch (key) {
+    case "soul":
+      return "SOUL.md";
+    case "agents":
+      return "AGENTS.md";
+    case "tools":
+      return "TOOLS.md";
+    case "identity":
+      return "IDENTITY.md";
+    case "install":
+      return "INSTALL.md";
+    case "status":
+      return "STATUS.md";
+    default:
+      return key;
   }
 }
 
@@ -107,6 +138,13 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
   const [creating, setCreating] = useState(false);
   const [createMsg, setCreateMsg] = useState<string>("");
 
+  // Agent create modal state
+  const [createAgentOpen, setCreateAgentOpen] = useState(false);
+  const [agentId, setAgentId] = useState("");
+  const [agentName, setAgentName] = useState("");
+  const [creatingAgent, setCreatingAgent] = useState(false);
+  const [createAgentMsg, setCreateAgentMsg] = useState<string>("");
+
   useEffect(() => {
     (async () => {
       setLoading(true);
@@ -132,6 +170,11 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
 
   const teamFrontmatter = useMemo(() => {
     if (!recipe || recipe.kind !== "team") return { fm: null as TeamRecipeFrontmatter | null, error: undefined as string | undefined };
+    return parseFrontmatter(content);
+  }, [recipe, content]);
+
+  const agentFrontmatter = useMemo(() => {
+    if (!recipe || recipe.kind !== "agent") return { fm: null as AgentRecipeFrontmatter | null, error: undefined as string | undefined };
     return parseFrontmatter(content);
   }, [recipe, content]);
 
@@ -162,6 +205,14 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
     setTeamId(teamFrontmatter.fm?.team?.teamId || "");
     setCronInstallChoice("no");
     setCreateOpen(true);
+  }
+
+  function openCreateAgent() {
+    setCreateAgentMsg("");
+    const defaultId = (agentFrontmatter.fm?.id || recipe?.id || "").trim();
+    setAgentId(defaultId);
+    setAgentName((agentFrontmatter.fm?.name || recipe?.name || "").trim());
+    setCreateAgentOpen(true);
   }
 
   async function onSubmitCreateTeam() {
@@ -202,11 +253,52 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
     }
   }
 
+  async function onSubmitCreateAgent() {
+    if (!recipe || recipe.kind !== "agent") return;
+
+    const a = agentId.trim();
+    if (!a) {
+      setCreateAgentMsg("Agent id is required.");
+      return;
+    }
+
+    setCreatingAgent(true);
+    setCreateAgentMsg("");
+
+    try {
+      const res = await fetch("/api/scaffold", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "agent",
+          recipeId: recipe.id,
+          agentId: a,
+          name: agentName.trim() || undefined,
+          applyConfig: true,
+          overwrite: false,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Create Agent failed");
+
+      setCreateAgentOpen(false);
+      router.push(`/agents/${encodeURIComponent(a)}`);
+      router.refresh();
+    } catch (e: unknown) {
+      setCreateAgentMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setCreatingAgent(false);
+    }
+  }
+
   if (loading) return <div className="ck-glass mx-auto max-w-4xl p-6">Loading…</div>;
   if (!recipe) return <div className="ck-glass mx-auto max-w-4xl p-6">Not found.</div>;
 
   const fm = recipe.kind === "team" ? teamFrontmatter.fm : null;
   const fmErr = recipe.kind === "team" ? teamFrontmatter.error : undefined;
+
+  const afm = recipe.kind === "agent" ? agentFrontmatter.fm : null;
+  const afmErr = recipe.kind === "agent" ? agentFrontmatter.error : undefined;
 
   return (
     <div className="ck-glass mx-auto max-w-6xl p-6 sm:p-8">
@@ -389,9 +481,68 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
           </div>
         ) : (
           <div className="ck-glass-strong p-4">
-            <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Agent recipe</div>
-            <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
-              (Agent recipe preview panel coming soon — use the markdown editor on the left.)
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Agent recipe</div>
+                <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+                  Create an agent from this recipe, and preview what will be scaffolded.
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={openCreateAgent}
+                className="shrink-0 rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[var(--ck-accent-red-hover)] active:bg-[var(--ck-accent-red-active)]"
+              >
+                Create Agent
+              </button>
+            </div>
+
+            {afmErr ? (
+              <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-xs text-[color:var(--ck-text-primary)]">
+                Frontmatter parse error: {afmErr}
+              </div>
+            ) : null}
+
+            <div className="mt-4 space-y-3">
+              <details className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/15 p-3">
+                <summary className="cursor-pointer text-sm font-medium text-[color:var(--ck-text-primary)]">
+                  Files ({Object.keys(afm?.templates ?? {}).length})
+                </summary>
+                <div className="mt-2 space-y-1 text-xs text-[color:var(--ck-text-secondary)]">
+                  {Object.keys(afm?.templates ?? {}).length ? (
+                    <ul className="list-disc space-y-1 pl-5">
+                      {Object.keys(afm?.templates ?? {}).map((k) => (
+                        <li key={k}>
+                          <span className="font-mono text-[11px]">{k}</span>
+                          <span className="text-[color:var(--ck-text-tertiary)]"> → </span>
+                          <span className="font-mono text-[11px]">{agentTemplateKeyToFileName(k)}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <div className="text-[color:var(--ck-text-tertiary)]">(No templates listed in frontmatter)</div>
+                  )}
+                </div>
+              </details>
+
+              <details className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/15 p-3" open>
+                <summary className="cursor-pointer text-sm font-medium text-[color:var(--ck-text-primary)]">
+                  Metadata
+                </summary>
+                <div className="mt-2 space-y-1 text-xs text-[color:var(--ck-text-secondary)]">
+                  <div>
+                    <span className="text-[color:var(--ck-text-tertiary)]">Recipe id:</span> {afm?.id ?? recipe.id}
+                  </div>
+                  <div>
+                    <span className="text-[color:var(--ck-text-tertiary)]">Version:</span> {afm?.version ?? "(unknown)"}
+                  </div>
+                  {afm?.description ? <div className="whitespace-pre-wrap">{afm.description}</div> : null}
+                </div>
+              </details>
+
+              <p className="text-xs text-[color:var(--ck-text-tertiary)]">
+                Create Agent runs <code>openclaw recipes scaffold</code> with <code>--apply-config</code>.
+              </p>
             </div>
           </div>
         )}
@@ -469,8 +620,76 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
         </div>
       ) : null}
 
+      {createAgentOpen ? (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4" role="dialog" aria-modal="true">
+          <div className="ck-glass w-full max-w-lg p-5">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="truncate text-lg font-semibold tracking-tight">Create Agent</div>
+                <div className="mt-1 text-xs text-[color:var(--ck-text-secondary)]">From recipe: {recipe.id}</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => (!creatingAgent ? setCreateAgentOpen(false) : null)}
+                className="rounded-[var(--ck-radius-sm)] px-2 py-1 text-sm text-[color:var(--ck-text-secondary)] hover:text-[color:var(--ck-text-primary)]"
+              >
+                Close
+              </button>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              <label className="block">
+                <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Agent id</div>
+                <input
+                  value={agentId}
+                  onChange={(e) => setAgentId(e.target.value)}
+                  placeholder="e.g. larry"
+                  className="mt-2 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+                  disabled={creatingAgent}
+                />
+              </label>
+
+              <label className="block">
+                <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Name (optional)</div>
+                <input
+                  value={agentName}
+                  onChange={(e) => setAgentName(e.target.value)}
+                  placeholder="e.g. Larry"
+                  className="mt-2 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+                  disabled={creatingAgent}
+                />
+              </label>
+
+              {createAgentMsg ? (
+                <div className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-sm">{createAgentMsg}</div>
+              ) : null}
+
+              <div className="flex justify-end gap-2 pt-2">
+                <button
+                  type="button"
+                  disabled={creatingAgent}
+                  onClick={() => setCreateAgentOpen(false)}
+                  className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] transition-colors hover:bg-white/10 disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  disabled={creatingAgent}
+                  onClick={onSubmitCreateAgent}
+                  className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[var(--ck-accent-red-hover)] active:bg-[var(--ck-accent-red-active)] disabled:opacity-50"
+                >
+                  {creatingAgent ? "Creating…" : "Create Agent"}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
       <p className="mt-6 text-xs text-[color:var(--ck-text-tertiary)]">
-        This page edits the recipe markdown and previews what will be created when you click Create Team.
+        This page edits the recipe markdown and previews what will be created when you click{" "}
+        {recipe.kind === "team" ? "Create Team" : "Create Agent"}.
       </p>
     </div>
   );

--- a/src/app/recipes/[id]/RecipeEditor.tsx
+++ b/src/app/recipes/[id]/RecipeEditor.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { parse as parseYaml } from "yaml";
 
 type Recipe = {
   id: string;
@@ -11,13 +13,68 @@ type Recipe = {
   filePath: string | null;
 };
 
+type TeamRecipeFrontmatter = {
+  id?: string;
+  name?: string;
+  version?: string;
+  description?: string;
+  kind?: "team";
+  source?: string;
+  cronJobs?: Array<{
+    id?: string;
+    name?: string;
+    schedule?: string;
+    agentId?: string;
+    channel?: string;
+    message?: string;
+    enabledByDefault?: boolean;
+  }>;
+  team?: {
+    teamId?: string;
+    agents?: Array<{
+      role?: string;
+      name?: string;
+      tools?: {
+        profile?: string;
+        allow?: string[];
+        deny?: string[];
+      };
+    }>;
+  };
+};
+
+function parseFrontmatter(raw: string): { fm: TeamRecipeFrontmatter | null; error?: string } {
+  // Very small, tolerant frontmatter extractor.
+  // Expects:
+  // ---\n<yaml>\n---\n
+  const m = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n/);
+  if (!m) return { fm: null };
+
+  try {
+    const fm = parseYaml(m[1]) as TeamRecipeFrontmatter;
+    if (!fm || typeof fm !== "object") return { fm: null };
+    return { fm };
+  } catch (e) {
+    return { fm: null, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
 export default function RecipeEditor({ recipeId }: { recipeId: string }) {
+  const router = useRouter();
+
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [recipe, setRecipe] = useState<Recipe | null>(null);
   const [content, setContent] = useState<string>("");
   const [message, setMessage] = useState<string>("");
   const [scaffoldOut, setScaffoldOut] = useState<string>("");
+
+  // Team create modal state
+  const [createOpen, setCreateOpen] = useState(false);
+  const [teamId, setTeamId] = useState("");
+  const [cronInstallChoice, setCronInstallChoice] = useState<"yes" | "no">("no");
+  const [creating, setCreating] = useState(false);
+  const [createMsg, setCreateMsg] = useState<string>("");
 
   useEffect(() => {
     (async () => {
@@ -41,6 +98,11 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
     if (!recipe) return false;
     return recipe.filePath !== null;
   }, [recipe]);
+
+  const teamFrontmatter = useMemo(() => {
+    if (!recipe || recipe.kind !== "team") return { fm: null as TeamRecipeFrontmatter | null, error: undefined as string | undefined };
+    return parseFrontmatter(content);
+  }, [recipe, content]);
 
   async function onSave() {
     setSaving(true);
@@ -86,8 +148,56 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
     }
   }
 
+  function openCreateTeam() {
+    setCreateMsg("");
+    setTeamId(teamFrontmatter.fm?.team?.teamId || "");
+    setCronInstallChoice("no");
+    setCreateOpen(true);
+  }
+
+  async function onSubmitCreateTeam() {
+    if (!recipe || recipe.kind !== "team") return;
+
+    const t = teamId.trim();
+    if (!t) {
+      setCreateMsg("Team id is required.");
+      return;
+    }
+
+    setCreating(true);
+    setCreateMsg("");
+
+    try {
+      const res = await fetch("/api/scaffold", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "team",
+          recipeId: recipe.id,
+          teamId: t,
+          applyConfig: true,
+          overwrite: false,
+          cronInstallChoice,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Create Team failed");
+
+      setCreateOpen(false);
+      router.push(`/teams/${encodeURIComponent(t)}`);
+      router.refresh();
+    } catch (e: unknown) {
+      setCreateMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setCreating(false);
+    }
+  }
+
   if (loading) return <div className="ck-glass mx-auto max-w-4xl p-6">Loading…</div>;
   if (!recipe) return <div className="ck-glass mx-auto max-w-4xl p-6">Not found.</div>;
+
+  const fm = recipe.kind === "team" ? teamFrontmatter.fm : null;
+  const fmErr = recipe.kind === "team" ? teamFrontmatter.error : undefined;
 
   return (
     <div className="ck-glass mx-auto max-w-6xl p-6 sm:p-8">
@@ -135,17 +245,223 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
             spellCheck={false}
           />
         </div>
-        <div className="ck-glass-strong p-4">
-          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Scaffold output</div>
-          <pre className="mt-2 h-[70vh] w-full overflow-auto rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 p-3 text-xs text-[color:var(--ck-text-primary)]">
-            {scaffoldOut || "(no output yet)"}
-          </pre>
-        </div>
+
+        {recipe.kind === "team" ? (
+          <div className="ck-glass-strong p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Team recipe</div>
+                <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+                  Create a team from this recipe, and preview what will be scaffolded.
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={openCreateTeam}
+                className="shrink-0 rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[var(--ck-accent-red-hover)] active:bg-[var(--ck-accent-red-active)]"
+              >
+                Create Team
+              </button>
+            </div>
+
+            {fmErr ? (
+              <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-xs text-[color:var(--ck-text-primary)]">
+                Frontmatter parse error: {fmErr}
+              </div>
+            ) : null}
+
+            <div className="mt-4 space-y-3">
+              <details className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/15 p-3" open>
+                <summary className="cursor-pointer text-sm font-medium text-[color:var(--ck-text-primary)]">
+                  Metadata
+                </summary>
+                <div className="mt-2 space-y-1 text-xs text-[color:var(--ck-text-secondary)]">
+                  <div>
+                    <span className="text-[color:var(--ck-text-tertiary)]">Version:</span> {fm?.version ?? "(unknown)"}
+                  </div>
+                  {fm?.description ? <div className="whitespace-pre-wrap">{fm.description}</div> : null}
+                </div>
+              </details>
+
+              <details className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/15 p-3">
+                <summary className="cursor-pointer text-sm font-medium text-[color:var(--ck-text-primary)]">
+                  Agents ({fm?.team?.agents?.length ?? 0})
+                </summary>
+                <div className="mt-2 space-y-2">
+                  {(fm?.team?.agents ?? []).map((a, idx) => (
+                    <details
+                      key={`${a.role ?? "agent"}:${idx}`}
+                      className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3"
+                    >
+                      <summary className="cursor-pointer text-sm text-[color:var(--ck-text-primary)]">
+                        <span className="font-medium">{a.name ?? a.role ?? "(unnamed)"}</span>
+                        {a.role ? <span className="text-[color:var(--ck-text-tertiary)]"> — {a.role}</span> : null}
+                      </summary>
+                      <div className="mt-2 space-y-1 text-xs text-[color:var(--ck-text-secondary)]">
+                        <div>
+                          <span className="text-[color:var(--ck-text-tertiary)]">Tools profile:</span> {a.tools?.profile ?? "(default)"}
+                        </div>
+                        <div>
+                          <span className="text-[color:var(--ck-text-tertiary)]">Allow:</span>{" "}
+                          {(a.tools?.allow ?? []).length ? (a.tools?.allow ?? []).join(", ") : "(none)"}
+                        </div>
+                        <div>
+                          <span className="text-[color:var(--ck-text-tertiary)]">Deny:</span>{" "}
+                          {(a.tools?.deny ?? []).length ? (a.tools?.deny ?? []).join(", ") : "(none)"}
+                        </div>
+                      </div>
+                    </details>
+                  ))}
+                  {(!fm?.team?.agents || fm.team.agents.length === 0) ? (
+                    <div className="text-xs text-[color:var(--ck-text-tertiary)]">(No agents listed in frontmatter)</div>
+                  ) : null}
+                </div>
+              </details>
+
+              <details className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/15 p-3">
+                <summary className="cursor-pointer text-sm font-medium text-[color:var(--ck-text-primary)]">
+                  Cron jobs ({fm?.cronJobs?.length ?? 0})
+                </summary>
+                <div className="mt-2 space-y-2">
+                  {(fm?.cronJobs ?? []).map((c, idx) => (
+                    <details
+                      key={`${c.id ?? "cron"}:${idx}`}
+                      className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3"
+                    >
+                      <summary className="cursor-pointer text-sm text-[color:var(--ck-text-primary)]">
+                        <span className="font-medium">{c.name ?? c.id ?? "(unnamed)"}</span>
+                        {c.schedule ? <span className="text-[color:var(--ck-text-tertiary)]"> — {c.schedule}</span> : null}
+                      </summary>
+                      <div className="mt-2 space-y-1 text-xs text-[color:var(--ck-text-secondary)]">
+                        {c.agentId ? (
+                          <div>
+                            <span className="text-[color:var(--ck-text-tertiary)]">Agent:</span> {c.agentId}
+                          </div>
+                        ) : null}
+                        {c.channel ? (
+                          <div>
+                            <span className="text-[color:var(--ck-text-tertiary)]">Channel:</span> {c.channel}
+                          </div>
+                        ) : null}
+                        {typeof c.enabledByDefault === "boolean" ? (
+                          <div>
+                            <span className="text-[color:var(--ck-text-tertiary)]">Enabled by default:</span>{" "}
+                            {c.enabledByDefault ? "yes" : "no"}
+                          </div>
+                        ) : null}
+                        {c.message ? (
+                          <div className="mt-2 whitespace-pre-wrap rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 p-2 text-[11px] text-[color:var(--ck-text-primary)]">
+                            {c.message}
+                          </div>
+                        ) : null}
+                      </div>
+                    </details>
+                  ))}
+                  {(!fm?.cronJobs || fm.cronJobs.length === 0) ? (
+                    <div className="text-xs text-[color:var(--ck-text-tertiary)]">(No cron jobs listed in frontmatter)</div>
+                  ) : null}
+                </div>
+              </details>
+
+              <details className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/15 p-3">
+                <summary className="cursor-pointer text-sm font-medium text-[color:var(--ck-text-primary)]">
+                  Scaffold output
+                </summary>
+                <pre className="mt-2 h-[30vh] w-full overflow-auto rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 p-3 text-xs text-[color:var(--ck-text-primary)]">
+                  {scaffoldOut || "(no output yet)"}
+                </pre>
+              </details>
+
+              <p className="text-xs text-[color:var(--ck-text-tertiary)]">
+                Create Team runs <code>openclaw recipes scaffold-team</code> with <code>--apply-config</code>.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="ck-glass-strong p-4">
+            <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Scaffold output</div>
+            <pre className="mt-2 h-[70vh] w-full overflow-auto rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 p-3 text-xs text-[color:var(--ck-text-primary)]">
+              {scaffoldOut || "(no output yet)"}
+            </pre>
+          </div>
+        )}
       </div>
 
+      {createOpen ? (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4" role="dialog" aria-modal="true">
+          <div className="ck-glass w-full max-w-lg p-5">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="truncate text-lg font-semibold tracking-tight">Create Team</div>
+                <div className="mt-1 text-xs text-[color:var(--ck-text-secondary)]">From recipe: {recipe.id}</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => (!creating ? setCreateOpen(false) : null)}
+                className="rounded-[var(--ck-radius-sm)] px-2 py-1 text-sm text-[color:var(--ck-text-secondary)] hover:text-[color:var(--ck-text-primary)]"
+              >
+                Close
+              </button>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              <label className="block">
+                <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Team id</div>
+                <input
+                  value={teamId}
+                  onChange={(e) => setTeamId(e.target.value)}
+                  placeholder="e.g. acme"
+                  className="mt-2 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+                  disabled={creating}
+                />
+              </label>
+
+              <label className="block">
+                <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Install cron jobs</div>
+                <select
+                  value={cronInstallChoice}
+                  onChange={(e) => setCronInstallChoice(e.target.value as "yes" | "no")}
+                  className="mt-2 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+                  disabled={creating}
+                >
+                  <option value="no">No (recommended)</option>
+                  <option value="yes">Yes</option>
+                </select>
+                <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+                  Kitchen scaffolds non-interactively; this controls the one-time cron install choice for this run.
+                </div>
+              </label>
+
+              {createMsg ? (
+                <div className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-sm">{createMsg}</div>
+              ) : null}
+
+              <div className="flex justify-end gap-2 pt-2">
+                <button
+                  type="button"
+                  disabled={creating}
+                  onClick={() => setCreateOpen(false)}
+                  className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] transition-colors hover:bg-white/10 disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  disabled={creating}
+                  onClick={onSubmitCreateTeam}
+                  className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[var(--ck-accent-red-hover)] active:bg-[var(--ck-accent-red-active)] disabled:opacity-50"
+                >
+                  {creating ? "Creating…" : "Create Team"}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
       <p className="mt-6 text-xs text-[color:var(--ck-text-tertiary)]">
-        Phase 1: Scaffold button runs <code>openclaw recipes scaffold</code> or <code>scaffold-team</code>.
-        We’ll add apply-config/overwrite toggles and a dry-run/plan view next.
+        Phase 1: Scaffold button runs <code>openclaw recipes scaffold</code> or <code>scaffold-team</code>. The right panel adds a
+        lightweight preview for team recipes (agents + cron jobs) and a Create Team flow.
       </p>
     </div>
   );

--- a/src/app/recipes/[id]/RecipeEditor.tsx
+++ b/src/app/recipes/[id]/RecipeEditor.tsx
@@ -202,15 +202,16 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
 
   function openCreateTeam() {
     setCreateMsg("");
-    setTeamId(teamFrontmatter.fm?.team?.teamId || "");
+    // Leave blank by default to avoid collisions (e.g. team id === recipe id).
+    setTeamId("");
     setCronInstallChoice("no");
     setCreateOpen(true);
   }
 
   function openCreateAgent() {
     setCreateAgentMsg("");
-    const defaultId = (agentFrontmatter.fm?.id || recipe?.id || "").trim();
-    setAgentId(defaultId);
+    // Leave blank by default to avoid collisions (e.g. agent id === recipe id).
+    setAgentId("");
     setAgentName((agentFrontmatter.fm?.name || recipe?.name || "").trim());
     setCreateAgentOpen(true);
   }
@@ -221,6 +222,10 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
     const t = teamId.trim();
     if (!t) {
       setCreateMsg("Team id is required.");
+      return;
+    }
+    if (t === recipe.id) {
+      setCreateMsg(`Team id cannot be the same as the recipe id (${recipe.id}). Choose a new team id.`);
       return;
     }
 
@@ -259,6 +264,10 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
     const a = agentId.trim();
     if (!a) {
       setCreateAgentMsg("Agent id is required.");
+      return;
+    }
+    if (a === recipe.id) {
+      setCreateAgentMsg(`Agent id cannot be the same as the recipe id (${recipe.id}). Choose a new agent id.`);
       return;
     }
 

--- a/src/app/recipes/[id]/RecipeEditor.tsx
+++ b/src/app/recipes/[id]/RecipeEditor.tsx
@@ -347,7 +347,7 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
               <div>
                 <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Team recipe</div>
                 <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
-                  Create a team from this recipe, and preview what will be scaffolded.
+                  Create a team from this recipe. Creating a Team runs <code>openclaw recipes scaffold-team</code> with <code>--apply-config</code>.
                 </div>
               </div>
               <button
@@ -366,6 +366,24 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
             ) : null}
 
             <div className="mt-4 space-y-3">
+              <details className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/15 p-3" open>
+                <summary className="cursor-pointer text-sm font-medium text-[color:var(--ck-text-primary)]">
+                  Recipe information
+                </summary>
+                <div className="mt-2 space-y-1 text-xs text-[color:var(--ck-text-secondary)]">
+                  <div>
+                    <span className="text-[color:var(--ck-text-tertiary)]">Recipe id:</span> {fm?.id ?? recipe.id}
+                  </div>
+                  <div>
+                    <span className="text-[color:var(--ck-text-tertiary)]">Version:</span> {fm?.version ?? "(unknown)"}
+                  </div>
+                  <div>
+                    <span className="text-[color:var(--ck-text-tertiary)]">Team id:</span> {fm?.team?.teamId ?? "(not set)"}
+                  </div>
+                  {fm?.description ? <div className="whitespace-pre-wrap">{fm.description}</div> : null}
+                </div>
+              </details>
+
               <details className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/15 p-3">
                 <summary className="cursor-pointer text-sm font-medium text-[color:var(--ck-text-primary)]">
                   Agents ({fm?.agents?.length ?? 0})
@@ -455,28 +473,6 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
                   ) : null}
                 </div>
               </details>
-
-              <details className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/15 p-3" open>
-                <summary className="cursor-pointer text-sm font-medium text-[color:var(--ck-text-primary)]">
-                  Metadata
-                </summary>
-                <div className="mt-2 space-y-1 text-xs text-[color:var(--ck-text-secondary)]">
-                  <div>
-                    <span className="text-[color:var(--ck-text-tertiary)]">Recipe id:</span> {fm?.id ?? recipe.id}
-                  </div>
-                  <div>
-                    <span className="text-[color:var(--ck-text-tertiary)]">Version:</span> {fm?.version ?? "(unknown)"}
-                  </div>
-                  <div>
-                    <span className="text-[color:var(--ck-text-tertiary)]">Team id:</span> {fm?.team?.teamId ?? "(not set)"}
-                  </div>
-                  {fm?.description ? <div className="whitespace-pre-wrap">{fm.description}</div> : null}
-                </div>
-              </details>
-
-              <p className="text-xs text-[color:var(--ck-text-tertiary)]">
-                Create Team runs <code>openclaw recipes scaffold-team</code> with <code>--apply-config</code>.
-              </p>
             </div>
           </div>
         ) : (
@@ -485,7 +481,7 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
               <div>
                 <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Agent recipe</div>
                 <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
-                  Create an agent from this recipe, and preview what will be scaffolded.
+                  Create an agent from this recipe. Creating an Agent runs <code>openclaw recipes scaffold</code> with <code>--apply-config</code>.
                 </div>
               </div>
               <button
@@ -504,6 +500,21 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
             ) : null}
 
             <div className="mt-4 space-y-3">
+              <details className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/15 p-3" open>
+                <summary className="cursor-pointer text-sm font-medium text-[color:var(--ck-text-primary)]">
+                  Recipe information
+                </summary>
+                <div className="mt-2 space-y-1 text-xs text-[color:var(--ck-text-secondary)]">
+                  <div>
+                    <span className="text-[color:var(--ck-text-tertiary)]">Recipe id:</span> {afm?.id ?? recipe.id}
+                  </div>
+                  <div>
+                    <span className="text-[color:var(--ck-text-tertiary)]">Version:</span> {afm?.version ?? "(unknown)"}
+                  </div>
+                  {afm?.description ? <div className="whitespace-pre-wrap">{afm.description}</div> : null}
+                </div>
+              </details>
+
               <details className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/15 p-3">
                 <summary className="cursor-pointer text-sm font-medium text-[color:var(--ck-text-primary)]">
                   Files ({Object.keys(afm?.templates ?? {}).length})
@@ -524,25 +535,6 @@ export default function RecipeEditor({ recipeId }: { recipeId: string }) {
                   )}
                 </div>
               </details>
-
-              <details className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/15 p-3" open>
-                <summary className="cursor-pointer text-sm font-medium text-[color:var(--ck-text-primary)]">
-                  Metadata
-                </summary>
-                <div className="mt-2 space-y-1 text-xs text-[color:var(--ck-text-secondary)]">
-                  <div>
-                    <span className="text-[color:var(--ck-text-tertiary)]">Recipe id:</span> {afm?.id ?? recipe.id}
-                  </div>
-                  <div>
-                    <span className="text-[color:var(--ck-text-tertiary)]">Version:</span> {afm?.version ?? "(unknown)"}
-                  </div>
-                  {afm?.description ? <div className="whitespace-pre-wrap">{afm.description}</div> : null}
-                </div>
-              </details>
-
-              <p className="text-xs text-[color:var(--ck-text-tertiary)]">
-                Create Agent runs <code>openclaw recipes scaffold</code> with <code>--apply-config</code>.
-              </p>
             </div>
           </div>
         )}

--- a/src/app/recipes/[id]/page.tsx
+++ b/src/app/recipes/[id]/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { redirect } from "next/navigation";
 import { runOpenClaw } from "@/lib/openclaw";
 import RecipeEditor from "./RecipeEditor";
 
@@ -25,11 +24,9 @@ export default async function RecipePage({ params }: { params: Promise<{ id: str
   const { id } = await params;
   const kind = await getKind(id);
 
-  // Team recipes should use the Team editor UI.
-  if (kind === "team") {
-    // Team recipes map directly to /teams/<teamId> (no extra "-team" suffix).
-    redirect(`/teams/${encodeURIComponent(id)}`);
-  }
+  // NOTE: We do NOT redirect team recipes to /teams/<id>.
+  // /recipes/<id> is the recipe editor/preview surface; /teams/<id> is the installed team editor.
+  void kind;
 
   return (
     <main className="min-h-screen p-8">

--- a/src/app/recipes/recipes-client.tsx
+++ b/src/app/recipes/recipes-client.tsx
@@ -345,6 +345,8 @@ export default function RecipesClient({
         setTeamId={setCreateTeamId}
         installCron={installCron}
         setInstallCron={setInstallCron}
+        existingRecipeIds={[...builtin, ...customTeamRecipes, ...customAgentRecipes].map((r) => r.id)}
+        existingAgentIds={installedAgentIds}
         busy={createBusy}
         error={createError}
         onClose={() => setCreateOpen(false)}
@@ -359,6 +361,8 @@ export default function RecipesClient({
         setAgentId={setCreateAgentId}
         agentName={createAgentName}
         setAgentName={setCreateAgentName}
+        existingRecipeIds={[...builtin, ...customTeamRecipes, ...customAgentRecipes].map((r) => r.id)}
+        existingAgentIds={installedAgentIds}
         busy={createAgentBusy}
         error={createAgentError}
         onClose={() => setCreateAgentOpen(false)}

--- a/src/app/teams/[teamId]/PublishChangesModal.tsx
+++ b/src/app/teams/[teamId]/PublishChangesModal.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { createPortal } from "react-dom";
+
+export function PublishChangesModal({
+  open,
+  teamId,
+  recipeId,
+  onClose,
+  onConfirm,
+  busy,
+}: {
+  open: boolean;
+  teamId: string;
+  recipeId: string;
+  busy?: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[200]">
+      <div className="fixed inset-0 bg-black/60" onClick={onClose} />
+      <div className="fixed inset-0 overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center p-4">
+          <div className="w-full max-w-lg rounded-2xl border border-white/10 bg-[color:var(--ck-bg-glass-strong)] p-5 shadow-[var(--ck-shadow-2)]">
+            <div className="text-lg font-semibold text-[color:var(--ck-text-primary)]">Publish changes</div>
+            <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+              This will re-scaffold team <code className="font-mono">{teamId}</code> from recipe <code className="font-mono">{recipeId}</code>.
+            </p>
+
+            <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-amber-400/30 bg-amber-500/10 p-3 text-sm text-amber-100">
+              <div className="font-medium">Complete overwrite</div>
+              <div className="mt-1">
+                All existing team workspace files managed by the recipe will be overwritten (for example: <code className="font-mono">AGENTS.md</code>,{" "}
+                <code className="font-mono">SOUL.md</code>, role templates, and other scaffolded files). Any manual edits in those files will be lost.
+              </div>
+            </div>
+
+            <div className="mt-6 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={onConfirm}
+                className="rounded-[var(--ck-radius-sm)] bg-emerald-600 px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] hover:bg-emerald-500 disabled:opacity-50"
+              >
+                {busy ? "Publishing…" : "Publish changes"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -54,6 +54,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
   const [activeTab, setActiveTab] = useState<"recipe" | "agents" | "skills" | "cron" | "files">("recipe");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
   const [loadingSource, setLoadingSource] = useState(false);
   const [recipeLoadError, setRecipeLoadError] = useState<string>("");
   const toast = useToast();
@@ -116,6 +117,8 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
     setContent("");
     setLoadedRecipeHash(null);
     setTeamMetaRecipeHash(null);
+    setPublishOpen(false);
+    setDeleteOpen(false);
   }, [teamId]);
 
   useEffect(() => {
@@ -495,7 +498,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                 onClick={() => setPublishOpen(true)}
                 className="rounded-[var(--ck-radius-sm)] bg-emerald-600 px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] transition-colors hover:bg-emerald-500 active:bg-emerald-700 disabled:opacity-50"
               >
-                {saving ? "Publishing…" : "Publish changes"}
+                {publishing ? "Publishing…" : "Publish changes"}
               </button>
 
               <button
@@ -932,10 +935,10 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
         open={publishOpen}
         teamId={teamId}
         recipeId={toId}
-        busy={saving}
+        busy={publishing}
         onClose={() => setPublishOpen(false)}
         onConfirm={async () => {
-          setSaving(true);
+          setPublishing(true);
           try {
             const res = await fetch("/api/scaffold", {
               method: "POST",
@@ -969,7 +972,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
           } catch (e: unknown) {
             flashMessage(e instanceof Error ? e.message : String(e), "error");
           } finally {
-            setSaving(false);
+            setPublishing(false);
           }
         }}
       />

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -78,6 +78,8 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
   const [availableSkills, setAvailableSkills] = useState<string[]>([]);
   const [selectedSkill, setSelectedSkill] = useState<string>("");
   const [installingSkill, setInstallingSkill] = useState(false);
+  const [teamSkillMsg, setTeamSkillMsg] = useState<string>("");
+  const [teamSkillError, setTeamSkillError] = useState<string>("");
 
   const teamRecipes = useMemo(() => recipes.filter((r) => r.kind === "team"), [recipes]);
 
@@ -672,6 +674,8 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                 disabled={installingSkill || !selectedSkill}
                 onClick={async () => {
                   setInstallingSkill(true);
+                  setTeamSkillMsg("");
+                  setTeamSkillError("");
                   try {
                     const res = await fetch("/api/teams/skills/install", {
                       method: "POST",
@@ -680,14 +684,14 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                     });
                     const json = await res.json();
                     if (!res.ok || !json.ok) throw new Error(json.error || "Failed to install skill");
-                    flashMessage(`Installed skill: ${selectedSkill}`, "success");
+                    setTeamSkillMsg(`Installed skill: ${selectedSkill}`);
 
                     // Refresh installed list.
                     const r = await fetch(`/api/teams/skills?teamId=${encodeURIComponent(teamId)}`, { cache: "no-store" });
                     const j = await r.json();
                     if (r.ok && j.ok) setSkillsList(Array.isArray(j.skills) ? (j.skills as string[]) : []);
                   } catch (e: unknown) {
-                    flashMessage(e instanceof Error ? e.message : String(e), "error");
+                    setTeamSkillError(e instanceof Error ? e.message : String(e));
                   } finally {
                     setInstallingSkill(false);
                   }
@@ -697,6 +701,18 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                 {installingSkill ? "Adding…" : "Add"}
               </button>
             </div>
+            {teamSkillError ? (
+              <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">
+                {teamSkillError}
+              </div>
+            ) : null}
+
+            {teamSkillMsg ? (
+              <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-emerald-400/30 bg-emerald-500/10 p-3 text-sm text-emerald-100">
+                {teamSkillMsg}
+              </div>
+            ) : null}
+
             <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
               This uses <code>openclaw recipes install-skill &lt;skill&gt; --team-id {teamId} --yes</code>.
             </div>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -38,7 +38,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               <NavLink href="/recipes" label="Recipes" />
               <NavLink href="/tickets" label="Tickets" />
               <NavLink href="/goals" label="Goals" />
-              <NavLink href="/channels" label="Channels" />
+              {/* Channels hidden for release */}
               <NavLink href="/cron-jobs" label="Cron jobs" />
               <NavLink href="/settings" label="Settings" />
             </nav>


### PR DESCRIPTION
Summary\n- Team editor: Publish changes flow with confirmation modal, complete overwrite wording, background markdown load, faster initial render, file errors localized.\n- Recipes: Create Team/Agent modals now support name→id slugging and id availability (fast local check + server confirm).\n- Scaffold API: collision guards, agent/team provenance, gateway restart best-effort, allow overwrite publish to bypass recipe-id collision guard.\n- Cron Jobs page: enabled-first sort and expandable job details (fixed hydration by avoiding nested buttons).\n- Agent editor: background loading and split file/skill messages.\n\nNotes\n- This branch is feature/0075-ux-v2.