### PR TITLE
fix: overlay follow-up (20s + fully opaque)

### DIFF
--- a/src/app/recipes/recipes-client.tsx
+++ b/src/app/recipes/recipes-client.tsx
@@ -261,6 +261,9 @@ export default function RecipesClient({
     setCreateBusy(true);
     setCreateError(null);
 
+    // Hide the modal immediately so the overlay is the only visible UI during scaffold.
+    setCreateOpen(false);
+
     setOverlayOpen(true);
     setOverlayStep(1);
     setOverlayDetails("");
@@ -289,7 +292,7 @@ export default function RecipesClient({
       // apply/restart phase even if the CLI didn't print the restart hint yet.
       serveTimer = setTimeout(() => {
         setOverlayStep((prev) => (prev < 3 ? 3 : prev));
-      }, 15_000);
+      }, 20_000);
 
       const stderr = typeof json.stderr === "string" ? json.stderr : "";
       if (stderr.trim()) setOverlayDetails(stderr.trim());
@@ -354,6 +357,8 @@ export default function RecipesClient({
     setCreateAgentBusy(true);
     setCreateAgentError(null);
 
+    setCreateAgentOpen(false);
+
     setOverlayOpen(true);
     setOverlayStep(1);
     setOverlayDetails("");
@@ -380,7 +385,7 @@ export default function RecipesClient({
 
       serveTimer = setTimeout(() => {
         setOverlayStep((prev) => (prev < 3 ? 3 : prev));
-      }, 15_000);
+      }, 20_000);
 
       const stderr = typeof json.stderr === "string" ? json.stderr : "";
       if (stderr.trim()) setOverlayDetails(stderr.trim());

--- a/src/components/ScaffoldOverlay.tsx
+++ b/src/components/ScaffoldOverlay.tsx
@@ -22,9 +22,9 @@ export function ScaffoldOverlay({
   if (!open) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-[500]">
+    <div className="fixed inset-0 z-[9999]">
       {/* Solid overlay (no seeing through during restarts/partial renders). */}
-      <div className="fixed inset-0 bg-[color:var(--ck-bg)]" />
+      <div className="fixed inset-0 bg-white dark:bg-black" />
       <div className="fixed inset-0 flex items-center justify-center p-6 sm:p-10">
         <div className="w-full max-w-2xl rounded-2xl border border-white/10 bg-[color:var(--ck-bg-glass-strong)] p-8 sm:p-10 shadow-[var(--ck-shadow-2)]">
           <div className="text-2xl font-semibold text-[color:var(--ck-text-primary)]">Claw Kitchen</div>


### PR DESCRIPTION
Follow-up after #55 was merged.

- Auto-switch overlay step 2→3 after 20s (was 15s)
- Make overlay truly opaque/full-screen (no seeing modal/page behind)
  - z-index bump
  - solid bg (white in light mode, black in dark mode)
- Close Create Team/Create Agent modal immediately once scaffold starts
