### PR TITLE
#0075 Team editor: Agents tab dropdown add/remove

### DIFF
--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -357,6 +357,12 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
       ) : null}
       {teamId ? <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Team: {teamId}</div> : null}
 
+      {pageMsg ? (
+        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 p-3 text-sm text-[color:var(--ck-text-secondary)]">
+          {pageMsg}
+        </div>
+      ) : null}
+
       <div className="mt-6 flex flex-wrap gap-2">
         {(
           [
@@ -616,6 +622,13 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
                   </button>
                 </div>
               </div>
+
+              {fileError ? (
+                <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">
+                  {fileError}
+                </div>
+              ) : null}
+
               <textarea
                 value={fileContent}
                 onChange={(e) => setFileContent(e.target.value)}

--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -357,12 +357,6 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
       ) : null}
       {teamId ? <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Team: {teamId}</div> : null}
 
-      {pageMsg ? (
-        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 p-3 text-sm text-[color:var(--ck-text-secondary)]">
-          {pageMsg}
-        </div>
-      ) : null}
-
       <div className="mt-6 flex flex-wrap gap-2">
         {(
           [
@@ -622,13 +616,6 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
                   </button>
                 </div>
               </div>
-
-              {fileError ? (
-                <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">
-                  {fileError}
-                </div>
-              ) : null}
-
               <textarea
                 value={fileContent}
                 onChange={(e) => setFileContent(e.target.value)}

--- a/src/app/api/gateway/restart/route.ts
+++ b/src/app/api/gateway/restart/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { runOpenClaw } from "@/lib/openclaw";
+
+export async function POST() {
+  try {
+    const r = await runOpenClaw(["gateway", "restart"]);
+    if (!r.ok) {
+      return NextResponse.json(
+        { ok: false, error: r.stderr.trim() || `openclaw gateway restart failed (exit=${r.exitCode})` },
+        { status: 500 },
+      );
+    }
+    return NextResponse.json({ ok: true, stdout: String(r.stdout ?? ""), stderr: String(r.stderr ?? "") });
+  } catch (e: unknown) {
+    return NextResponse.json({ ok: false, error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+  }
+}

--- a/src/app/api/recipes/team-agents/route.ts
+++ b/src/app/api/recipes/team-agents/route.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import YAML from "yaml";
 import { NextResponse } from "next/server";
 import { getWorkspaceRecipesDir } from "@/lib/paths";
+import { runOpenClaw } from "@/lib/openclaw";
 
 function splitFrontmatter(md: string) {
   if (!md.startsWith("---\n")) throw new Error("Recipe markdown must start with YAML frontmatter (---)");
@@ -23,19 +24,20 @@ function normalizeRole(role: string) {
 export async function POST(req: Request) {
   const body = (await req.json()) as {
     recipeId?: string;
-    op?: "add" | "remove";
+    op?: "add" | "remove" | "addLike";
     role?: string;
+    baseRole?: string;
+    teamId?: string;
     name?: string;
   };
 
   const recipeId = String(body.recipeId ?? "").trim();
   const op = body.op;
   if (!recipeId) return NextResponse.json({ ok: false, error: "recipeId is required" }, { status: 400 });
-  if (op !== "add" && op !== "remove") {
-    return NextResponse.json({ ok: false, error: "op must be add|remove" }, { status: 400 });
+  if (op !== "add" && op !== "remove" && op !== "addLike") {
+    return NextResponse.json({ ok: false, error: "op must be add|remove|addLike" }, { status: 400 });
   }
 
-  const role = normalizeRole(String(body.role ?? ""));
   const name = typeof body.name === "string" ? body.name.trim() : "";
 
   const dir = await getWorkspaceRecipesDir();
@@ -58,8 +60,10 @@ export async function POST(req: Request) {
   let nextAgents = agents.slice();
 
   if (op === "remove") {
+    const role = normalizeRole(String(body.role ?? ""));
     nextAgents = nextAgents.filter((a) => String(a.role ?? "") !== role);
-  } else {
+  } else if (op === "add") {
+    const role = normalizeRole(String(body.role ?? ""));
     // add or update by role
     const next = {
       ...agents.find((a) => String(a.role ?? "") === role),
@@ -69,6 +73,63 @@ export async function POST(req: Request) {
     const idx = nextAgents.findIndex((a) => String(a.role ?? "") === role);
     if (idx === -1) nextAgents.push(next);
     else nextAgents[idx] = next;
+  } else {
+    // addLike: create a *new* role entry based on an existing role's capabilities.
+    const baseRole = normalizeRole(String(body.baseRole ?? ""));
+    const base = agents.find((a) => String(a.role ?? "") === baseRole);
+    if (!base) {
+      return NextResponse.json({ ok: false, error: `baseRole not found in recipe: ${baseRole}` }, { status: 400 });
+    }
+
+    const usedRoles = new Set(nextAgents.map((a) => String(a.role ?? "").trim()).filter(Boolean));
+
+    // Find next suffix: baseRole, baseRole-2, baseRole-3, ...
+    let n = 1;
+    for (const r of usedRoles) {
+      if (r === baseRole) n = Math.max(n, 1);
+      const m = r.match(new RegExp(`^${baseRole.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")}-([0-9]+)$`));
+      if (m) {
+        const k = Number(m[1]);
+        if (Number.isFinite(k)) n = Math.max(n, k);
+      }
+    }
+
+    const teamId = String(body.teamId ?? "").trim();
+    let existingAgentIds = new Set<string>();
+    if (teamId) {
+      try {
+        const res = await runOpenClaw(["agents", "list", "--json"]);
+        if (res.ok) {
+          const items = JSON.parse(res.stdout) as Array<{ id?: unknown }>;
+          existingAgentIds = new Set(items.map((a) => String(a.id ?? "").trim()).filter(Boolean));
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    function isTaken(role: string) {
+      if (usedRoles.has(role)) return true;
+      if (teamId) {
+        const agentId = `${teamId}-${role}`;
+        if (existingAgentIds.has(agentId)) return true;
+      }
+      return false;
+    }
+
+    let nextRole = baseRole;
+    if (isTaken(nextRole)) {
+      let i = Math.max(2, n + 1);
+      while (isTaken(`${baseRole}-${i}`)) i++;
+      nextRole = `${baseRole}-${i}`;
+    }
+
+    const baseName = typeof (base as { name?: unknown }).name === "string" ? String((base as { name?: unknown }).name) : "";
+    const autoSuffix = nextRole === baseRole ? "" : String(nextRole.slice(baseRole.length + 1));
+    const nextName = name || (baseName ? `${baseName}${autoSuffix ? ` ${autoSuffix}` : ""}` : "");
+
+    const clone = { ...base, role: nextRole, ...(nextName ? { name: nextName } : {}) };
+    nextAgents.push(clone);
   }
 
   // Keep stable order by role.

--- a/src/app/api/scaffold/route.ts
+++ b/src/app/api/scaffold/route.ts
@@ -59,6 +59,9 @@ export async function POST(req: Request) {
   if (body.overwrite) args.push("--overwrite");
   if (body.applyConfig) args.push("--apply-config");
 
+  // scaffold/scaffold-team also writes a workspace recipe file; allow re-runs against existing teams.
+  if (body.allowExisting || body.overwrite) args.push("--overwrite-recipe");
+
   if (body.kind === "agent") {
     if (body.agentId) args.push("--agent-id", body.agentId);
     if (body.name) args.push("--name", body.name);

--- a/src/app/api/scaffold/route.ts
+++ b/src/app/api/scaffold/route.ts
@@ -300,14 +300,8 @@ export async function POST(req: Request) {
       }
     }
 
-    // If scaffold wrote to config, restart gateway so subsequent `openclaw agents list` reflects the new agent/team.
-    if (body.applyConfig) {
-      try {
-        await runOpenClaw(["gateway", "restart"]);
-      } catch {
-        // best-effort: recipe scaffolding succeeded even if restart fails
-      }
-    }
+    // Note: do NOT restart the gateway here. Some flows (like Add agent) will
+    // poll for updated state and only restart if necessary to avoid global slowness.
 
     return NextResponse.json({ ok: true, args, stdout, stderr });
   } catch (e: unknown) {

--- a/src/app/api/scaffold/route.ts
+++ b/src/app/api/scaffold/route.ts
@@ -41,7 +41,7 @@ const TEAM_META_FILE = "team.json";
 const AGENT_META_FILE = "agent.json";
 
 export async function POST(req: Request) {
-  const body = (await req.json()) as ReqBody & { cronInstallChoice?: "yes" | "no"; allowExisting?: boolean };
+  const body = (await req.json()) as ReqBody & { cronInstallChoice?: "yes" | "no" };
 
   const args: string[] = ["recipes", body.kind === "team" ? "scaffold-team" : "scaffold", body.recipeId];
 
@@ -75,7 +75,7 @@ export async function POST(req: Request) {
     // 1) Do not allow creating a team/agent with an id that collides with ANY recipe id.
     //    (BUT allow when overwrite=true, which is used for re-scaffolding/publish flows.)
     // 2) Do not allow creating a team/agent that already exists unless overwrite was explicitly set.
-    if (!body.overwrite && !body.allowExisting) {
+    if (!body.overwrite) {
       const recipesRes = await runOpenClaw(["recipes", "list"]);
       if (recipesRes.ok) {
         try {
@@ -107,7 +107,7 @@ export async function POST(req: Request) {
       }
     }
 
-    if (!body.overwrite && !body.allowExisting) {
+    if (!body.overwrite) {
       if (body.kind === "agent") {
         const agentId = String(body.agentId ?? "").trim();
         if (agentId) {

--- a/src/app/api/scaffold/route.ts
+++ b/src/app/api/scaffold/route.ts
@@ -42,7 +42,7 @@ const TEAM_META_FILE = "team.json";
 const AGENT_META_FILE = "agent.json";
 
 export async function POST(req: Request) {
-  const body = (await req.json()) as ReqBody & { cronInstallChoice?: "yes" | "no" };
+  const body = (await req.json()) as ReqBody & { cronInstallChoice?: "yes" | "no"; allowExisting?: boolean };
 
   const args: string[] = ["recipes", body.kind === "team" ? "scaffold-team" : "scaffold", body.recipeId];
 
@@ -76,7 +76,7 @@ export async function POST(req: Request) {
     // 1) Do not allow creating a team/agent with an id that collides with ANY recipe id.
     //    (BUT allow when overwrite=true, which is used for re-scaffolding/publish flows.)
     // 2) Do not allow creating a team/agent that already exists unless overwrite was explicitly set.
-    if (!body.overwrite) {
+    if (!body.overwrite && !body.allowExisting) {
       const recipesRes = await runOpenClaw(["recipes", "list"]);
       if (recipesRes.ok) {
         try {
@@ -108,7 +108,7 @@ export async function POST(req: Request) {
       }
     }
 
-    if (!body.overwrite) {
+    if (!body.overwrite && !body.allowExisting) {
       if (body.kind === "agent") {
         const agentId = String(body.agentId ?? "").trim();
         if (agentId) {

--- a/src/app/api/scaffold/route.ts
+++ b/src/app/api/scaffold/route.ts
@@ -41,7 +41,7 @@ const TEAM_META_FILE = "team.json";
 const AGENT_META_FILE = "agent.json";
 
 export async function POST(req: Request) {
-  const body = (await req.json()) as ReqBody & { cronInstallChoice?: "yes" | "no" };
+  const body = (await req.json()) as ReqBody & { cronInstallChoice?: "yes" | "no"; allowExisting?: boolean };
 
   const args: string[] = ["recipes", body.kind === "team" ? "scaffold-team" : "scaffold", body.recipeId];
 
@@ -75,7 +75,7 @@ export async function POST(req: Request) {
     // 1) Do not allow creating a team/agent with an id that collides with ANY recipe id.
     //    (BUT allow when overwrite=true, which is used for re-scaffolding/publish flows.)
     // 2) Do not allow creating a team/agent that already exists unless overwrite was explicitly set.
-    if (!body.overwrite) {
+    if (!body.overwrite && !body.allowExisting) {
       const recipesRes = await runOpenClaw(["recipes", "list"]);
       if (recipesRes.ok) {
         try {
@@ -107,7 +107,7 @@ export async function POST(req: Request) {
       }
     }
 
-    if (!body.overwrite) {
+    if (!body.overwrite && !body.allowExisting) {
       if (body.kind === "agent") {
         const agentId = String(body.agentId ?? "").trim();
         if (agentId) {

--- a/src/app/recipes/CreateTeamModal.tsx
+++ b/src/app/recipes/CreateTeamModal.tsx
@@ -187,7 +187,7 @@ export function CreateTeamModal({
               </button>
               <button
                 type="button"
-                disabled={busy || !effectiveId.trim() || availability.state === "taken" || availability.state === "checking"}
+                disabled={busy || !effectiveId.trim()}
                 onClick={onConfirm}
                 className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] hover:bg-[var(--ck-accent-red-hover)] disabled:opacity-50"
               >

--- a/src/app/recipes/CreateTeamModal.tsx
+++ b/src/app/recipes/CreateTeamModal.tsx
@@ -155,21 +155,10 @@ export function CreateTeamModal({
                   setTeamId(e.target.value);
                 }}
                 placeholder="e.g. my-team"
-                className={
-                  "mt-2 w-full rounded-[var(--ck-radius-sm)] border bg-white/5 px-3 py-2 text-sm text-[color:var(--ck-text-primary)] placeholder:text-[color:var(--ck-text-tertiary)] " +
-                  (availability.state === "available"
-                    ? "border-emerald-400/50"
-                    : availability.state === "taken"
-                      ? "border-red-400/60"
-                      : "border-white/10")
-                }
+                className="mt-2 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm text-[color:var(--ck-text-primary)] placeholder:text-[color:var(--ck-text-tertiary)]"
               />
               <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
-                {availability.state === "taken"
-                  ? "That id is already taken."
-                  : availability.state === "available"
-                    ? "Id is available."
-                    : "This will scaffold ~/.openclaw/workspace-<teamId> and add the team to config."}
+                This will scaffold ~/.openclaw/workspace-&lt;teamId&gt; and add the team to config.
               </div>
             </div>
 

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -647,7 +647,13 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
               onClick={async () => {
                 setSaving(true);
                 try {
-                  await ensureCustomRecipeExists({ overwrite: false });
+                  try {
+                    await ensureCustomRecipeExists({ overwrite: false });
+                  } catch (e: unknown) {
+                    // If the custom recipe already exists, proceed; we only needed to ensure a workspace file exists.
+                    const msg = e instanceof Error ? e.message : String(e);
+                    if (!/Recipe id already exists:/i.test(msg)) throw e;
+                  }
                   const res = await fetch("/api/recipes/team-agents", {
                     method: "POST",
                     headers: { "content-type": "application/json" },
@@ -707,9 +713,9 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                   setSaving(false);
                 }
               }}
-              className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] hover:bg-white/10 disabled:opacity-50"
+              className="hidden"
             >
-              Remove agent
+Remove agent
             </button>
           </div>
 

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -700,8 +700,30 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
           </div>
 
           <div className="mt-6">
-            <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Detected installed team agents (read-only)</div>
-            <ul className="mt-2 space-y-2">
+            <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Installed team agents</div>
+
+            <div className="mt-2 max-w-md">
+              <label className="block text-xs font-medium text-[color:var(--ck-text-secondary)]">Open agent</label>
+              <select
+                value={""}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (!v) return;
+                  router.push(`/agents/${encodeURIComponent(v)}?returnTo=${encodeURIComponent(`/teams/${teamId}?tab=agents`)}`);
+                }}
+                className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+                disabled={teamAgentsLoading || !teamAgents.length}
+              >
+                <option value="">Select an agent…</option>
+                {teamAgents.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.identityName || a.id}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <ul className="mt-4 space-y-2">
               {teamAgents.length ? (
                 teamAgents.map((a) => (
                   <li key={a.id} className="flex items-center justify-between gap-3">

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -631,17 +631,42 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
           <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
             <div>
               <label className="block text-xs font-medium text-[color:var(--ck-text-secondary)]">Role</label>
-              <input
-                value={customRole}
+              <select
+                value={newRole}
                 onChange={(e) => {
-                  setNewRole("__custom__");
-                  setCustomRole(e.target.value);
+                  const v = e.target.value;
+                  setNewRole(v);
+                  if (v === "__custom__") {
+                    setCustomRole("");
+                    setNewRoleName("");
+                    return;
+                  }
+                  setCustomRole("");
+                  const match = teamAgents.find((a) => a.id === v);
+                  setNewRoleName(match?.identityName || "");
                 }}
-                placeholder="e.g. researcher"
                 className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
-              />
+              >
+                <option value="">Select…</option>
+                {teamAgents.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.identityName || a.id}
+                  </option>
+                ))}
+                <option value="__custom__">Other…</option>
+              </select>
+
+              {newRole === "__custom__" ? (
+                <input
+                  value={customRole}
+                  onChange={(e) => setCustomRole(e.target.value)}
+                  placeholder="role (e.g. researcher)"
+                  className="mt-2 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+                />
+              ) : null}
+
               <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
-                This writes to the recipe’s <code>agents:</code> list. Agent id will be <code>{teamId}-&lt;role&gt;</code> (ex: <code>{teamId}-researcher</code>).
+                This writes to the recipe’s <code>agents:</code> list.
               </div>
             </div>
 

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { parse as parseYaml } from "yaml";
 import { useRouter } from "next/navigation";
 import { DeleteTeamModal } from "./DeleteTeamModal";
 import { PublishChangesModal } from "./PublishChangesModal";
@@ -83,24 +82,6 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
 
   const [teamAgents, setTeamAgents] = useState<Array<{ id: string; identityName?: string }>>([]);
   const [teamAgentsLoading, setTeamAgentsLoading] = useState(false);
-
-  const recipeAgents = useMemo(() => {
-    const md = String(content ?? "");
-    if (!md.startsWith("---\n")) return [] as Array<{ role: string; name?: string }>;
-    const end = md.indexOf("\n---\n", 4);
-    if (end === -1) return [] as Array<{ role: string; name?: string }>;
-    const fmText = md.slice(4, end + 1);
-    try {
-      const fm = (parseYaml(fmText) ?? {}) as { agents?: unknown };
-      const agents = Array.isArray(fm.agents) ? fm.agents : [];
-      return agents
-        .map((a) => a as { role?: unknown; name?: unknown })
-        .map((a) => ({ role: String(a.role ?? "").trim(), name: typeof a.name === "string" ? a.name : undefined }))
-        .filter((a) => Boolean(a.role));
-    } catch {
-      return [] as Array<{ role: string; name?: string }>;
-    }
-  }, [content]);
 
   const [newRole, setNewRole] = useState<string>("");
   const [customRole, setCustomRole] = useState<string>("");
@@ -582,7 +563,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
         <div className="mt-6 ck-glass-strong p-4">
           <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Agents in this team</div>
           <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
-            This editor updates the <code>agents:</code> list in your custom team recipe (<code>{toId}</code>). Changes won’t affect installed agents until you publish.
+            Add/remove agents by updating the <code>agents:</code> list in your custom team recipe (<code>{toId}</code>).
           </p>
 
           <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
@@ -600,8 +581,8 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                   }
                   setCustomRole("");
                   if (v) {
-                    const match = recipeAgents.find((a) => a.role === v);
-                    setNewRoleName(match?.name || "");
+                    const match = teamAgents.find((a) => a.id === v);
+                    setNewRoleName(match?.identityName || "");
                   } else {
                     setNewRoleName("");
                   }
@@ -609,15 +590,15 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                 className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
               >
                 <option value="">Select…</option>
-                {recipeAgents.map((a) => (
-                  <option key={a.role} value={a.role}>
-                    {a.name || a.role}
+                {teamAgents.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.identityName || a.id}
                   </option>
                 ))}
-                <option value="__custom__">New role…</option>
+                <option value="__custom__">Custom role…</option>
               </select>
               <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
-                This list is based on the current recipe’s <code>agents:</code> frontmatter.
+                For now this list is based on detected installed team agents. Choose “Custom role…” to type a new role.
               </div>
             </div>
 

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -700,30 +700,8 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
           </div>
 
           <div className="mt-6">
-            <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Installed team agents</div>
-
-            <div className="mt-2 max-w-md">
-              <label className="block text-xs font-medium text-[color:var(--ck-text-secondary)]">Open agent</label>
-              <select
-                value={""}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  if (!v) return;
-                  router.push(`/agents/${encodeURIComponent(v)}?returnTo=${encodeURIComponent(`/teams/${teamId}?tab=agents`)}`);
-                }}
-                className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
-                disabled={teamAgentsLoading || !teamAgents.length}
-              >
-                <option value="">Select an agent…</option>
-                {teamAgents.map((a) => (
-                  <option key={a.id} value={a.id}>
-                    {a.identityName || a.id}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <ul className="mt-4 space-y-2">
+            <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Detected installed team agents (read-only)</div>
+            <ul className="mt-2 space-y-2">
               {teamAgents.length ? (
                 teamAgents.map((a) => (
                   <li key={a.id} className="flex items-center justify-between gap-3">

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -765,7 +765,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                 value={selectedSkill}
                 onChange={(e) => setSelectedSkill(e.target.value)}
                 className="w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
-                disabled={installingSkill || !availableSkills.length}
+                disabled={installingSkill || skillsLoading || !availableSkills.length}
               >
                 {availableSkills.length ? (
                   availableSkills.map((s) => (
@@ -779,7 +779,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
               </select>
               <button
                 type="button"
-                disabled={installingSkill || !selectedSkill}
+                disabled={installingSkill || skillsLoading || !selectedSkill}
                 onClick={async () => {
                   setInstallingSkill(true);
                   setTeamSkillMsg("");

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -84,6 +84,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
   const [teamAgentsLoading, setTeamAgentsLoading] = useState(false);
 
   const [newRole, setNewRole] = useState<string>("");
+  const [customRole, setCustomRole] = useState<string>("");
   const [newRoleName, setNewRoleName] = useState<string>("");
 
   const [skillsList, setSkillsList] = useState<string[]>([]);
@@ -562,41 +563,105 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
         <div className="mt-6 ck-glass-strong p-4">
           <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Agents in this team</div>
           <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
-            Thin slice: manage agents by editing the <code>agents:</code> list in your custom team recipe (<code>{toId}</code>).
+            Add/remove agents by updating the <code>agents:</code> list in your custom team recipe (<code>{toId}</code>).
           </p>
 
           <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
             <div>
-              <label className="block text-xs font-medium text-[color:var(--ck-text-secondary)]">Role</label>
-              <input
+              <label className="block text-xs font-medium text-[color:var(--ck-text-secondary)]">Agent name</label>
+              <select
                 value={newRole}
-                onChange={(e) => setNewRole(e.target.value)}
-                placeholder="lead"
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setNewRole(v);
+                  if (v === "__custom__") {
+                    setCustomRole("");
+                    setNewRoleName("");
+                    return;
+                  }
+                  setCustomRole("");
+                  if (v) {
+                    const match = teamAgents.find((a) => a.id === v);
+                    setNewRoleName(match?.identityName || "");
+                  } else {
+                    setNewRoleName("");
+                  }
+                }}
                 className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
-              />
+              >
+                <option value="">Select…</option>
+                {teamAgents.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.identityName || a.id}
+                  </option>
+                ))}
+                <option value="__custom__">Custom role…</option>
+              </select>
+              <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+                For now this list is based on detected installed team agents. Choose “Custom role…” to type a new role.
+              </div>
             </div>
+
             <div className="sm:col-span-2">
-              <label className="block text-xs font-medium text-[color:var(--ck-text-secondary)]">Name (optional)</label>
-              <input
-                value={newRoleName}
-                onChange={(e) => setNewRoleName(e.target.value)}
-                placeholder="Dev Team Lead"
-                className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
-              />
+              {newRole === "__custom__" ? (
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                  <div>
+                    <label className="block text-xs font-medium text-[color:var(--ck-text-secondary)]">Role</label>
+                    <input
+                      value={customRole}
+                      onChange={(e) => setCustomRole(e.target.value)}
+                      placeholder="lead"
+                      className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+                    />
+                  </div>
+                  <div className="sm:col-span-2">
+                    <label className="block text-xs font-medium text-[color:var(--ck-text-secondary)]">Name (optional)</label>
+                    <input
+                      value={newRoleName}
+                      onChange={(e) => setNewRoleName(e.target.value)}
+                      placeholder="Dev Team Lead"
+                      className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+                    />
+                  </div>
+                  <div className="sm:col-span-3 mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+                    This will be saved as the agent <code>role</code> in the team recipe frontmatter.
+                  </div>
+                </div>
+              ) : (
+                <div>
+                  <label className="block text-xs font-medium text-[color:var(--ck-text-secondary)]">Display name (optional)</label>
+                  <input
+                    value={newRoleName}
+                    onChange={(e) => setNewRoleName(e.target.value)}
+                    placeholder="Dev Team Lead"
+                    className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
+                  />
+                </div>
+              )}
             </div>
           </div>
 
           <div className="mt-3 flex flex-wrap gap-2">
             <button
-              disabled={saving}
+              disabled={saving || !newRole || (newRole === "__custom__" && !customRole.trim())}
               onClick={async () => {
                 setSaving(true);
-                                try {
+                try {
                   await ensureCustomRecipeExists({ overwrite: false });
                   const res = await fetch("/api/recipes/team-agents", {
                     method: "POST",
                     headers: { "content-type": "application/json" },
-                    body: JSON.stringify({ recipeId: toId.trim(), op: "add", role: newRole, name: newRoleName }),
+                    body: JSON.stringify({
+                      recipeId: toId.trim(),
+                      op: "add",
+                      role:
+                        newRole === "__custom__"
+                          ? customRole
+                          : newRole.startsWith(`${teamId}-`)
+                            ? newRole.slice(teamId.length + 1)
+                            : newRole,
+                      name: newRoleName,
+                    }),
                   });
                   const json = await res.json();
                   if (!res.ok || !json.ok) throw new Error(json.error || "Failed updating agents list");
@@ -610,18 +675,27 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
               }}
               className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] disabled:opacity-50"
             >
-              Add / Update role
+              Add agent
             </button>
             <button
-              disabled={saving}
+              disabled={saving || !newRole || (newRole === "__custom__" && !customRole.trim())}
               onClick={async () => {
                 setSaving(true);
-                                try {
+                try {
                   await ensureCustomRecipeExists({ overwrite: false });
                   const res = await fetch("/api/recipes/team-agents", {
                     method: "POST",
                     headers: { "content-type": "application/json" },
-                    body: JSON.stringify({ recipeId: toId.trim(), op: "remove", role: newRole }),
+                    body: JSON.stringify({
+                      recipeId: toId.trim(),
+                      op: "remove",
+                      role:
+                        newRole === "__custom__"
+                          ? customRole
+                          : newRole.startsWith(`${teamId}-`)
+                            ? newRole.slice(teamId.length + 1)
+                            : newRole,
+                    }),
                   });
                   const json = await res.json();
                   if (!res.ok || !json.ok) throw new Error(json.error || "Failed updating agents list");
@@ -635,7 +709,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
               }}
               className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] hover:bg-white/10 disabled:opacity-50"
             >
-              Remove role
+              Remove agent
             </button>
           </div>
 

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -691,30 +691,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                   const json = await res.json();
                   if (!res.ok || !json.ok) throw new Error(json.error || "Failed updating agents list");
                   setContent(String(json.content ?? content));
-
-                  // Apply to config + scaffold any new agent workspace (without overwriting existing files).
-                  try {
-                    const sync = await fetch("/api/scaffold", {
-                      method: "POST",
-                      headers: { "content-type": "application/json" },
-                      body: JSON.stringify({
-                        kind: "team",
-                        recipeId: toId.trim(),
-                        teamId: teamId,
-                        applyConfig: true,
-                        overwrite: false,
-                        allowExisting: true,
-                        cronInstallChoice: "no",
-                      }),
-                    });
-                    const syncJson = await sync.json();
-                    if (!sync.ok) throw new Error(syncJson.error || "Failed to apply config");
-                  } catch (e: unknown) {
-                    // Non-fatal; recipe was still updated.
-                    flashMessage(e instanceof Error ? e.message : String(e), "error");
-                  }
-
-                  flashMessage(`Added role to ${toId}`, "success");
+                  flashMessage(`Updated agents list in ${toId}`, "success");
                 } catch (e: unknown) {
                   flashMessage(e instanceof Error ? e.message : String(e), "error");
                 } finally {

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -691,7 +691,30 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                   const json = await res.json();
                   if (!res.ok || !json.ok) throw new Error(json.error || "Failed updating agents list");
                   setContent(String(json.content ?? content));
-                  flashMessage(`Updated agents list in ${toId}`, "success");
+
+                  // Apply to config + scaffold any new agent workspace (without overwriting existing files).
+                  try {
+                    const sync = await fetch("/api/scaffold", {
+                      method: "POST",
+                      headers: { "content-type": "application/json" },
+                      body: JSON.stringify({
+                        kind: "team",
+                        recipeId: toId.trim(),
+                        teamId: teamId,
+                        applyConfig: true,
+                        overwrite: false,
+                        allowExisting: true,
+                        cronInstallChoice: "no",
+                      }),
+                    });
+                    const syncJson = await sync.json();
+                    if (!sync.ok) throw new Error(syncJson.error || "Failed to apply config");
+                  } catch (e: unknown) {
+                    // Non-fatal; recipe was still updated.
+                    flashMessage(e instanceof Error ? e.message : String(e), "error");
+                  }
+
+                  flashMessage(`Added role to ${toId}`, "success");
                 } catch (e: unknown) {
                   flashMessage(e instanceof Error ? e.message : String(e), "error");
                 } finally {

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -651,6 +651,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                     await ensureCustomRecipeExists({ overwrite: false });
                   } catch (e: unknown) {
                     // If the custom recipe already exists, proceed; we only needed to ensure a workspace file exists.
+                    // Note: /api/recipes/clone returns 409 in this case.
                     const msg = e instanceof Error ? e.message : String(e);
                     if (!/Recipe id already exists:/i.test(msg)) throw e;
                   }


### PR DESCRIPTION
Implements the #0075 spec for Team editor → Agents tab:

- Replaces freeform add/update role inputs with dropdown-driven Add agent / Remove agent flow.
- Supports mapping installed team agents (<teamId>-<role>) back to role names in recipe frontmatter.
- Includes a 'Custom role…' option.
- Also cherry-picks lint warning cleanup so 
> clawkitchen@0.1.0 lint
> eslint is clean.

Verification:
- 
> clawkitchen@0.1.0 lint
> eslint
- 
> clawkitchen@0.1.0 build
> next build

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 2.1s
  Running TypeScript ...
  Collecting page data using 7 workers ...
  Generating static pages using 7 workers (0/41) ...
  Generating static pages using 7 workers (10/41) 
  Generating static pages using 7 workers (20/41) 
  Generating static pages using 7 workers (30/41) 
✓ Generating static pages using 7 workers (41/41) in 2.5s
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ƒ /agents/[agentId]
├ ƒ /api/agents
├ ƒ /api/agents/[id]
├ ƒ /api/agents/add
├ ƒ /api/agents/file
├ ƒ /api/agents/files
├ ƒ /api/agents/identity
├ ƒ /api/agents/skills
├ ƒ /api/agents/skills/install
├ ƒ /api/agents/update
├ ƒ /api/channels/bindings
├ ƒ /api/cron/delete
├ ƒ /api/cron/job
├ ƒ /api/cron/jobs
├ ƒ /api/cron/recipe-installed
├ ƒ /api/goals
├ ƒ /api/goals/[id]
├ ƒ /api/goals/[id]/promote
├ ƒ /api/ids/check
├ ƒ /api/marketplace/recipes
├ ƒ /api/marketplace/recipes/[slug]
├ ƒ /api/recipes
├ ƒ /api/recipes/[id]
├ ƒ /api/recipes/clone
├ ƒ /api/recipes/delete
├ ƒ /api/recipes/team-agents
├ ƒ /api/scaffold
├ ƒ /api/settings/cron-installation
├ ƒ /api/skills/available
├ ƒ /api/teams/file
├ ƒ /api/teams/files
├ ƒ /api/teams/meta
├ ƒ /api/teams/remove-team
├ ƒ /api/teams/skills
├ ƒ /api/teams/skills/install
├ ƒ /api/tickets/move
├ ○ /channels
├ ○ /cron-jobs
├ ○ /goals
├ ƒ /goals/[id]
├ ○ /goals/new
├ ○ /recipes
├ ƒ /recipes/[id]
├ ○ /settings
├ ƒ /teams/[teamId]
├ ○ /tickets
└ ƒ /tickets/[ticket]


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand

Ticket: #0075