### PR TITLE
feat: package ClawKitchen as OpenClaw plugin (@jiggai/kitchen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ Phase 1 focus:
 - OpenClaw installed and on PATH (`openclaw`)
 - ClawRecipes plugin installed/linked so `openclaw recipes ...` works
 
-## Running locally
+---
+
+## Option A: Run as a standalone app (dev)
+
 ```bash
 npm install
 npm run dev -- --port 3001
@@ -19,6 +22,133 @@ npm run dev -- --port 3001
 
 Open:
 - http://localhost:3001
+
+Notes:
+- This is the fastest iteration loop.
+- This mode is local-only unless you separately expose the port.
+
+---
+
+## Option B: Run as an OpenClaw plugin (@jiggai/kitchen)
+
+ClawKitchen can be loaded as an OpenClaw plugin so it runs locally on the orchestrator.
+
+### 1) Load the plugin from a local path (pre-release testing)
+
+Before publishing to npm, you can load it directly from the repo by adding the repo path to `plugins.load.paths`.
+
+Edit your OpenClaw config (`~/.openclaw/openclaw.json`) and add:
+
+```json5
+{
+  "plugins": {
+    "load": {
+      "paths": ["/home/control/clawkitchen"]
+    },
+
+    // If you use plugins.allow, ensure kitchen is allowed.
+    "allow": ["kitchen", "recipes"],
+
+    "entries": {
+      "kitchen": {
+        "enabled": true,
+        "config": {
+          "enabled": true,
+          "dev": true,
+          "host": "127.0.0.1",
+          "port": 7777,
+          "authToken": ""
+        }
+      }
+    }
+  }
+}
+```
+
+Notes:
+- Plugin id is `kitchen` (from `openclaw.plugin.json`).
+- If `plugins.allow` is present, it **must** include `kitchen` or config validation will fail.
+
+### 2) Restart the gateway
+
+Config changes require a gateway restart:
+
+```bash
+openclaw gateway restart
+```
+
+### 3) Confirm Kitchen is running
+
+```bash
+openclaw kitchen status
+openclaw kitchen open
+```
+
+Then open:
+- http://127.0.0.1:7777
+
+---
+
+## Tailscale / remote access (recommended)
+
+This is intended for **Tailscale-only** remote access.
+
+### 1) Pick an auth token
+
+Use a long random string. Examples:
+
+```bash
+# base64 token
+openssl rand -base64 32
+
+# hex token
+openssl rand -hex 32
+
+# node (URL-safe)
+node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+```
+
+### 2) Bind to your Tailscale IP
+
+Update OpenClaw config:
+
+```json5
+{
+  "plugins": {
+    "entries": {
+      "kitchen": {
+        "enabled": true,
+        "config": {
+          "host": "<tailscale-ip>",
+          "port": 7777,
+          "authToken": "<token>",
+          "dev": true
+        }
+      }
+    }
+  }
+}
+```
+
+Restart:
+```bash
+openclaw gateway restart
+```
+
+### 3) Connect
+
+Open in a browser:
+- `http://<tailscale-ip>:7777`
+
+Authentication:
+- HTTP Basic Auth
+  - username: `kitchen`
+  - password: `<token>`
+
+Safety rule:
+- If `host` is not localhost, `authToken` is required.
+
+---
 
 ## Goals
 See [docs/GOALS.md](docs/GOALS.md).

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,0 +1,24 @@
+{
+  "id": "kitchen",
+  "name": "ClawKitchen",
+  "description": "Local UI for managing OpenClaw recipes, teams, agents, cron jobs, and skills.",
+  "version": "0.1.0",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": { "type": "boolean", "default": true },
+      "dev": { "type": "boolean", "default": true, "description": "Run Next.js in dev mode (no prebuild required)." },
+      "host": { "type": "string", "default": "127.0.0.1" },
+      "port": { "type": "integer", "default": 7777, "minimum": 1, "maximum": 65535 },
+      "authToken": { "type": "string", "default": "" }
+    }
+  },
+  "uiHints": {
+    "enabled": { "label": "Enabled" },
+    "dev": { "label": "Dev mode", "help": "If true, Kitchen runs in Next dev mode. For production packaging, set this to false and ship built assets." },
+    "host": { "label": "Host", "help": "Default binds to localhost. For Tailscale remote access, bind to your Tailscale IP or 0.0.0.0 and set authToken." },
+    "port": { "label": "Port" },
+    "authToken": { "label": "Auth token", "help": "Required when host is not localhost. Used for HTTP Basic auth (username: kitchen)." }
+  }
+}

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -1,0 +1,170 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Next is already a dependency of ClawKitchen.
+import next from "next";
+
+type KitchenConfig = {
+  enabled?: boolean;
+  dev?: boolean;
+  host?: string;
+  port?: number;
+  authToken?: string;
+};
+
+function isLocalhost(host: string) {
+  const h = (host || "").trim().toLowerCase();
+  return h === "127.0.0.1" || h === "localhost" || h === "::1";
+}
+
+function parseBasicAuth(req: http.IncomingMessage) {
+  const header = String(req.headers.authorization || "").trim();
+  if (!header.toLowerCase().startsWith("basic ")) return null;
+  try {
+    const raw = Buffer.from(header.slice(6), "base64").toString("utf8");
+    const idx = raw.indexOf(":");
+    if (idx === -1) return null;
+    return { user: raw.slice(0, idx), pass: raw.slice(idx + 1) };
+  } catch {
+    return null;
+  }
+}
+
+let server: http.Server | null = null;
+let startedAt: string | null = null;
+
+async function startKitchen(api: OpenClawPluginApi, cfg: KitchenConfig) {
+  if (server) return;
+
+  const host = String(cfg.host || "127.0.0.1").trim();
+  const port = Number(cfg.port || 7777);
+  const dev = cfg.dev !== false;
+  const authToken = String(cfg.authToken || "");
+
+  if (!isLocalhost(host) && !authToken.trim()) {
+    throw new Error("Kitchen: authToken is required when binding to a non-localhost host (for Tailscale/remote access).");
+  }
+
+  const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+  const app = next({ dev, dir: rootDir });
+  await app.prepare();
+  const handle = app.getRequestHandler();
+
+  server = http.createServer(async (req, res) => {
+    try {
+      const url = req.url || "/";
+
+      // Health check
+      if (url.startsWith("/healthz")) {
+        res.statusCode = 200;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ ok: true, startedAt }));
+        return;
+      }
+
+      if (!isLocalhost(host) && authToken.trim()) {
+        const creds = parseBasicAuth(req);
+        const ok = creds && creds.user === "kitchen" && creds.pass === authToken;
+        if (!ok) {
+          res.statusCode = 401;
+          res.setHeader("www-authenticate", 'Basic realm="kitchen"');
+          res.end("Unauthorized");
+          return;
+        }
+      }
+
+      await handle(req, res);
+    } catch (e: unknown) {
+      api.logger.error(`[kitchen] request error: ${e instanceof Error ? e.message : String(e)}`);
+      res.statusCode = 500;
+      res.end("Internal Server Error");
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server!.once("error", reject);
+    server!.listen(port, host, () => resolve());
+  });
+
+  startedAt = new Date().toISOString();
+  api.logger.info(`[kitchen] listening on http://${host}:${port} (dev=${dev})`);
+}
+
+async function stopKitchen(api: OpenClawPluginApi) {
+  if (!server) return;
+  const s = server;
+  server = null;
+  startedAt = null;
+  await new Promise<void>((resolve) => s.close(() => resolve()));
+  api.logger.info("[kitchen] stopped");
+}
+
+const kitchenPlugin = {
+  id: "kitchen",
+  name: "ClawKitchen",
+  description: "Local UI for managing recipes, teams, agents, cron jobs, and skills.",
+  configSchema: { type: "object", additionalProperties: true, properties: {} },
+  register(api: OpenClawPluginApi) {
+    const cfg = (api.pluginConfig || {}) as KitchenConfig;
+
+    api.registerCli(
+      ({ program }) => {
+        const cmd = program.command("kitchen").description("ClawKitchen UI");
+
+        cmd
+          .command("status")
+          .description("Print Kitchen status")
+          .action(() => {
+            const host = String(cfg.host || "127.0.0.1").trim();
+            const port = Number(cfg.port || 7777);
+            console.log(
+              JSON.stringify(
+                {
+                  ok: true,
+                  running: Boolean(server),
+                  url: `http://${host}:${port}`,
+                  startedAt,
+                },
+                null,
+                2,
+              ),
+            );
+          });
+
+        cmd
+          .command("open")
+          .description("Print the Kitchen URL")
+          .action(() => {
+            const host = String(cfg.host || "127.0.0.1").trim();
+            const port = Number(cfg.port || 7777);
+            console.log(`http://${host}:${port}`);
+          });
+      },
+      { commands: ["kitchen"] },
+    );
+
+    api.registerService({
+      id: "kitchen",
+      start: async () => {
+        if (cfg.enabled === false) return;
+        try {
+          await startKitchen(api, cfg);
+        } catch (e: unknown) {
+          api.logger.error(`[kitchen] failed to start: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      },
+      stop: async () => {
+        try {
+          await stopKitchen(api);
+        } catch (e: unknown) {
+          api.logger.error(`[kitchen] failed to stop: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      },
+    });
+  },
+};
+
+export default kitchenPlugin;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "clawkitchen",
+  "name": "@jiggai/kitchen",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
+  "openclaw": {
+    "extensions": ["./openclaw/index.ts"]
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "openclaw"]
 }


### PR DESCRIPTION
Packages ClawKitchen as an installable OpenClaw plugin.

What’s included
- Adds `openclaw.plugin.json` (plugin id: `kitchen`) with config schema.
- Adds plugin entrypoint `openclaw/index.ts` via `package.json openclaw.extensions`.
- Registers a background service that starts the Kitchen UI (Next) on `127.0.0.1:7777` by default.
- Supports Tailscale/remote bind by setting `host` to a non-localhost value; requires `authToken` in that case (HTTP Basic auth, username `kitchen`).
- Adds `openclaw kitchen status|open` CLI helpers.

Notes
- `dev` mode defaults to true so the plugin can run without shipping a prebuilt `.next` bundle (production packaging can flip this later).
- `tsconfig.json` excludes `openclaw/` so local Next builds don’t require OpenClaw’s plugin-sdk typings.

How to test (local)
1) Enable plugin in OpenClaw config: `plugins.entries.kitchen.enabled=true` and set `plugins.allow` accordingly.
2) Restart gateway.
3) Confirm Kitchen serves at http://127.0.0.1:7777 and `openclaw kitchen status` prints running + URL.
4) (Optional) Set host to Tailscale IP and authToken; confirm browser prompts for basic auth.
