### PR TITLE
feat: scaffold/restart overlay (ordering → cooking → serving)

### DIFF
--- a/src/app/recipes/recipes-client.tsx
+++ b/src/app/recipes/recipes-client.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { ScaffoldOverlay, type ScaffoldOverlayStep } from "@/components/ScaffoldOverlay";
 import { useToast } from "@/components/ToastProvider";
 import { CreateTeamModal } from "./CreateTeamModal";
 import { CreateAgentModal } from "./CreateAgentModal";
@@ -122,6 +123,10 @@ export default function RecipesClient({
   installedAgentIds: string[];
 }) {
   const toast = useToast();
+
+  const [overlayOpen, setOverlayOpen] = useState(false);
+  const [overlayStep, setOverlayStep] = useState<ScaffoldOverlayStep>(1);
+  const [overlayDetails, setOverlayDetails] = useState<string>("");
   const router = useRouter();
 
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -193,6 +198,23 @@ export default function RecipesClient({
     }
   }
 
+  async function waitForKitchenHealthy(opts?: { timeoutMs?: number }) {
+    const timeoutMs = opts?.timeoutMs ?? 30_000;
+    const started = Date.now();
+
+    while (Date.now() - started < timeoutMs) {
+      try {
+        const res = await fetch("/healthz", { cache: "no-store" });
+        if (res.ok) return true;
+      } catch {
+        // ignore
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+
+    return false;
+  }
+
   async function confirmCreateTeam() {
     const recipe = createRecipe;
     if (!recipe) return;
@@ -210,6 +232,10 @@ export default function RecipesClient({
     setCreateBusy(true);
     setCreateError(null);
 
+    setOverlayOpen(true);
+    setOverlayStep(1);
+    setOverlayDetails("");
+
     try {
       const res = await fetch("/api/scaffold", {
         method: "POST",
@@ -226,23 +252,33 @@ export default function RecipesClient({
       const json = await res.json();
       if (!res.ok || !json.ok) throw new Error(String(json.error || "Create team failed"));
 
-      toast.push({ kind: "success", message: `Created team: ${t}` });
-      setCreateOpen(false);
+      setOverlayStep(2);
 
-      // If scaffolding changed config, the gateway may need a restart before the new team
-      // consistently shows up across pages.
       const stderr = typeof json.stderr === "string" ? json.stderr : "";
+      if (stderr.trim()) setOverlayDetails(stderr.trim());
+
+      // If scaffolding changed config, the gateway may need a restart. During restart, new pages
+      // will throw transient errors (RSC/markdown fetches/etc.), so keep the overlay up.
       if (/Restart required:/i.test(stderr)) {
-        toast.push({ kind: "info", message: "Restarting gateway to apply team config…" });
+        setOverlayStep(3);
         try {
           await fetch("/api/gateway/restart", { method: "POST" });
         } catch {
-          // best-effort; navigation can still work but may be inconsistent until restart
+          // best-effort
         }
+        await waitForKitchenHealthy({ timeoutMs: 60_000 });
       }
 
+      toast.push({ kind: "success", message: `Created team: ${t}` });
+      setCreateOpen(false);
+
+      // Navigate only after restart (if any) to avoid the ugly error+reload UX.
       router.push(`/teams/${encodeURIComponent(t)}`);
+
+      // Give the next page a beat to mount before removing the overlay.
+      setTimeout(() => setOverlayOpen(false), 500);
     } catch (e: unknown) {
+      setOverlayOpen(false);
       const msg = e instanceof Error ? e.message : String(e);
       setCreateError(msg);
       toast.push({ kind: "error", message: msg });
@@ -268,6 +304,10 @@ export default function RecipesClient({
     setCreateAgentBusy(true);
     setCreateAgentError(null);
 
+    setOverlayOpen(true);
+    setOverlayStep(1);
+    setOverlayDetails("");
+
     try {
       const res = await fetch("/api/scaffold", {
         method: "POST",
@@ -284,21 +324,28 @@ export default function RecipesClient({
       const json = await res.json();
       if (!res.ok || !json.ok) throw new Error(String(json.error || "Create agent failed"));
 
-      toast.push({ kind: "success", message: `Created agent: ${a}` });
-      setCreateAgentOpen(false);
+      setOverlayStep(2);
 
       const stderr = typeof json.stderr === "string" ? json.stderr : "";
+      if (stderr.trim()) setOverlayDetails(stderr.trim());
+
       if (/Restart required:/i.test(stderr)) {
-        toast.push({ kind: "info", message: "Restarting gateway to apply agent config…" });
+        setOverlayStep(3);
         try {
           await fetch("/api/gateway/restart", { method: "POST" });
         } catch {
           // best-effort
         }
+        await waitForKitchenHealthy({ timeoutMs: 60_000 });
       }
 
+      toast.push({ kind: "success", message: `Created agent: ${a}` });
+      setCreateAgentOpen(false);
+
       router.push(`/agents/${encodeURIComponent(a)}`);
+      setTimeout(() => setOverlayOpen(false), 500);
     } catch (e: unknown) {
+      setOverlayOpen(false);
       const msg = e instanceof Error ? e.message : String(e);
       setCreateAgentError(msg);
       toast.push({ kind: "error", message: msg });
@@ -309,6 +356,7 @@ export default function RecipesClient({
 
   return (
     <>
+      <ScaffoldOverlay open={overlayOpen} step={overlayStep} details={overlayDetails} />
       <div className="mt-8 space-y-10">
         <section>
           <h2 className="text-xl font-semibold tracking-tight text-[color:var(--ck-text-primary)]">Custom recipes</h2>

--- a/src/components/ScaffoldOverlay.tsx
+++ b/src/components/ScaffoldOverlay.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { createPortal } from "react-dom";
+
+export type ScaffoldOverlayStep = 1 | 2 | 3;
+
+const stepLabel: Record<ScaffoldOverlayStep, string> = {
+  1: "Ordering team…",
+  2: "Cooking up agents…",
+  3: "Serving them up hot…",
+};
+
+export function ScaffoldOverlay({
+  open,
+  step,
+  details,
+}: {
+  open: boolean;
+  step: ScaffoldOverlayStep;
+  details?: string;
+}) {
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[500]">
+      <div className="fixed inset-0 bg-black/70" />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <div className="w-full max-w-lg rounded-2xl border border-white/10 bg-[color:var(--ck-bg-glass-strong)] p-6 shadow-[var(--ck-shadow-2)]">
+          <div className="text-lg font-semibold text-[color:var(--ck-text-primary)]">Claw Kitchen</div>
+          <div className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">Hang tight — we’re updating your OpenClaw install.</div>
+
+          <div className="mt-5 space-y-3 text-sm">
+            {[1, 2, 3].map((n) => {
+              const s = n as ScaffoldOverlayStep;
+              const active = s === step;
+              const done = s < step;
+              return (
+                <div key={s} className="flex items-center gap-3">
+                  <div
+                    className={
+                      "h-2.5 w-2.5 rounded-full " +
+                      (done
+                        ? "bg-emerald-400"
+                        : active
+                          ? "bg-[var(--ck-accent-red)] animate-pulse"
+                          : "bg-white/20")
+                    }
+                  />
+                  <div className={done ? "text-[color:var(--ck-text-secondary)] line-through" : "text-[color:var(--ck-text-primary)]"}>
+                    {stepLabel[s]}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {details ? (
+            <details className="mt-5">
+              <summary className="cursor-pointer select-none text-xs text-[color:var(--ck-text-tertiary)]">Details</summary>
+              <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap rounded-lg border border-white/10 bg-black/30 p-3 text-xs text-[color:var(--ck-text-secondary)]">
+                {details}
+              </pre>
+            </details>
+          ) : null}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}


### PR DESCRIPTION
Adds a full-page overlay during Create Team / Create Agent scaffolding and (if required) gateway restarts.

- Shows 3-step progress copy: Ordering team → Cooking up agents → Serving them up hot
- If scaffold stderr contains 'Restart required', calls /api/gateway/restart then polls /healthz before navigating
- Prevents the terrible UX where the destination page loads mid-restart and throws client-side exceptions / reloads
