### PR TITLE
fix: home page should not cache agents/teams

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,9 @@
 import { runOpenClaw } from "@/lib/openclaw";
 import HomeClient from "./HomeClient";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 type AgentListItem = {
   id: string;
   identityName?: string;


### PR DESCRIPTION
Home page was effectively static-rendered and could show stale teams/agents after config changes (e.g. remove-team).

- Force `/` to be dynamic (`dynamic = force-dynamic`, `revalidate = 0`) so it always reflects current `openclaw agents list` output.
