### PR TITLE
fix: overlay polish (solid backdrop + auto Serving after 15s)

### DIFF
--- a/src/components/ScaffoldOverlay.tsx
+++ b/src/components/ScaffoldOverlay.tsx
@@ -23,22 +23,23 @@ export function ScaffoldOverlay({
 
   return createPortal(
     <div className="fixed inset-0 z-[500]">
-      <div className="fixed inset-0 bg-black/70" />
-      <div className="fixed inset-0 flex items-center justify-center p-4">
-        <div className="w-full max-w-lg rounded-2xl border border-white/10 bg-[color:var(--ck-bg-glass-strong)] p-6 shadow-[var(--ck-shadow-2)]">
-          <div className="text-lg font-semibold text-[color:var(--ck-text-primary)]">Claw Kitchen</div>
-          <div className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">Hang tight — we’re updating your OpenClaw install.</div>
+      {/* Solid overlay (no seeing through during restarts/partial renders). */}
+      <div className="fixed inset-0 bg-[color:var(--ck-bg)]" />
+      <div className="fixed inset-0 flex items-center justify-center p-6 sm:p-10">
+        <div className="w-full max-w-2xl rounded-2xl border border-white/10 bg-[color:var(--ck-bg-glass-strong)] p-8 sm:p-10 shadow-[var(--ck-shadow-2)]">
+          <div className="text-2xl font-semibold text-[color:var(--ck-text-primary)]">Claw Kitchen</div>
+          <div className="mt-3 text-base text-[color:var(--ck-text-secondary)]">Hang tight — we’re updating your OpenClaw install.</div>
 
-          <div className="mt-5 space-y-3 text-sm">
+          <div className="mt-8 space-y-4 text-base">
             {[1, 2, 3].map((n) => {
               const s = n as ScaffoldOverlayStep;
               const active = s === step;
               const done = s < step;
               return (
-                <div key={s} className="flex items-center gap-3">
+                <div key={s} className="flex items-center gap-4">
                   <div
                     className={
-                      "h-2.5 w-2.5 rounded-full " +
+                      "h-4 w-4 rounded-full " +
                       (done
                         ? "bg-emerald-400"
                         : active
@@ -55,9 +56,9 @@ export function ScaffoldOverlay({
           </div>
 
           {details ? (
-            <details className="mt-5">
-              <summary className="cursor-pointer select-none text-xs text-[color:var(--ck-text-tertiary)]">Details</summary>
-              <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap rounded-lg border border-white/10 bg-black/30 p-3 text-xs text-[color:var(--ck-text-secondary)]">
+            <details className="mt-8">
+              <summary className="cursor-pointer select-none text-sm text-[color:var(--ck-text-tertiary)]">Details</summary>
+              <pre className="mt-3 max-h-64 overflow-auto whitespace-pre-wrap rounded-lg border border-white/10 bg-black/30 p-4 text-xs text-[color:var(--ck-text-secondary)]">
                 {details}
               </pre>
             </details>


### PR DESCRIPTION
Overlay UX polish (baseline/revert branch).

- After 15s in step 2 (Cooking up agents), automatically switch to step 3 (Serving them up hot).
- Make overlay backdrop solid (uses var(--ck-bg), not semi-transparent black).
- Larger text, dots, and padding.
