### PR TITLE
fix: scaffold overlay polling (timeouts/backoff; meta best-effort)

### DIFF
--- a/src/app/recipes/recipes-client.tsx
+++ b/src/app/recipes/recipes-client.tsx
@@ -219,32 +219,73 @@ export default function RecipesClient({
     const timeoutMs = opts?.timeoutMs ?? 30_000;
     const started = Date.now();
 
+    let delayMs = 250;
+    let consecutiveNetworkFails = 0;
+
+    async function fetchJsonWithTimeout(url: string, ms: number) {
+      const ctl = new AbortController();
+      const t = setTimeout(() => ctl.abort(), ms);
+      try {
+        const res = await fetch(url, { cache: "no-store", signal: ctl.signal });
+        const json = (await res.json()) as unknown;
+        return { res, json };
+      } finally {
+        clearTimeout(t);
+      }
+    }
+
     while (Date.now() - started < timeoutMs) {
       try {
-        const [recipesRes, metaRes] = await Promise.all([
-          fetch("/api/recipes", { cache: "no-store" }),
-          fetch(`/api/teams/meta?teamId=${encodeURIComponent(teamId)}`, { cache: "no-store" }),
-        ]);
-
-        const recipesJson = (await recipesRes.json()) as { recipes?: Array<{ id?: unknown; kind?: unknown }> };
+        // 1) Check recipes first.
+        const recipesOut = await fetchJsonWithTimeout("/api/recipes", 5_000);
+        const recipesJson = recipesOut.json as { recipes?: Array<{ id?: unknown; kind?: unknown }> };
         const list = Array.isArray(recipesJson.recipes) ? recipesJson.recipes : [];
         const hasRecipe = list.some((r) => String(r.id ?? "") === teamId && String(r.kind ?? "") === "team");
 
-        const metaJson = (await metaRes.json()) as { ok?: boolean; missing?: boolean; meta?: unknown };
-        const hasMeta = Boolean(metaRes.ok && metaJson.ok && !metaJson.missing);
+        // If the recipe isn't visible yet, don't hammer meta.
+        if (!hasRecipe) {
+          consecutiveNetworkFails = 0;
+          await new Promise((r) => setTimeout(r, delayMs));
+          delayMs = Math.min(2000, Math.round(delayMs * 1.5));
+          continue;
+        }
 
-        // Meta is best-effort provenance. Don't block navigation forever on it.
-        // If the recipe exists, the team page can still load and the editor will show provenanceMissing.
-        if (hasRecipe && (hasMeta || Date.now() - started > 3_000)) return true;
+        // 2) Once recipe exists, try meta (best-effort) with timeout.
+        try {
+          const metaOut = await fetchJsonWithTimeout(`/api/teams/meta?teamId=${encodeURIComponent(teamId)}`, 5_000);
+          const metaJson = metaOut.json as { ok?: boolean; missing?: boolean };
+          const hasMeta = Boolean(metaOut.res.ok && metaJson.ok && !metaJson.missing);
+          if (hasMeta) return true;
+        } catch {
+          // ignore meta failures; we fall back to recipe-only readiness below
+        }
+
+        // Meta can be flaky during restarts; don't block forever.
+        if (Date.now() - started > 3_000) return true;
+
+        consecutiveNetworkFails = 0;
       } catch {
-        // ignore
+        // Likely aborted/timeout during restart.
+        consecutiveNetworkFails += 1;
+
+        // If we keep failing, check healthz and back off.
+        if (consecutiveNetworkFails >= 3) {
+          try {
+            await fetchJsonWithTimeout("/healthz", 2_500);
+            consecutiveNetworkFails = 0;
+          } catch {
+            // still down
+          }
+        }
       }
 
-      await new Promise((r) => setTimeout(r, 500));
+      await new Promise((r) => setTimeout(r, delayMs));
+      delayMs = Math.min(2000, Math.round(delayMs * 1.5));
     }
 
     return false;
   }
+
 
   async function confirmCreateTeam() {
     const recipe = createRecipe;

--- a/src/app/recipes/recipes-client.tsx
+++ b/src/app/recipes/recipes-client.tsx
@@ -230,10 +230,12 @@ export default function RecipesClient({
         const list = Array.isArray(recipesJson.recipes) ? recipesJson.recipes : [];
         const hasRecipe = list.some((r) => String(r.id ?? "") === teamId && String(r.kind ?? "") === "team");
 
-        const metaJson = (await metaRes.json()) as { ok?: boolean; missing?: boolean };
+        const metaJson = (await metaRes.json()) as { ok?: boolean; missing?: boolean; meta?: unknown };
         const hasMeta = Boolean(metaRes.ok && metaJson.ok && !metaJson.missing);
 
-        if (hasRecipe && hasMeta) return true;
+        // Meta is best-effort provenance. Don't block navigation forever on it.
+        // If the recipe exists, the team page can still load and the editor will show provenanceMissing.
+        if (hasRecipe && (hasMeta || Date.now() - started > 3_000)) return true;
       } catch {
         // ignore
       }


### PR DESCRIPTION
Follow-up to #48.

This improves the scaffold overlay polling logic so it behaves well during gateway/Kitchen restarts:

- Provenance meta (/api/teams/meta) is best-effort; don’t block the overlay indefinitely if it’s temporarily unavailable.
- Add request timeouts (AbortController) + exponential backoff to reduce "no response data" spam when connections get aborted.
- Only query /api/teams/meta once /api/recipes shows the new team.
