### PR TITLE
chore: overlay backdrop 90% opacity

### DIFF
--- a/src/components/ScaffoldOverlay.tsx
+++ b/src/components/ScaffoldOverlay.tsx
@@ -24,7 +24,7 @@ export function ScaffoldOverlay({
   return createPortal(
     <div className="fixed inset-0 z-[9999]">
       {/* Slightly transparent full-screen overlay so we hide the app while still showing a hint of context. */}
-      <div className="fixed inset-0 bg-white/95 dark:bg-black/95" />
+      <div className="fixed inset-0 bg-white/90 dark:bg-black/90" />
 
       {onDismiss ? (
         <button


### PR DESCRIPTION
Follow-up after the overlay escape-hatch PR was merged.

- Adjust overlay backdrop opacity to 90% (was 95%).
