### PR TITLE
Fix eslint unused vars warnings (agent/team editors)

### DIFF
--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -357,6 +357,12 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
       ) : null}
       {teamId ? <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Team: {teamId}</div> : null}
 
+      {pageMsg ? (
+        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 p-3 text-sm text-[color:var(--ck-text-secondary)]">
+          {pageMsg}
+        </div>
+      ) : null}
+
       <div className="mt-6 flex flex-wrap gap-2">
         {(
           [
@@ -616,6 +622,13 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
                   </button>
                 </div>
               </div>
+
+              {fileError ? (
+                <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">
+                  {fileError}
+                </div>
+              ) : null}
+
               <textarea
                 value={fileContent}
                 onChange={(e) => setFileContent(e.target.value)}

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -691,7 +691,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                 value={selectedSkill}
                 onChange={(e) => setSelectedSkill(e.target.value)}
                 className="w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
-                disabled={installingSkill || !availableSkills.length}
+                disabled={installingSkill || skillsLoading || !availableSkills.length}
               >
                 {availableSkills.length ? (
                   availableSkills.map((s) => (
@@ -705,7 +705,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
               </select>
               <button
                 type="button"
-                disabled={installingSkill || !selectedSkill}
+                disabled={installingSkill || skillsLoading || !selectedSkill}
                 onClick={async () => {
                   setInstallingSkill(true);
                   setTeamSkillMsg("");


### PR DESCRIPTION
Ticket: development-team #0075\n\n- Render file-load errors in Agent editor Files tab (uses existing fileError state)\n- Render pageMsg in Agent editor header (uses existing pageMsg state)\n- Use skillsLoading to disable team Skills selector/button while loading\n\nVerification:\n- npm run lint\n- npm run build