### PR TITLE
Skills install: surface ClawHub npx instructions

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "kitchen",
   "name": "ClawKitchen",
   "description": "Local UI for managing OpenClaw recipes, teams, agents, cron jobs, and skills.",
-  "version": "0.1.0",
+  "version": "0.1.6",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "clawkitchen",
-  "version": "0.1.1",
+  "name": "@jiggai/kitchen",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "clawkitchen",
-      "version": "0.1.1",
+      "name": "@jiggai/kitchen",
+      "version": "0.1.5",
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": false,
   "openclaw": {
     "extensions": [

--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -109,7 +109,7 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
   const [agentFiles, setAgentFiles] = useState<Array<FileEntry & { required?: boolean; rationale?: string }>>([]);
   const [agentFilesLoading, setAgentFilesLoading] = useState(false);
   const [showOptionalFiles, setShowOptionalFiles] = useState(false);
-  const [fileName, setFileName] = useState<string>("IDENTITY.md");
+  const [fileName, setFileName] = useState<string>("SOUL.md");
   const [fileContent, setFileContent] = useState<string>("");
 
   const teamId = agentId.includes("-") ? agentId.split("-").slice(0, -1).join("-") : "";

--- a/src/app/api/agents/skills/install/route.ts
+++ b/src/app/api/agents/skills/install/route.ts
@@ -28,8 +28,16 @@ export async function POST(req: Request) {
 
   const res = await runOpenClaw(args);
   if (!res.ok) {
+    const stdout = res.stdout?.trim();
+    const stderr = res.stderr?.trim();
     return NextResponse.json(
-      { ok: false, error: res.stderr.trim() || `openclaw ${args.join(" ")} failed (exit=${res.exitCode})`, stdout: res.stdout, stderr: res.stderr },
+      {
+        ok: false,
+        error: stderr || stdout || `openclaw ${args.join(" ")} failed (exit=${res.exitCode})`,
+        stdout: res.stdout,
+        stderr: res.stderr,
+        scopeArgs: args,
+      },
       { status: 500 },
     );
   }

--- a/src/app/api/teams/skills/install/route.ts
+++ b/src/app/api/teams/skills/install/route.ts
@@ -12,10 +12,12 @@ export async function POST(req: Request) {
   const args = ["recipes", "install-skill", skill, "--team-id", teamId, "--yes"];
   const res = await runOpenClaw(args);
   if (!res.ok) {
+    const stdout = res.stdout?.trim();
+    const stderr = res.stderr?.trim();
     return NextResponse.json(
       {
         ok: false,
-        error: res.stderr.trim() || `openclaw ${args.join(" ")} failed (exit=${res.exitCode})`,
+        error: stderr || stdout || `openclaw ${args.join(" ")} failed (exit=${res.exitCode})`,
         stdout: res.stdout,
         stderr: res.stderr,
       },


### PR DESCRIPTION
## Problem\nWhen  requires the ClawHub CLI, it prints the exact  command to STDOUT and exits non-zero. Kitchen’s API was only surfacing STDERR, so the UI showed a generic failure and hid the actionable instructions.\n\n## Fix\n- On error, set  to stderr OR stdout (whichever is present), so the UI shows the real install command.\n- Applied to both agent-skill install and team-skill install endpoints.\n\n## Test\n- lint + build