### PR TITLE
fix: create-team overlay polish + avoid empty-body 200s

### DIFF
--- a/src/app/teams/[teamId]/page.tsx
+++ b/src/app/teams/[teamId]/page.tsx
@@ -56,15 +56,6 @@ export default async function TeamPage({ params }: { params: Promise<{ teamId: s
         </div>
       </div>
 
-      <div className="mx-auto mb-4 flex max-w-6xl items-center justify-end">
-        <Link
-          href={`/goals?team=${encodeURIComponent(teamId)}`}
-          className="text-sm font-medium text-[color:var(--ck-text-secondary)] hover:underline"
-        >
-          View goals for this team →
-        </Link>
-      </div>
-
       <TeamEditor teamId={teamId} />
     </main>
   );

--- a/src/components/ScaffoldOverlay.tsx
+++ b/src/components/ScaffoldOverlay.tsx
@@ -23,22 +23,23 @@ export function ScaffoldOverlay({
 
   return createPortal(
     <div className="fixed inset-0 z-[500]">
-      <div className="fixed inset-0 bg-black/70" />
-      <div className="fixed inset-0 flex items-center justify-center p-4">
-        <div className="w-full max-w-lg rounded-2xl border border-white/10 bg-[color:var(--ck-bg-glass-strong)] p-6 shadow-[var(--ck-shadow-2)]">
-          <div className="text-lg font-semibold text-[color:var(--ck-text-primary)]">Claw Kitchen</div>
-          <div className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">Hang tight — we’re updating your OpenClaw install.</div>
+      {/* Full blackout/whiteout to hide the app while gateway/Kitchen may be restarting. */}
+      <div className="fixed inset-0 bg-[color:var(--ck-bg)]" />
+      <div className="fixed inset-0 flex items-center justify-center p-6 sm:p-10">
+        <div className="w-full max-w-2xl rounded-2xl border border-white/10 bg-[color:var(--ck-bg-glass-strong)] p-8 sm:p-10 shadow-[var(--ck-shadow-2)]">
+          <div className="text-2xl font-semibold text-[color:var(--ck-text-primary)]">Claw Kitchen</div>
+          <div className="mt-3 text-base text-[color:var(--ck-text-secondary)]">Hang tight — we’re updating your OpenClaw install.</div>
 
-          <div className="mt-5 space-y-3 text-sm">
+          <div className="mt-8 space-y-4 text-base">
             {[1, 2, 3].map((n) => {
               const s = n as ScaffoldOverlayStep;
               const active = s === step;
               const done = s < step;
               return (
-                <div key={s} className="flex items-center gap-3">
+                <div key={s} className="flex items-center gap-4">
                   <div
                     className={
-                      "h-2.5 w-2.5 rounded-full " +
+                      "h-3.5 w-3.5 rounded-full " +
                       (done
                         ? "bg-emerald-400"
                         : active


### PR DESCRIPTION
Fix remaining create-team UX issues during scaffold/restart.

- Wait until `/api/teams/meta` actually returns a valid JSON body (no more 200 with empty body treated as success)
  - Use res.text() + JSON.parse with an explicit empty-body error
  - Require meta readiness before navigating to `/teams/<id>` to avoid the "raw markdown" load error
- Make the scaffold overlay larger (padding/fonts/dots)
- Use a full solid overlay background via `var(--ck-bg)` (black/white depending on theme)
- Remove the Team page "View goals" link (it was causing failing prefetches like `/goals?team=...&_rsc=...`)
