### PR TITLE
docs: clarify plugins.load.paths is local dev only

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Edit your OpenClaw config (`~/.openclaw/openclaw.json`) and add:
 ```json5
 {
   "plugins": {
+    // Local developers only
     "load": {
       "paths": ["/home/control/clawkitchen"]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawkitchen",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawkitchen",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "openclaw": {
-    "extensions": ["./openclaw/index.ts"]
+    "extensions": [
+      "./openclaw/index.ts"
+    ]
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Adds a  comment above the example  entry in README.