### PR TITLE
feat: package ClawKitchen as OpenClaw plugin (@jiggai/kitchen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,34 +2,13 @@
 
 Local-first UI companion for **ClawRecipes** (OpenClaw Recipes plugin).
 
-Phase 1 focus:
-- list recipes (builtin + workspace)
-- edit recipes (including builtin) and save back to disk
-- scaffold agents/teams via `openclaw recipes scaffold` / `scaffold-team`
-
 ## Prerequisites
 - OpenClaw installed and on PATH (`openclaw`)
 - ClawRecipes plugin installed/linked so `openclaw recipes ...` works
 
 ---
 
-## Option A: Run as a standalone app (dev)
-
-```bash
-npm install
-npm run dev -- --port 3001
-```
-
-Open:
-- http://localhost:3001
-
-Notes:
-- This is the fastest iteration loop.
-- This mode is local-only unless you separately expose the port.
-
----
-
-## Option B: Run as an OpenClaw plugin (@jiggai/kitchen)
+## Run as an OpenClaw plugin (@jiggai/kitchen)
 
 ClawKitchen can be loaded as an OpenClaw plugin so it runs locally on the orchestrator.
 


### PR DESCRIPTION
Packages ClawKitchen as an installable OpenClaw plugin.\n\n- Adds openclaw.plugin.json (plugin id: kitchen)\n- Adds openclaw/index.ts plugin entrypoint via package.json openclaw.extensions\n- Starts Kitchen service on 127.0.0.1:7777 by default\n- Supports Tailscale/remote bind with required authToken (Basic auth user: kitchen)\n- README includes exact local + Tailscale setup steps\n\nTest:\n1) Add /home/control/clawkitchen to plugins.load.paths, enable plugins.entries.kitchen, restart gateway\n2) Visit http://127.0.0.1:7777\n3) Set host=<tailscale-ip>, authToken=<token>, restart, visit http://<tailscale-ip>:7777 and confirm Basic auth\n