### PR TITLE
Team agents: delete role dir; install skills at team scope; show team skills

### DIFF
--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -1,12 +1,26 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { NextResponse } from "next/server";
 
 import { runOpenClaw } from "@/lib/openclaw";
+import { parseTeamRoleWorkspace } from "@/lib/agent-workspace";
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const agentId = String(id ?? "").trim();
     if (!agentId) return NextResponse.json({ ok: false, error: "agent id is required" }, { status: 400 });
+
+    // Resolve workspace BEFORE deleting (after deletion it may disappear from list).
+    let workspace: string | null = null;
+    try {
+      const { stdout } = await runOpenClaw(["agents", "list", "--json"]);
+      const list = JSON.parse(stdout) as Array<{ id: string; workspace?: string }>;
+      const agent = list.find((a) => a.id === agentId);
+      workspace = agent?.workspace ? String(agent.workspace) : null;
+    } catch {
+      workspace = null;
+    }
 
     const result = await runOpenClaw(["agents", "delete", agentId, "--force", "--json"]);
     if (!result.ok) {
@@ -26,6 +40,29 @@ export async function DELETE(_req: Request, { params }: { params: Promise<{ id: 
       parsed = JSON.parse(result.stdout);
     } catch {
       parsed = null;
+    }
+
+    // If this was a team role agent, also remove its role directory.
+    // Safer than rm: move to a team-local .trash folder.
+    if (workspace) {
+      const info = parseTeamRoleWorkspace(workspace);
+      if (info.kind === "teamRole") {
+        const trashDir = path.join(info.teamDir, ".trash", "roles");
+        const ts = new Date().toISOString().replace(/[:.]/g, "-");
+        const dst = path.join(trashDir, `${info.role}-${ts}`);
+        try {
+          await fs.mkdir(trashDir, { recursive: true });
+          // Only move if the dir exists.
+          await fs.rename(info.roleDir, dst);
+        } catch {
+          // If rename fails (cross-device / missing), fall back to best-effort recursive removal.
+          try {
+            await fs.rm(info.roleDir, { recursive: true, force: true });
+          } catch {
+            // ignore
+          }
+        }
+      }
     }
 
     return NextResponse.json({ ok: true, result: parsed ?? result.stdout });

--- a/src/app/api/agents/files/route.ts
+++ b/src/app/api/agents/files/route.ts
@@ -26,11 +26,13 @@ export async function GET(req: Request) {
 
   // Required vs optional classification to avoid "missing" noise.
   const candidates: Array<{ name: string; required: boolean; rationale: string }> = [
-    { name: "IDENTITY.md", required: true, rationale: "Identity (name/emoji/avatar)" },
     { name: "SOUL.md", required: true, rationale: "Agent persona/instructions" },
     { name: "AGENTS.md", required: true, rationale: "Agent operating rules" },
     { name: "TOOLS.md", required: true, rationale: "Agent local notes" },
 
+    { name: "STATUS.md", required: false, rationale: "Optional current status snapshot" },
+    { name: "NOTES.md", required: false, rationale: "Optional scratchpad" },
+    { name: "IDENTITY.md", required: false, rationale: "Optional identity (name/emoji/avatar)" },
     { name: "USER.md", required: false, rationale: "Optional user profile" },
     { name: "HEARTBEAT.md", required: false, rationale: "Optional periodic checklist" },
   ];

--- a/src/app/api/agents/skills/route.ts
+++ b/src/app/api/agents/skills/route.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { NextResponse } from "next/server";
 import { runOpenClaw } from "@/lib/openclaw";
+import { parseTeamRoleWorkspace } from "@/lib/agent-workspace";
 
 type AgentListItem = { id: string; workspace?: string };
 
@@ -19,17 +20,32 @@ export async function GET(req: Request) {
   if (!agentId) return NextResponse.json({ ok: false, error: "agentId is required" }, { status: 400 });
 
   const ws = await resolveAgentWorkspace(agentId);
-  const skillsDir = path.join(ws, "skills");
 
-  try {
-    const entries = await fs.readdir(skillsDir, { withFileTypes: true });
-    const skills = entries
-      .filter((e) => e.isDirectory())
-      .map((e) => e.name)
-      .sort((a, b) => a.localeCompare(b));
-
-    return NextResponse.json({ ok: true, agentId, workspace: ws, skillsDir, skills });
-  } catch (e: unknown) {
-    return NextResponse.json({ ok: true, agentId, workspace: ws, skillsDir, skills: [], note: e instanceof Error ? e.message : String(e) });
+  const info = parseTeamRoleWorkspace(ws);
+  const dirs: string[] = [path.join(ws, "skills")];
+  if (info.kind === "teamRole") {
+    // If skills were installed at the team scope, surface them for the role agent too.
+    dirs.push(path.join(info.teamDir, "skills"));
   }
+
+  const skills = new Set<string>();
+  const notes: string[] = [];
+
+  for (const skillsDir of dirs) {
+    try {
+      const entries = await fs.readdir(skillsDir, { withFileTypes: true });
+      for (const e of entries) if (e.isDirectory()) skills.add(e.name);
+    } catch (e: unknown) {
+      notes.push(`${skillsDir}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    agentId,
+    workspace: ws,
+    skillsDirs: dirs,
+    skills: Array.from(skills).sort((a, b) => a.localeCompare(b)),
+    note: notes.length ? notes.join("; ") : undefined,
+  });
 }

--- a/src/lib/agent-workspace.ts
+++ b/src/lib/agent-workspace.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+
+export function parseTeamRoleWorkspace(ws: string):
+  | { kind: "teamRole"; teamDir: string; teamId: string; roleDir: string; role: string }
+  | { kind: "other" } {
+  const normalized = ws.replace(/\\/g, "/");
+  const m = normalized.match(/^(.*\/workspace-([^\/]+))\/roles\/([^\/]+)\/?$/);
+  if (!m) return { kind: "other" };
+  const teamDir = m[1];
+  const teamId = m[2];
+  const role = m[3];
+  const roleDir = path.join(teamDir, "roles", role);
+  return { kind: "teamRole", teamDir, teamId, roleDir, role };
+}


### PR DESCRIPTION
## Problems\n1) Deleting a team agent left its roles/<role>/ workspace folder behind.\n2) Installing a skill for a team role agent didn’t show up in the Skills list.\n3) Installing a skill for a team role agent created a new workspace-<agentId> (wrong scope).\n\n## Fix\n- Detect team role workspaces (workspace-<teamId>/roles/<role>).\n- On agent delete: move roles/<role> into workspace-<teamId>/.trash/roles/<role>-<ts> (best-effort).\n- On skill install: for team role agents, install via --team-id <teamId> to avoid creating workspace-<agentId>.\n- Skills list now unions roleDir/skills + teamDir/skills for team role agents.\n\n## Notes\n- Lint + build pass.