### PR TITLE
chore(release): bump @jiggai/kitchen to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.1.1",
+  "version": "0.1.5",
   "private": false,
   "openclaw": {
     "extensions": [
@@ -22,7 +22,6 @@
     "next.config.ts",
     "public/",
     "src/",
-
     ".next/BUILD_ID",
     ".next/server/",
     ".next/static/",


### PR DESCRIPTION
Aligns main with the version bump needed for publish after PR #66, without the multiple local bump commits.