### PR TITLE
#0092 Swarm UX: Kitchen invokes CLI runner

### DIFF
--- a/src/app/api/swarms/start/route.ts
+++ b/src/app/api/swarms/start/route.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { NextResponse } from "next/server";
+
+import { getKitchenApi } from "@/lib/kitchen-api";
+
+function normalizeId(kind: string, id: string) {
+  const s = String(id ?? "").trim();
+  if (!s) throw new Error(`${kind} is required`);
+  if (!/^[a-z0-9][a-z0-9-]{0,62}$/i.test(s)) {
+    throw new Error(`${kind} must match /^[a-z0-9][a-z0-9-]{0,62}$/i`);
+  }
+  return s;
+}
+
+async function resolveOrchestratorWorkspace(orchestratorAgentId: string) {
+  const cfgPath = path.join(os.homedir(), ".openclaw", "openclaw.json");
+  const raw = await fs.readFile(cfgPath, "utf8");
+  const cfg = JSON.parse(raw) as { agents?: { defaults?: { workspace?: string } } };
+
+  const baseWorkspace = String(cfg?.agents?.defaults?.workspace ?? "").trim();
+  if (!baseWorkspace) throw new Error("agents.defaults.workspace not set");
+
+  // convention: ~/.openclaw/workspace-<id>
+  return path.resolve(baseWorkspace, "..", `workspace-${orchestratorAgentId}`);
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as {
+      orchestratorAgentId?: string;
+      agentId?: string; // compat
+      taskId?: string;
+      spec?: string;
+      specFile?: string;
+      baseRef?: string;
+      branch?: string;
+      tmuxSession?: string;
+      agent?: "codex" | "claude";
+      model?: string;
+      reasoning?: "low" | "medium" | "high";
+      timeoutMs?: number;
+    };
+
+    const orchestratorAgentId = normalizeId("orchestratorAgentId", String(body.orchestratorAgentId ?? body.agentId ?? ""));
+    const taskId = normalizeId("taskId", String(body.taskId ?? ""));
+
+    const spec = typeof body.spec === "string" ? body.spec : "";
+    const specFile = typeof body.specFile === "string" ? body.specFile : "";
+    if (!!spec === !!specFile) {
+      throw new Error("Provide exactly one of spec or specFile");
+    }
+
+    const orchestratorWs = await resolveOrchestratorWorkspace(orchestratorAgentId);
+    const cliPath = path.join(orchestratorWs, ".clawdbot", "task.sh");
+
+    // Prefer spec-file to avoid shell quoting surprises.
+    let effectiveSpecFile = specFile;
+    let tmpToCleanup: string | null = null;
+
+    if (spec) {
+      const tmp = path.join(os.tmpdir(), `clawkitchen-swarm-${taskId}-${Date.now()}.md`);
+      await fs.writeFile(tmp, spec, "utf8");
+      effectiveSpecFile = tmp;
+      tmpToCleanup = tmp;
+    }
+
+    // Basic existence checks for actionable errors.
+    await fs.access(cliPath);
+
+    const timeoutMs = Number.isFinite(body.timeoutMs) ? Number(body.timeoutMs) : 120000;
+
+    const args: string[] = [
+      "bash",
+      cliPath,
+      "start",
+      "--task-id",
+      taskId,
+      "--spec-file",
+      effectiveSpecFile,
+    ];
+
+    if (typeof body.baseRef === "string" && body.baseRef.trim()) {
+      args.push("--base-ref", body.baseRef.trim());
+    }
+    if (typeof body.branch === "string" && body.branch.trim()) {
+      args.push("--branch", body.branch.trim());
+    }
+    if (typeof body.tmuxSession === "string" && body.tmuxSession.trim()) {
+      args.push("--tmux-session", body.tmuxSession.trim());
+    }
+    if (typeof body.agent === "string" && body.agent.trim()) {
+      args.push("--agent", body.agent.trim());
+    }
+    if (typeof body.model === "string" && body.model.trim()) {
+      args.push("--model", body.model.trim());
+    }
+    if (typeof body.reasoning === "string" && body.reasoning.trim()) {
+      args.push("--reasoning", body.reasoning.trim());
+    }
+
+    const api = getKitchenApi();
+    const res = await api.runtime.system.runCommandWithTimeout(args, { timeoutMs });
+
+    // best-effort tmp cleanup
+    if (tmpToCleanup) {
+      void fs.unlink(tmpToCleanup).catch(() => {});
+    }
+
+    return NextResponse.json({ ok: true, orchestratorWorkspace: orchestratorWs, stdout: res.stdout, stderr: res.stderr });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const status = /required|match \//i.test(msg) ? 400 : 500;
+    return NextResponse.json({ ok: false, error: msg }, { status });
+  }
+}

