### PR TITLE
Fix lint warnings: agent notices + Create Team id availability

### DIFF
--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -357,6 +357,11 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
       ) : null}
       {teamId ? <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Team: {teamId}</div> : null}
 
+      {pageMsg ? (
+        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 p-3 text-sm text-[color:var(--ck-text-primary)]">
+          {pageMsg}
+        </div>
+      ) : null}
 
       <div className="mt-6 flex flex-wrap gap-2">
         {(
@@ -617,6 +622,12 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
                   </button>
                 </div>
               </div>
+
+              {fileError ? (
+                <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">
+                  {fileError}
+                </div>
+              ) : null}
 
               <textarea
                 value={fileContent}

--- a/src/app/recipes/CreateTeamModal.tsx
+++ b/src/app/recipes/CreateTeamModal.tsx
@@ -160,6 +160,13 @@ export function CreateTeamModal({
               <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
                 This will scaffold ~/.openclaw/workspace-&lt;teamId&gt; and add the team to config.
               </div>
+              {availability.state === "checking" ? (
+                <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">Checking availability…</div>
+              ) : availability.state === "taken" ? (
+                <div className="mt-2 text-xs text-red-200">That id is taken.</div>
+              ) : availability.state === "available" ? (
+                <div className="mt-2 text-xs text-emerald-200">Id is available.</div>
+              ) : null}
             </div>
 
             <label className="mt-4 flex items-center gap-2 text-sm text-[color:var(--ck-text-secondary)]">
@@ -187,7 +194,12 @@ export function CreateTeamModal({
               </button>
               <button
                 type="button"
-                disabled={busy || !effectiveId.trim()}
+                disabled={
+                  busy ||
+                  !effectiveId.trim() ||
+                  availability.state === "checking" ||
+                  availability.state === "taken"
+                }
                 onClick={onConfirm}
                 className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] hover:bg-[var(--ck-accent-red-hover)] disabled:opacity-50"
               >


### PR DESCRIPTION
Fixes eslint unused-vars warnings that appeared on main after merging #30/#31 by rendering Agent editor page notices (pageMsg) and Files-tab fileError.

Also uses CreateTeamModal availability state to disable Create while checking/taken and shows a small availability indicator.

Verification:
- npm run lint (clean)
- npm run build (success)