### PR TITLE
feat: ship prebuilt .next bundle for Kitchen plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ Local-first UI companion for **ClawRecipes** (OpenClaw Recipes plugin).
 
 ClawKitchen can be loaded as an OpenClaw plugin so it runs locally on the orchestrator.
 
-### 1) Load the plugin from a local path (pre-release testing)
+### 1) Install / load the plugin
 
-Before publishing to npm, you can load it directly from the repo by adding the repo path to `plugins.load.paths`.
+**Recommended (end users):** install the published plugin package (ships with a prebuilt `.next/` so you don’t run any npm commands).
+
+**Developer/testing:** you can also load it directly from a local repo path via `plugins.load.paths`.
 
 Edit your OpenClaw config (`~/.openclaw/openclaw.json`) and add:
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,9 @@ const nextConfig: NextConfig = {
   },
   // Also helps Next resolve dependencies correctly in nested repos.
   outputFileTracingRoot: __dirname,
+
+  // Required so we can ship a prebuilt server bundle (no npm commands for end users).
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -10,8 +10,19 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "smoke:goals": "node scripts/goals-smoke.mjs"
+    "smoke:goals": "node scripts/goals-smoke.mjs",
+    "prepack": "npm run build"
   },
+  "files": [
+    "openclaw/",
+    "openclaw.plugin.json",
+    "README.md",
+    "next.config.ts",
+    "public/",
+    "src/",
+    ".next/standalone/",
+    ".next/static/"
+  ],
   "dependencies": {
     "next": "16.1.6",
     "react": "19.2.3",


### PR DESCRIPTION
Ship Kitchen with a prebuilt Next.js bundle so end users never run npm commands.

Changes
- `next.config.ts`: set `output: "standalone"`.
- `package.json`:
  - add `prepack` hook to run `next build` before `npm pack`/publish
  - add `files` whitelist to include `.next/standalone` + `.next/static` in the published package
- README: reframe install to recommend the published plugin package (prebuilt), keeping `plugins.load.paths` as dev/testing only.

Verification
- `npm pack` now includes `.next/standalone` + `.next/static` (so `dev:false` works without local builds).

Notes
- This package will be larger (standalone bundle), but removes the biggest UX footgun (missing/outdated `.next` causing 500s on /_next/static/chunks/*).
