### PR TITLE
fix: global scaffold overlay (no peeking behind; persists across nav)

### DIFF
--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { DeleteTeamModal } from "./DeleteTeamModal";
 import { PublishChangesModal } from "./PublishChangesModal";
 import { useToast } from "@/components/ToastProvider";
+import { useScaffoldOverlay } from "@/components/ScaffoldOverlayProvider";
 
 type RecipeListItem = {
   id: string;
@@ -115,6 +116,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
   const [loadingSource, setLoadingSource] = useState(false);
   const [recipeLoadError, setRecipeLoadError] = useState<string>("");
   const toast = useToast();
+  const overlay = useScaffoldOverlay();
 
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [publishOpen, setPublishOpen] = useState(false);
@@ -258,6 +260,9 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
 
         // Render ASAP; load the heavier per-tab data in the background.
         setLoading(false);
+
+        // If we navigated here after scaffold/restart, clear the global overlay once the page is alive.
+        overlay.hide();
 
         void (async () => {
           setTeamFilesLoading(true);

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { ToastProvider } from "@/components/ToastProvider";
+import { ScaffoldOverlayProvider } from "@/components/ScaffoldOverlayProvider";
 
 function NavLink({ href, label }: { href: string; label: string }) {
   const pathname = usePathname();
@@ -27,7 +28,8 @@ function NavLink({ href, label }: { href: string; label: string }) {
 export function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <ToastProvider>
-      <div className="min-h-screen">
+      <ScaffoldOverlayProvider>
+        <div className="min-h-screen">
       <header className="sticky top-0 z-50 border-b border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] backdrop-blur-[var(--ck-glass-blur)]">
         <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3">
           <div className="flex items-center gap-3">
@@ -60,6 +62,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
       <main className="mx-auto max-w-6xl px-4 py-8">{children}</main>
     </div>
+      </ScaffoldOverlayProvider>
     </ToastProvider>
   );
 }

--- a/src/components/ScaffoldOverlay.tsx
+++ b/src/components/ScaffoldOverlay.tsx
@@ -24,7 +24,7 @@ export function ScaffoldOverlay({
   return createPortal(
     <div className="fixed inset-0 z-[500]">
       {/* Full blackout/whiteout to hide the app while gateway/Kitchen may be restarting. */}
-      <div className="fixed inset-0 bg-[color:var(--ck-bg)]" />
+      <div className="fixed inset-0 bg-[color:var(--ck-bg)] opacity-100" />
       <div className="fixed inset-0 flex items-center justify-center p-6 sm:p-10">
         <div className="w-full max-w-2xl rounded-2xl border border-white/10 bg-[color:var(--ck-bg-glass-strong)] p-8 sm:p-10 shadow-[var(--ck-shadow-2)]">
           <div className="text-2xl font-semibold text-[color:var(--ck-text-primary)]">Claw Kitchen</div>

--- a/src/components/ScaffoldOverlayProvider.tsx
+++ b/src/components/ScaffoldOverlayProvider.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { ScaffoldOverlay, type ScaffoldOverlayStep } from "@/components/ScaffoldOverlay";
+
+type OverlayState = {
+  open: boolean;
+  step: ScaffoldOverlayStep;
+  details?: string;
+};
+
+type OverlayApi = {
+  show: (state: { step: ScaffoldOverlayStep; details?: string }) => void;
+  setStep: (step: ScaffoldOverlayStep) => void;
+  setDetails: (details: string) => void;
+  hide: () => void;
+  snapshot: () => OverlayState;
+};
+
+const STORAGE_KEY = "ck.scaffoldOverlay";
+
+const Ctx = createContext<OverlayApi | null>(null);
+
+function safeParse(raw: string | null): OverlayState | null {
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw) as Partial<OverlayState>;
+    if (!v || typeof v !== "object") return null;
+    if (v.open !== true) return null;
+    const step = v.step;
+    if (step !== 1 && step !== 2 && step !== 3) return null;
+    return { open: true, step, details: typeof v.details === "string" ? v.details : undefined };
+  } catch {
+    return null;
+  }
+}
+
+export function ScaffoldOverlayProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<OverlayState>({ open: false, step: 1, details: "" });
+
+  // On first client mount, restore overlay state across navigations/restarts.
+  useEffect(() => {
+    const restored = safeParse(globalThis?.sessionStorage?.getItem(STORAGE_KEY) ?? null);
+    if (restored) setState(restored);
+  }, []);
+
+  const persist = useCallback((next: OverlayState) => {
+    try {
+      if (!globalThis?.sessionStorage) return;
+      if (next.open) sessionStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      else sessionStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const api = useMemo<OverlayApi>(() => {
+    return {
+      show: ({ step, details }) => {
+        const next: OverlayState = { open: true, step, details };
+        setState(next);
+        persist(next);
+      },
+      setStep: (step) => {
+        setState((prev) => {
+          const next = { ...prev, open: true, step };
+          persist(next);
+          return next;
+        });
+      },
+      setDetails: (details) => {
+        setState((prev) => {
+          const next = { ...prev, open: true, details };
+          persist(next);
+          return next;
+        });
+      },
+      hide: () => {
+        const next: OverlayState = { open: false, step: 1, details: "" };
+        setState(next);
+        persist(next);
+      },
+      snapshot: () => state,
+    };
+  }, [persist, state]);
+
+  return (
+    <Ctx.Provider value={api}>
+      <ScaffoldOverlay open={state.open} step={state.step} details={state.details} />
+      {children}
+    </Ctx.Provider>
+  );
+}
+
+export function useScaffoldOverlay() {
+  const v = useContext(Ctx);
+  if (!v) throw new Error("useScaffoldOverlay must be used within ScaffoldOverlayProvider");
+  return v;
+}


### PR DESCRIPTION
Fix scaffold/restart UX so users never see the app in a broken mid-restart state.

- Make the scaffold overlay GLOBAL (AppShell provider) so it persists across route navigation.
- Keep overlay up until destination team page finishes its initial load, then hide.
- On errors, hide overlay and do NOT navigate.
- Ensure overlay backdrop is fully opaque (no seeing content behind it).
