### PR TITLE
#0075 UX v2: recipe Create Team/Agent CTAs, editor preview/actions, publish changes gating

### DIFF
--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -348,11 +348,6 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
       ) : null}
       {teamId ? <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Team: {teamId}</div> : null}
 
-      {pageMsg ? (
-        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 p-3 text-sm text-[color:var(--ck-text-secondary)]">
-          {pageMsg}
-        </div>
-      ) : null}
 
       <div className="mt-6 flex flex-wrap gap-2">
         {(

--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -608,12 +608,6 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
                 </div>
               </div>
 
-              {fileError ? (
-                <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">
-                  {fileError}
-                </div>
-              ) : null}
-
               <textarea
                 value={fileContent}
                 onChange={(e) => setFileContent(e.target.value)}

--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -348,6 +348,12 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
       ) : null}
       {teamId ? <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Team: {teamId}</div> : null}
 
+      {pageMsg ? (
+        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 p-3 text-sm text-[color:var(--ck-text-secondary)]">
+          {pageMsg}
+        </div>
+      ) : null}
+
       <div className="mt-6 flex flex-wrap gap-2">
         {(
           [
@@ -606,6 +612,13 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
                   </button>
                 </div>
               </div>
+
+              {fileError ? (
+                <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">
+                  {fileError}
+                </div>
+              ) : null}
+
               <textarea
                 value={fileContent}
                 onChange={(e) => setFileContent(e.target.value)}

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -685,7 +685,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
                 value={selectedSkill}
                 onChange={(e) => setSelectedSkill(e.target.value)}
                 className="w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-3 py-2 text-sm text-[color:var(--ck-text-primary)]"
-                disabled={installingSkill || !availableSkills.length}
+                disabled={installingSkill || skillsLoading || !availableSkills.length}
               >
                 {availableSkills.length ? (
                   availableSkills.map((s) => (
@@ -699,7 +699,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
               </select>
               <button
                 type="button"
-                disabled={installingSkill || !selectedSkill}
+                disabled={installingSkill || skillsLoading || !selectedSkill}
                 onClick={async () => {
                   setInstallingSkill(true);
                   setTeamSkillMsg("");


### PR DESCRIPTION
Implements major pieces of ticket #0075 (ClawKitchen UX overhaul for recipes/teams/agents).

Includes:
- Recipes page: Create Team + Create Agent CTAs (modal prompts; apply-config scaffold; navigation)
- Recipe editor (/recipes/<id>): right-panel preview/actions for team + agent recipes; Create Team/Create Agent flows
- Create Team/Create Agent modals: name→id slugify + live id availability checks; collision guards
- Team editor: recipe markdown loads by default; Publish changes enabled only when there are unpropagated changes; publish confirm modal
- Skills dropdown+Add pattern for team + agent skills; APIs to list available skills + install into scope
- Team→Agent edit flow: returnTo back-link + Save & return
- Hide Channels from top nav for release

Notes:
- This PR intentionally does NOT include the Agents tab dropdown Add/Remove flow (separate PR #30).

Verification:
- 
> clawkitchen@0.1.0 lint
> eslint (clean)
- 
> clawkitchen@0.1.0 build
> next build

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 2.1s
  Running TypeScript ... (OK)