### PR TITLE
docs: add npm install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ ClawKitchen can be loaded as an OpenClaw plugin so it runs locally on the orches
 
 **Recommended (end users):** install the published plugin package (ships with a prebuilt `.next/` so you don’t run any npm commands).
 
+```bash
+openclaw plugins install @jiggai/kitchen
+
+# If you use a plugin allowlist (plugins.allow), you must explicitly trust it:
+openclaw config get plugins.allow --json
+# then add "kitchen" and set it back, e.g.
+openclaw config set plugins.allow --json '["memory-core","telegram","recipes","kitchen"]'
+```
+
 **Developer/testing:** you can also load it directly from a local repo path via `plugins.load.paths`.
 
 Edit your OpenClaw config (`~/.openclaw/openclaw.json`) and add:


### PR DESCRIPTION
Adds an explicit Downloading @jiggai/kitchen…
Extracting /tmp/openclaw-npm-pack-AWpPlw/jiggai-kitchen-0.1.1.tgz…
WARNING: Plugin "kitchen" contains dangerous code patterns: Environment variable access combined with network send — possible credential harvesting (/tmp/openclaw-plugin-Zgr2nN/extract/package/src/lib/gateway.ts:32); Shell command execution detected (child_process) (/tmp/openclaw-plugin-Zgr2nN/extract/package/src/lib/openclaw.ts:14); Environment variable access combined with network send — possible credential harvesting (/tmp/openclaw-plugin-Zgr2nN/extract/package/src/app/api/agents/add/route.ts:35)
Installing to /home/control/.openclaw/extensions/kitchen…
Installing plugin dependencies…
Installed plugin: kitchen
Restart the gateway to load plugins. example under the end-user install section.