### PR TITLE
fix: publish prebuilt Next production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,17 @@
     "next.config.ts",
     "public/",
     "src/",
-    ".next/standalone/",
-    ".next/static/"
+
+    ".next/BUILD_ID",
+    ".next/server/",
+    ".next/static/",
+    ".next/required-server-files.json",
+    ".next/required-server-files.js",
+    ".next/routes-manifest.json",
+    ".next/prerender-manifest.json",
+    ".next/build-manifest.json",
+    ".next/app-path-routes-manifest.json",
+    ".next/package.json"
   ],
   "dependencies": {
     "next": "16.1.6",


### PR DESCRIPTION
Fixes npm-installed Kitchen failing to start with: 'Could not find a production build in the .next directory'.

Changes package.json  to include the required .next production build artifacts (BUILD_ID, server, static, required-server-files*, manifests).

Verified 
> @jiggai/kitchen@0.1.1 prepack
> npm run build


> @jiggai/kitchen@0.1.1 build
> next build

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 4.1s
  Running TypeScript ...
  Collecting page data using 7 workers ...
  Generating static pages using 7 workers (0/41) ...
  Generating static pages using 7 workers (10/41) 
  Generating static pages using 7 workers (20/41) 
  Generating static pages using 7 workers (30/41) 
✓ Generating static pages using 7 workers (41/41) in 2.3s
  Finalizing page optimization ...

Route (app)
┌ ƒ /
├ ○ /_not-found
├ ƒ /agents/[agentId]
├ ƒ /api/agents
├ ƒ /api/agents/[id]
├ ƒ /api/agents/add
├ ƒ /api/agents/file
├ ƒ /api/agents/files
├ ƒ /api/agents/identity
├ ƒ /api/agents/skills
├ ƒ /api/agents/skills/install
├ ƒ /api/agents/update
├ ƒ /api/channels/bindings
├ ƒ /api/cron/delete
├ ƒ /api/cron/job
├ ƒ /api/cron/jobs
├ ƒ /api/cron/recipe-installed
├ ƒ /api/gateway/restart
├ ƒ /api/goals
├ ƒ /api/goals/[id]
├ ƒ /api/goals/[id]/promote
├ ƒ /api/ids/check
├ ƒ /api/marketplace/recipes
├ ƒ /api/marketplace/recipes/[slug]
├ ƒ /api/recipes
├ ƒ /api/recipes/[id]
├ ƒ /api/recipes/clone
├ ƒ /api/recipes/delete
├ ƒ /api/recipes/team-agents
├ ƒ /api/scaffold
├ ƒ /api/settings/cron-installation
├ ƒ /api/skills/available
├ ƒ /api/teams/file
├ ƒ /api/teams/files
├ ƒ /api/teams/meta
├ ƒ /api/teams/remove-team
├ ƒ /api/teams/skills
├ ƒ /api/teams/skills/install
├ ƒ /api/tickets/move
├ ○ /channels
├ ○ /cron-jobs
├ ○ /goals
├ ƒ /goals/[id]
├ ○ /goals/new
├ ○ /recipes
├ ƒ /recipes/[id]
├ ○ /settings
├ ƒ /teams/[teamId]
├ ○ /tickets
└ ƒ /tickets/[ticket]


ƒ Proxy (Middleware)

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand

jiggai-kitchen-0.1.1.tgz contains package/.next/BUILD_ID + package/.next/server + package/.next/static.