### PR TITLE
ClawKitchen: Orchestrator tab for teams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jiggai/kitchen",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": false,
   "openclaw": {
     "extensions": [

--- a/src/app/api/teams/orchestrator/route.ts
+++ b/src/app/api/teams/orchestrator/route.ts
@@ -1,0 +1,218 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+
+import { runOpenClaw } from "@/lib/openclaw";
+import { getKitchenApi } from "@/lib/kitchen-api";
+
+type AgentListItem = {
+  id: string;
+  identityName?: string;
+  workspace?: string;
+};
+
+type TmuxSession = {
+  name: string;
+  attached: boolean;
+  windows?: number;
+  created?: string;
+};
+
+type GitWorktree = {
+  path: string;
+  branch?: string;
+  sha?: string;
+};
+
+async function listAgents(): Promise<AgentListItem[]> {
+  const res = await runOpenClaw(["agents", "list", "--json"]);
+  if (!res.ok) throw new Error(res.stderr || "Failed to list agents");
+  return JSON.parse(res.stdout) as AgentListItem[];
+}
+
+function pickOrchestratorAgentId(teamId: string, agents: AgentListItem[]) {
+  const candidates = [
+    `${teamId}-swarm-orchestrator`,
+    `${teamId}-orchestrator`,
+    "swarm-orchestrator",
+    "orchestrator",
+  ];
+
+  for (const id of candidates) {
+    const match = agents.find((a) => a.id === id);
+    if (match) return match;
+  }
+
+  // Heuristic fallback: any agent id containing "orchestrator" whose workspace path mentions the teamId.
+  const heuristic = agents.find((a) => {
+    const id = String(a.id ?? "");
+    const ws = String(a.workspace ?? "");
+    return id.includes("orchestrator") && (ws.includes(`/workspace-${teamId}`) || ws.includes(teamId));
+  });
+  return heuristic ?? null;
+}
+
+async function runCommand(argv: string[], timeoutMs = 8000) {
+  const api = getKitchenApi();
+  const res = (await api.runtime.system.runCommandWithTimeout(argv, { timeoutMs })) as {
+    stdout?: unknown;
+    stderr?: unknown;
+  };
+  return { stdout: String(res.stdout ?? ""), stderr: String(res.stderr ?? "") };
+}
+
+function parseTmuxList(stdout: string): TmuxSession[] {
+  const lines = stdout
+    .split("\n")
+    .map((l) => l.trimEnd())
+    .filter(Boolean);
+
+  // Expected format:
+  // name\tattached\twindows\tcreated
+  return lines.map((line) => {
+    const [name, attached, windows, created] = line.split("\t");
+    return {
+      name: String(name ?? "").trim(),
+      attached: String(attached ?? "0").trim() === "1",
+      windows: windows ? Number(windows) : undefined,
+      created: created ? String(created) : undefined,
+    };
+  });
+}
+
+function parseWorktreePorcelain(stdout: string): GitWorktree[] {
+  // `git worktree list --porcelain` is a list of blocks separated by blank lines.
+  const blocks = stdout
+    .split(/\n\s*\n/g)
+    .map((b) => b.trim())
+    .filter(Boolean);
+
+  return blocks
+    .map((block) => {
+      const wt: GitWorktree = { path: "" };
+      for (const rawLine of block.split("\n")) {
+        const line = rawLine.trim();
+        if (line.startsWith("worktree ")) wt.path = line.slice("worktree ".length).trim();
+        else if (line.startsWith("HEAD ")) wt.sha = line.slice("HEAD ".length).trim();
+        else if (line.startsWith("branch ")) wt.branch = line.slice("branch ".length).trim();
+      }
+      return wt.path ? wt : null;
+    })
+    .filter((x): x is GitWorktree => Boolean(x));
+}
+
+async function firstExistingJsonFile(absCandidates: string[]) {
+  for (const p of absCandidates) {
+    try {
+      const stat = await fs.stat(p);
+      if (stat.isFile()) return p;
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const teamId = String(searchParams.get("teamId") ?? "").trim();
+  if (!teamId) return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
+
+  try {
+    const agents = await listAgents();
+    const match = pickOrchestratorAgentId(teamId, agents);
+
+    if (!match || !match.workspace) {
+      return NextResponse.json({
+        ok: true,
+        teamId,
+        present: false,
+        reason:
+          "No orchestrator agent detected. Expected an agent id like <teamId>-swarm-orchestrator (or swarm-orchestrator).",
+      });
+    }
+
+    const workspace = match.workspace;
+
+    // tmux sessions (best-effort)
+    let tmuxSessions: TmuxSession[] = [];
+    try {
+      const { stdout } = await runCommand([
+        "tmux",
+        "ls",
+        "-F",
+        "#S\t#{session_attached}\t#{session_windows}\t#{session_created_string}",
+      ]);
+      tmuxSessions = parseTmuxList(stdout);
+    } catch {
+      tmuxSessions = [];
+    }
+
+    // git worktrees (best-effort)
+    let worktrees: GitWorktree[] = [];
+    try {
+      const { stdout } = await runCommand(["git", "-C", workspace, "worktree", "list", "--porcelain"], 12000);
+      worktrees = parseWorktreePorcelain(stdout);
+    } catch {
+      worktrees = [];
+    }
+
+    // active tasks (best-effort)
+    const activeTasksPath = await firstExistingJsonFile([
+      path.join(workspace, "active-tasks.json"),
+      path.join(workspace, ".clawdbot", "active-tasks.json"),
+      path.join(workspace, "notes", "active-tasks.json"),
+    ]);
+
+    let activeTasksSummary: { path: string; taskCount?: number; rawType?: string } | null = null;
+    if (activeTasksPath) {
+      try {
+        const raw = await fs.readFile(activeTasksPath, "utf8");
+        const parsed = JSON.parse(raw) as unknown;
+        if (Array.isArray(parsed)) {
+          activeTasksSummary = { path: activeTasksPath, taskCount: parsed.length, rawType: "array" };
+        } else if (parsed && typeof parsed === "object") {
+          const obj = parsed as { tasks?: unknown };
+          const tasks = Array.isArray(obj.tasks) ? obj.tasks : null;
+          activeTasksSummary = {
+            path: activeTasksPath,
+            taskCount: tasks ? tasks.length : undefined,
+            rawType: "object",
+          };
+        } else {
+          activeTasksSummary = { path: activeTasksPath, rawType: typeof parsed };
+        }
+      } catch {
+        activeTasksSummary = { path: activeTasksPath };
+      }
+    }
+
+    const settingsPaths = [
+      path.join(workspace, ".env"),
+      path.join(workspace, ".clawdbot", "README.md"),
+      path.join(workspace, ".clawdbot", "CONVENTIONS.md"),
+      path.join(workspace, ".clawdbot", "PROMPT_TEMPLATE.md"),
+      path.join(workspace, ".clawdbot", "TEMPLATE.md"),
+    ];
+
+    return NextResponse.json({
+      ok: true,
+      teamId,
+      present: true,
+      agent: {
+        id: match.id,
+        identityName: match.identityName,
+        workspace,
+      },
+      tmuxSessions,
+      worktrees,
+      activeTasksSummary,
+      settingsPaths,
+    });
+  } catch (e: unknown) {
+    return NextResponse.json(
+      { ok: false, error: e instanceof Error ? e.message : String(e) },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/teams/[teamId]/OrchestratorPanel.tsx
+++ b/src/app/teams/[teamId]/OrchestratorPanel.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type OrchestratorState =
+  | {
+      ok: true;
+      teamId: string;
+      present: false;
+      reason?: string;
+    }
+  | {
+      ok: true;
+      teamId: string;
+      present: true;
+      agent: { id: string; identityName?: string; workspace: string };
+      tmuxSessions: Array<{ name: string; attached: boolean; windows?: number; created?: string }>;
+      worktrees: Array<{ path: string; branch?: string; sha?: string }>;
+      activeTasksSummary: null | { path: string; taskCount?: number; rawType?: string };
+      settingsPaths: string[];
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export function OrchestratorPanel({ teamId }: { teamId: string }) {
+  const [loading, setLoading] = useState(true);
+  const [state, setState] = useState<OrchestratorState | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/teams/orchestrator?teamId=${encodeURIComponent(teamId)}`, { cache: "no-store" });
+        const json = (await res.json()) as OrchestratorState;
+        setState(json);
+      } catch (e: unknown) {
+        setState({ ok: false, error: e instanceof Error ? e.message : String(e) });
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [teamId]);
+
+  if (loading) {
+    return <div className="mt-6 ck-glass-strong p-4">Loading orchestrator state…</div>;
+  }
+
+  if (!state) {
+    return <div className="mt-6 ck-glass-strong p-4">No orchestrator state available.</div>;
+  }
+
+  if (!state.ok) {
+    return (
+      <div className="mt-6 ck-glass-strong p-4">
+        <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Orchestrator</div>
+        <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">
+          {state.error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!state.present) {
+    return (
+      <div className="mt-6 ck-glass-strong p-4">
+        <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Orchestrator</div>
+        <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+          No swarm/orchestrator detected for this team.
+        </p>
+        <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-sm text-[color:var(--ck-text-secondary)]">
+          <div className="text-xs font-medium text-[color:var(--ck-text-tertiary)]">Detection</div>
+          <div className="mt-1 font-mono text-xs">{state.reason || "(no reason provided)"}</div>
+        </div>
+        <p className="mt-3 text-sm text-[color:var(--ck-text-secondary)]">
+          Once an orchestrator agent is installed (e.g. <code>&lt;teamId&gt;-swarm-orchestrator</code>), this tab will show:
+          tmux sessions, git worktrees/branches, and active task state.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-6 ck-glass-strong p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Orchestrator</div>
+          <div className="mt-1 text-xs text-[color:var(--ck-text-secondary)]">
+            Agent: <span className="font-mono">{state.agent.id}</span>
+            {state.agent.identityName ? ` (${state.agent.identityName})` : ""}
+          </div>
+          <div className="mt-1 text-xs text-[color:var(--ck-text-secondary)]">
+            Workspace: <span className="font-mono">{state.agent.workspace}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <section className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3">
+          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">tmux sessions</div>
+          {state.tmuxSessions.length ? (
+            <ul className="mt-2 space-y-2">
+              {state.tmuxSessions.map((s) => (
+                <li key={s.name} className="text-sm text-[color:var(--ck-text-secondary)]">
+                  <span className="font-mono">{s.name}</span>
+                  <span className="ml-2 text-xs text-[color:var(--ck-text-tertiary)]">
+                    attached={String(s.attached)}
+                    {typeof s.windows === "number" ? ` windows=${s.windows}` : ""}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">No sessions detected (or tmux not running).</div>
+          )}
+        </section>
+
+        <section className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3">
+          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">git worktrees</div>
+          {state.worktrees.length ? (
+            <ul className="mt-2 space-y-2">
+              {state.worktrees.map((w) => (
+                <li key={w.path} className="text-sm text-[color:var(--ck-text-secondary)]">
+                  <div className="font-mono text-xs">{w.path}</div>
+                  <div className="text-xs text-[color:var(--ck-text-tertiary)]">
+                    {w.branch ? w.branch : "(no branch)"}
+                    {w.sha ? ` @ ${w.sha.slice(0, 7)}` : ""}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">No worktrees detected.</div>
+          )}
+        </section>
+      </div>
+
+      <section className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3">
+        <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Active tasks</div>
+        {state.activeTasksSummary ? (
+          <div className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+            <div className="font-mono text-xs">{state.activeTasksSummary.path}</div>
+            <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+              {typeof state.activeTasksSummary.taskCount === "number" ? `tasks=${state.activeTasksSummary.taskCount}` : "tasks=?"}
+              {state.activeTasksSummary.rawType ? ` type=${state.activeTasksSummary.rawType}` : ""}
+            </div>
+          </div>
+        ) : (
+          <div className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">No active-tasks.json found.</div>
+        )}
+      </section>
+
+      <section className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3">
+        <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Where to change settings</div>
+        <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+          These are the common knobs for a swarm/orchestrator scaffold (read-only references):
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-[color:var(--ck-text-secondary)]">
+          {state.settingsPaths.map((p) => (
+            <li key={p} className="font-mono text-xs">
+              {p}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { DeleteTeamModal } from "./DeleteTeamModal";
 import { PublishChangesModal } from "./PublishChangesModal";
 import { useToast } from "@/components/ToastProvider";
+import { OrchestratorPanel } from "./OrchestratorPanel";
 
 type RecipeListItem = {
   id: string;
@@ -107,7 +108,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
   const [toName, setToName] = useState<string>(teamId);
   const [content, setContent] = useState<string>("");
   const [loadedRecipeHash, setLoadedRecipeHash] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<"recipe" | "agents" | "skills" | "cron" | "files">("recipe");
+  const [activeTab, setActiveTab] = useState<"recipe" | "agents" | "skills" | "cron" | "files" | "orchestrator">("recipe");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
@@ -515,6 +516,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
             { id: "skills", label: "Skills" },
             { id: "cron", label: "Cron" },
             { id: "files", label: "Files" },
+            { id: "orchestrator", label: "Orchestrator" },
           ] as const
         ).map((t) => (
           <button
@@ -1091,6 +1093,8 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
           </div>
         </div>
       ) : null}
+
+      {activeTab === "orchestrator" ? <OrchestratorPanel teamId={teamId} /> : null}
 
       {/* markdown editor lives below for convenience */}
       {activeTab === "recipe" ? (


### PR DESCRIPTION
Implements initial Orchestrator surfacing for teams (ticket #0083).

- Adds an **Orchestrator** tab on the Team page.
- Adds  to detect an orchestrator agent and return read-only state:
  - tmux sessions (best-effort)
  - git worktrees (best-effort)
  - active-tasks.json summary (best-effort)
  - common settings/conventions paths
- Shows a clear empty state when no orchestrator is detected.

Checks:
- 
> @jiggai/kitchen@0.1.9 lint
> eslint ✅
- 
> @jiggai/kitchen@0.1.9 build
> next build

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 4.0s
  Running TypeScript ...
  Collecting page data using 7 workers ...
  Generating static pages using 7 workers (0/40) ...
  Generating static pages using 7 workers (10/40) 
  Generating static pages using 7 workers (20/40) 
  Generating static pages using 7 workers (30/40) 
✓ Generating static pages using 7 workers (40/40) in 134.8ms
  Finalizing page optimization ...

Route (app)
┌ ƒ /
├ ○ /_not-found
├ ƒ /agents/[agentId]
├ ƒ /api/agents
├ ƒ /api/agents/[id]
├ ƒ /api/agents/add
├ ƒ /api/agents/file
├ ƒ /api/agents/files
├ ƒ /api/agents/identity
├ ƒ /api/agents/skills
├ ƒ /api/agents/skills/install
├ ƒ /api/agents/update
├ ƒ /api/channels/bindings
├ ƒ /api/cron/delete
├ ƒ /api/cron/job
├ ƒ /api/cron/jobs
├ ƒ /api/cron/recipe-installed
├ ƒ /api/gateway/restart
├ ƒ /api/goals
├ ƒ /api/goals/[id]
├ ƒ /api/goals/[id]/promote
├ ƒ /api/ids/check
├ ƒ /api/marketplace/recipes
├ ƒ /api/marketplace/recipes/[slug]
├ ƒ /api/recipes
├ ƒ /api/recipes/[id]
├ ƒ /api/recipes/clone
├ ƒ /api/recipes/delete
├ ƒ /api/recipes/team-agents
├ ƒ /api/scaffold
├ ƒ /api/settings/cron-installation
├ ƒ /api/skills/available
├ ƒ /api/teams/file
├ ƒ /api/teams/files
├ ƒ /api/teams/meta
├ ƒ /api/teams/orchestrator
├ ƒ /api/teams/remove-team
├ ƒ /api/teams/skills
├ ƒ /api/teams/skills/install
├ ƒ /api/tickets/move
├ ○ /channels
├ ○ /cron-jobs
├ ○ /goals
├ ƒ /goals/[id]
├ ○ /goals/new
├ ƒ /recipes
├ ƒ /recipes/[id]
├ ○ /settings
├ ƒ /teams/[teamId]
├ ƒ /tickets
└ ƒ /tickets/[ticket]


ƒ Proxy (Middleware)

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand


> @jiggai/kitchen@0.1.9 postbuild
> node scripts/copy-standalone-static.mjs

[postbuild] Copied Next static assets:
- from: /home/control/clawkitchen/.next/static
- to:   /home/control/clawkitchen/.next/standalone/.next/static ✅