--- a/src/app/api/swarms/status/route.ts
+++ b/src/app/api/swarms/status/route.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { NextResponse } from "next/server";
+
+import { getKitchenApi } from "@/lib/kitchen-api";
+
+function normalizeId(kind: string, id: string) {
+  const s = String(id ?? "").trim();
+  if (!s) throw new Error(`${kind} is required`);
+  if (!/^[a-z0-9][a-z0-9-]{0,62}$/i.test(s)) {
+    throw new Error(`${kind} must match /^[a-z0-9][a-z0-9-]{0,62}$/i`);
+  }
+  return s;
+}
+
+async function resolveOrchestratorWorkspace(orchestratorAgentId: string) {
+  const cfgPath = path.join(os.homedir(), ".openclaw", "openclaw.json");
+  const raw = await fs.readFile(cfgPath, "utf8");
+  const cfg = JSON.parse(raw) as { agents?: { defaults?: { workspace?: string } } };
+
+  const baseWorkspace = String(cfg?.agents?.defaults?.workspace ?? "").trim();
+  if (!baseWorkspace) throw new Error("agents.defaults.workspace not set");
+
+  return path.resolve(baseWorkspace, "..", `workspace-${orchestratorAgentId}`);
+}
+
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url);
+    const orchestratorAgentId = normalizeId(
+      "orchestratorAgentId",
+      url.searchParams.get("orchestratorAgentId") || url.searchParams.get("agentId") || "",
+    );
+
+    const orchestratorWs = await resolveOrchestratorWorkspace(orchestratorAgentId);
+    const cliPath = path.join(orchestratorWs, ".clawdbot", "task.sh");
+    await fs.access(cliPath);
+
+    const api = getKitchenApi();
+    const res = await api.runtime.system.runCommandWithTimeout(["bash", cliPath, "status"], { timeoutMs: 30000 });
+
+    return NextResponse.json({ ok: true, orchestratorWorkspace: orchestratorWs, stdout: res.stdout, stderr: res.stderr });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const status = /required|match \//i.test(msg) ? 400 : 500;
+    return NextResponse.json({ ok: false, error: msg }, { status });
+  }
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -12,7 +12,6 @@ export default function GlobalError({
   reset: () => void;
 }) {
   useEffect(() => {
-    // eslint-disable-next-line no-console
     console.error("Global error:", error);
   }, [error]);
 

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-/* eslint-disable @next/next/no-html-link-for-pages */
-
 import { useEffect } from "react";
 
 // NOTE: Next.js renders this when the root layout (or anything above the segment
-// error boundary) throws. Keep it dependency-light: no AppShell / no router
-// hooks (usePathname etc.), because those contexts may be unavailable.
+// error boundary) throws. Keep it dependency-light: no AppShell / no router hooks.
 export default function GlobalError({
   error,
   reset,
@@ -15,53 +12,39 @@ export default function GlobalError({
   reset: () => void;
 }) {
   useEffect(() => {
+    // eslint-disable-next-line no-console
     console.error("Global error:", error);
   }, [error]);
 
   return (
     <html lang="en">
-      <body style={{ padding: 24, fontFamily: "ui-sans-serif, system-ui" }}>
-        <h1 style={{ fontSize: 18, fontWeight: 700, marginBottom: 8 }}>
-          Something went wrong
-        </h1>
-        <p style={{ marginBottom: 16, opacity: 0.8 }}>
-          The app hit an unexpected error. You can try reloading.
-        </p>
+      <body className="min-h-screen bg-[color:var(--ck-bg)] text-[color:var(--ck-text-primary)]">
+        <div className="mx-auto max-w-2xl px-6 py-16">
+          <h1 className="text-xl font-semibold">Something went wrong</h1>
+          <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+            An unexpected error occurred.
+          </p>
 
-        <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
-          <button
-            onClick={() => reset()}
-            style={{
-              padding: "8px 12px",
-              borderRadius: 8,
-              border: "1px solid rgba(0,0,0,0.2)",
-            }}
-          >
-            Try again
-          </button>
-          <a
-            href="/"
-            style={{
-              padding: "8px 12px",
-              borderRadius: 8,
-              border: "1px solid rgba(0,0,0,0.2)",
-              textDecoration: "none",
-              color: "inherit",
-            }}
-          >
-            Home
-          </a>
-        </div>
+          <pre className="mt-6 overflow-auto rounded-md border border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] p-4 text-xs text-[color:var(--ck-text-secondary)]">
+            {String(error?.stack || error)}
+          </pre>
 
-        <details style={{ whiteSpace: "pre-wrap" }}>
-          <summary style={{ cursor: "pointer" }}>Details</summary>
-          <pre style={{ marginTop: 12 }}>{String(error?.stack || error)}</pre>
           {error?.digest ? (
-            <p style={{ marginTop: 12, opacity: 0.8 }}>
+            <p className="mt-3 text-xs text-[color:var(--ck-text-secondary)]">
               Digest: {error.digest}
             </p>
           ) : null}
-        </details>
+
+          <div className="mt-6 flex gap-3">
+            <button
+              type="button"
+              onClick={() => reset()}
+              className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-4 py-2 text-sm font-medium text-white"
+            >
+              Try again
+            </button>
+          </div>
+        </div>
       </body>
     </html>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-12">
+      <h1 className="text-xl font-semibold">Page not found</h1>
+      <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">The page you requested does not exist.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds Kitchen callsites for the CLI-first swarm runner (ticket #0092).

What changed
- Adds API routes:
  - `POST /api/swarms/start`
  - `GET /api/swarms/status`
- Uses `api.runtime.system.runCommandWithTimeout` to invoke the orchestrator workspace script:
  - `bash <workspace-<orchestratorAgentId>>/.clawdbot/task.sh start|status ...`
- Writes `spec` to a temp file and passes `--spec-file` (avoid quoting issues).

Why
- Keeps swarm UX CLI-first and avoids install-time warnings by not using `child_process`.

How to test
- Configure/identify an `orchestratorAgentId` that maps to `workspace-<id>`.
- Call `POST /api/swarms/start` with `{ orchestratorAgentId, taskId, spec }`.
- Confirm the orchestrator workspace gets:
  - `.clawdbot/tasks/<taskId>.md`
  - `.clawdbot/active-tasks.json`
- Call `GET /api/swarms/status?orchestratorAgentId=...`.

Ticket: #0092
Depends on: JIGGAI/ClawRecipes PR #67
