### PR TITLE
feat: default dark theme + icon toggle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         <script
           dangerouslySetInnerHTML={{
             __html:
-              "(function(){try{var t=localStorage.getItem('ck-theme');if(t==='dark'){document.documentElement.dataset.theme='dark';}}catch(e){}})();",
+              "(function(){try{var t=localStorage.getItem('ck-theme');var theme=(t==='light')?'light':'dark';document.documentElement.dataset.theme=theme;}catch(e){document.documentElement.dataset.theme='dark';}})();",
           }}
         />
       </head>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { MoonIcon, SunIcon } from "@/components/icons";
 
 export type Theme = "light" | "dark";
 
 const STORAGE_KEY = "ck-theme";
 
 function readInitialTheme(): Theme {
-  if (typeof window === "undefined") return "light";
+  // Default: dark mode.
+  if (typeof window === "undefined") return "dark";
   const saved = window.localStorage.getItem(STORAGE_KEY);
-  return saved === "dark" ? "dark" : "light";
+  return saved === "light" ? "light" : "dark";
 }
 
 function applyTheme(theme: Theme) {
@@ -28,15 +30,24 @@ export function ThemeToggle() {
     setTheme((t) => (t === "dark" ? "light" : "dark"));
   }
 
+  const label = theme === "dark" ? "Switch to light mode" : "Switch to dark mode";
+
   return (
     <button
       type="button"
       onClick={toggle}
-      className="rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] px-3 py-1.5 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[color:var(--ck-bg-glass-strong)]"
-      aria-label="Toggle theme"
-      title="Toggle theme"
+      className="grid h-9 w-9 place-items-center rounded-full border border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[color:var(--ck-bg-glass-strong)]"
+      aria-label={label}
+      title={label}
     >
-      <span suppressHydrationWarning>{theme === "dark" ? "Dark" : "Light"}</span>
+      <span className="sr-only" suppressHydrationWarning>
+        {label}
+      </span>
+      {theme === "dark" ? (
+        <MoonIcon className="h-4.5 w-4.5" />
+      ) : (
+        <SunIcon className="h-4.5 w-4.5" />
+      )}
     </button>
   );
 }

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+export function SunIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M12 18a6 6 0 1 0 0-12 6 6 0 0 0 0 12Z"
+        stroke="currentColor"
+        strokeWidth="1.8"
+      />
+      <path d="M12 2v2.5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <path d="M12 19.5V22" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <path d="M2 12h2.5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <path d="M19.5 12H22" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <path d="M4.2 4.2 6 6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <path d="M18 18l1.8 1.8" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <path d="M18 6l1.8-1.8" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <path d="M4.2 19.8 6 18" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function MoonIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M21 14.2A7.8 7.8 0 0 1 9.8 3a7 7 0 1 0 11.2 11.2Z"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
- Default theme is now **dark** unless the user has explicitly saved "light" in localStorage.
- Theme toggle button is now a small round icon button (moon/sun) instead of the Light/Dark text pill.

Implementation notes
- `layout.tsx` preload script now sets theme to dark by default (prevents flash).
- `ThemeToggle` defaults to dark and writes `ck-theme` as before.
