### PR TITLE
Fix eslint warnings: render agent notices + Create Team availability

### DIFF
--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -357,6 +357,11 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
       ) : null}
       {teamId ? <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">Team: {teamId}</div> : null}
 
+      {pageMsg ? (
+        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 p-3 text-sm text-[color:var(--ck-text-primary)]">
+          {pageMsg}
+        </div>
+      ) : null}
 
       <div className="mt-6 flex flex-wrap gap-2">
         {(
@@ -617,6 +622,12 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
                   </button>
                 </div>
               </div>
+
+              {fileError ? (
+                <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">
+                  {fileError}
+                </div>
+              ) : null}
 
               <textarea
                 value={fileContent}

--- a/src/app/recipes/CreateTeamModal.tsx
+++ b/src/app/recipes/CreateTeamModal.tsx
@@ -160,6 +160,14 @@ export function CreateTeamModal({
               <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
                 This will scaffold ~/.openclaw/workspace-&lt;teamId&gt; and add the team to config.
               </div>
+
+              {availability.state === "checking" ? (
+                <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">Checking availability…</div>
+              ) : availability.state === "taken" ? (
+                <div className="mt-2 text-xs text-red-200">That id is already taken.</div>
+              ) : availability.state === "available" ? (
+                <div className="mt-2 text-xs text-emerald-200">Id available.</div>
+              ) : null}
             </div>
 
             <label className="mt-4 flex items-center gap-2 text-sm text-[color:var(--ck-text-secondary)]">
@@ -187,7 +195,7 @@ export function CreateTeamModal({
               </button>
               <button
                 type="button"
-                disabled={busy || !effectiveId.trim()}
+                disabled={busy || !effectiveId.trim() || availability.state === "taken" || availability.state === "checking"}
                 onClick={onConfirm}
                 className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] hover:bg-[var(--ck-accent-red-hover)] disabled:opacity-50"
               >


### PR DESCRIPTION
Follow-up for #0075 post-merge: main has 3 eslint warnings (unused pageMsg/fileError/availability).\n\nChanges:\n- Agent editor: render  notice below header; render  in Files tab.\n- CreateTeamModal: surface id availability status + disable Create when taken/checking.\n\nVerification:\n- 
> @jiggai/kitchen@0.1.0 lint
> eslint (clean)\n- 
> @jiggai/kitchen@0.1.0 build
> next build

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 2.2s
  Running TypeScript ...
  Collecting page data using 7 workers ...
  Generating static pages using 7 workers (0/42) ...
  Generating static pages using 7 workers (10/42) 
  Generating static pages using 7 workers (20/42) 
  Generating static pages using 7 workers (31/42) 
✓ Generating static pages using 7 workers (42/42) in 2.6s
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ƒ /agents/[agentId]
├ ƒ /api/agents
├ ƒ /api/agents/[id]
├ ƒ /api/agents/add
├ ƒ /api/agents/file
├ ƒ /api/agents/files
├ ƒ /api/agents/identity
├ ƒ /api/agents/skills
├ ƒ /api/agents/skills/install
├ ƒ /api/agents/update
├ ƒ /api/channels/bindings
├ ƒ /api/cron/delete
├ ƒ /api/cron/job
├ ƒ /api/cron/jobs
├ ƒ /api/cron/recipe-installed
├ ƒ /api/gateway/restart
├ ƒ /api/goals
├ ƒ /api/goals/[id]
├ ƒ /api/goals/[id]/promote
├ ƒ /api/ids/check
├ ƒ /api/marketplace/recipes
├ ƒ /api/marketplace/recipes/[slug]
├ ƒ /api/recipes
├ ƒ /api/recipes/[id]
├ ƒ /api/recipes/clone
├ ƒ /api/recipes/delete
├ ƒ /api/recipes/team-agents
├ ƒ /api/scaffold
├ ƒ /api/settings/cron-installation
├ ƒ /api/skills/available
├ ƒ /api/teams/file
├ ƒ /api/teams/files
├ ƒ /api/teams/meta
├ ƒ /api/teams/remove-team
├ ƒ /api/teams/skills
├ ƒ /api/teams/skills/install
├ ƒ /api/tickets/move
├ ○ /channels
├ ○ /cron-jobs
├ ○ /goals
├ ƒ /goals/[id]
├ ○ /goals/new
├ ○ /recipes
├ ƒ /recipes/[id]
├ ○ /settings
├ ƒ /teams/[teamId]
├ ○ /tickets
└ ƒ /tickets/[ticket]


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand (OK)