### PR TITLE
fix: remove Create Team availability checks

### DIFF
--- a/src/app/recipes/recipes-client.tsx
+++ b/src/app/recipes/recipes-client.tsx
@@ -345,8 +345,6 @@ export default function RecipesClient({
         setTeamId={setCreateTeamId}
         installCron={installCron}
         setInstallCron={setInstallCron}
-        existingRecipeIds={[...builtin, ...customTeamRecipes, ...customAgentRecipes].map((r) => r.id)}
-        existingAgentIds={installedAgentIds}
         busy={createBusy}
         error={createError}
         onClose={() => setCreateOpen(false)}


### PR DESCRIPTION
Removes the Create Team modal id availability checks/gating (red/green + async checks). Creation relies on server-side validation in /api/scaffold.

- Drop /api/ids/check calls from CreateTeamModal
- Remove disabled gating on availability state
