### PR TITLE
docs: remove local-dev load.paths instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,11 @@ ClawKitchen can be loaded as an OpenClaw plugin so it runs locally on the orches
 
 **Recommended (end users):** install the published plugin package (ships with a prebuilt `.next/` so you don’t run any npm commands).
 
-**Developer/testing:** you can also load it directly from a local repo path via `plugins.load.paths`.
-
 Edit your OpenClaw config (`~/.openclaw/openclaw.json`) and add:
 
 ```json5
 {
   "plugins": {
-    // Local developers only
-    "load": {
-      "paths": ["/home/control/clawkitchen"]
-    },
-
     // If you use plugins.allow, ensure kitchen is allowed.
     "allow": ["kitchen", "recipes"],
 


### PR DESCRIPTION
Removes the Developer/testing note and the  example from the README so the docs focus on installing the published package.