### PR TITLE
#0093: Full-screen AppShell layout for team routes

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -98,7 +98,7 @@ export default function HomeClient({
   }, [agents, teamFilter, teamNames]);
 
   return (
-    <div className="ck-glass mx-auto max-w-5xl p-6 sm:p-8">
+    <div className="ck-glass w-full p-6 sm:p-8">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h1 className="text-3xl font-semibold tracking-tight">

--- a/src/app/cron-jobs/page.tsx
+++ b/src/app/cron-jobs/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 export default function CronJobsPage() {
   return (
-    <div className="ck-glass mx-auto max-w-5xl p-6 sm:p-8">
+    <div className="ck-glass w-full p-6 sm:p-8">
       <div className="flex items-baseline justify-between gap-4">
         <h1 className="text-2xl font-semibold tracking-tight">Cron Jobs (recipe-installed)</h1>
         <div className="flex gap-3">

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -57,7 +57,7 @@ export default async function RecipesPage() {
   const customAgentRecipes = workspace.filter((r) => r.kind === "agent");
 
   return (
-    <div className="ck-glass mx-auto max-w-4xl p-6 sm:p-8">
+    <div className="ck-glass w-full p-6 sm:p-8">
       <div className="flex items-baseline justify-between gap-4">
         <h1 className="text-2xl font-semibold tracking-tight">Recipes</h1>
         <Link

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,7 +2,7 @@ import SettingsClient from "./settings-client";
 
 export default function SettingsPage() {
   return (
-    <div className="ck-glass mx-auto max-w-3xl p-6 sm:p-8">
+    <div className="ck-glass w-full p-6 sm:p-8">
       <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
       <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
         Configuration that affects scaffold behavior and automation.

--- a/src/app/teams/[teamId]/page.tsx
+++ b/src/app/teams/[teamId]/page.tsx
@@ -27,13 +27,18 @@ async function getTeamDisplayName(teamId: string) {
 
 export default async function TeamPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ teamId: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   // Team pages depend on live OpenClaw state; never serve cached HTML.
   noStore();
 
   const { teamId } = await params;
+  const sp = (await searchParams) ?? {};
+  const tabRaw = sp.tab;
+  const tab = Array.isArray(tabRaw) ? tabRaw[0] : tabRaw;
   const name = await getTeamDisplayName(teamId);
 
   return (
@@ -56,7 +61,7 @@ export default async function TeamPage({
         </div>
       </div>
 
-      <TeamEditor teamId={teamId} />
+      <TeamEditor teamId={teamId} initialTab={typeof tab === "string" ? tab : undefined} />
     </div>
   );
 }

--- a/src/app/teams/[teamId]/page.tsx
+++ b/src/app/teams/[teamId]/page.tsx
@@ -25,7 +25,11 @@ async function getTeamDisplayName(teamId: string) {
   }
 }
 
-export default async function TeamPage({ params }: { params: Promise<{ teamId: string }> }) {
+export default async function TeamPage({
+  params,
+}: {
+  params: Promise<{ teamId: string }>;
+}) {
   // Team pages depend on live OpenClaw state; never serve cached HTML.
   noStore();
 
@@ -33,36 +37,23 @@ export default async function TeamPage({ params }: { params: Promise<{ teamId: s
   const name = await getTeamDisplayName(teamId);
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4 p-6">
       <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="flex flex-col gap-1">
-          <Link
-            href="/"
-            className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
-          >
-            ← Home
-          </Link>
-          <Link
-            href="/recipes"
-            className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
-          >
-            ← Recipes
-          </Link>
-        </div>
-
-        <div className="text-right">
-          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">{name || teamId}</div>
+        <div>
+          <div className="text-xl font-semibold tracking-tight text-[color:var(--ck-text-primary)]">
+            {name || teamId}
+          </div>
           <div className="text-xs text-[color:var(--ck-text-tertiary)]">{teamId}</div>
         </div>
-      </div>
 
-      <div className="flex items-center justify-end">
-        <Link
-          href={`/goals?team=${encodeURIComponent(teamId)}`}
-          className="text-sm font-medium text-[color:var(--ck-text-secondary)] hover:underline"
-        >
-          View goals for this team →
-        </Link>
+        <div className="flex items-center gap-3">
+          <Link
+            href={`/goals?team=${encodeURIComponent(teamId)}`}
+            className="text-sm font-medium text-[color:var(--ck-text-secondary)] hover:underline"
+          >
+            View goals →
+          </Link>
+        </div>
       </div>
 
       <TeamEditor teamId={teamId} />

--- a/src/app/teams/[teamId]/page.tsx
+++ b/src/app/teams/[teamId]/page.tsx
@@ -33,8 +33,8 @@ export default async function TeamPage({ params }: { params: Promise<{ teamId: s
   const name = await getTeamDisplayName(teamId);
 
   return (
-    <main className="min-h-screen p-8">
-      <div className="mx-auto mb-4 flex max-w-6xl items-start justify-between gap-4">
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="flex flex-col gap-1">
           <Link
             href="/"
@@ -56,7 +56,7 @@ export default async function TeamPage({ params }: { params: Promise<{ teamId: s
         </div>
       </div>
 
-      <div className="mx-auto mb-4 flex max-w-6xl items-center justify-end">
+      <div className="flex items-center justify-end">
         <Link
           href={`/goals?team=${encodeURIComponent(teamId)}`}
           className="text-sm font-medium text-[color:var(--ck-text-secondary)] hover:underline"
@@ -66,6 +66,6 @@ export default async function TeamPage({ params }: { params: Promise<{ teamId: s
       </div>
 
       <TeamEditor teamId={teamId} />
-    </main>
+    </div>
   );
 }

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -658,10 +658,10 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
   }
 
   // Initial load only gates the minimal state (recipes + team meta). Everything else streams in.
-  if (loading) return <div className="ck-glass mx-auto max-w-4xl p-6">Loading…</div>;
+  if (loading) return <div className="ck-glass w-full p-6">Loading…</div>;
 
   return (
-    <div className="ck-glass p-6 sm:p-8">
+    <div className="ck-glass w-full p-6 sm:p-8">
       <h1 className="text-2xl font-semibold tracking-tight">Team editor</h1>
       <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
         Bootstrap a <strong>custom team recipe</strong> for this installed team, without modifying builtin recipes.

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -99,7 +99,7 @@ function forceFrontmatterTeamTeamId(md: string, teamId: string) {
   return `---\n${next.join("\n")}\n---\n${body}`;
 }
 
-export default function TeamEditor({ teamId }: { teamId: string }) {
+export default function TeamEditor({ teamId, initialTab }: { teamId: string; initialTab?: string }) {
   const router = useRouter();
   const [recipes, setRecipes] = useState<RecipeListItem[]>([]);
   const [fromId, setFromId] = useState<string>("");
@@ -111,6 +111,14 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
   const [content, setContent] = useState<string>("");
   const [loadedRecipeHash, setLoadedRecipeHash] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<"recipe" | "agents" | "skills" | "cron" | "workflows" | "files" | "orchestrator">("recipe");
+
+  useEffect(() => {
+    const allowed = ["recipe", "agents", "skills", "cron", "workflows", "files", "orchestrator"] as const;
+    if (initialTab && (allowed as readonly string[]).includes(initialTab)) {
+      setActiveTab(initialTab as (typeof allowed)[number]);
+    }
+  }, [initialTab]);
+
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
@@ -667,6 +675,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
         Bootstrap a <strong>custom team recipe</strong> for this installed team, without modifying builtin recipes.
       </p>
 
+
       <div className="mt-6 flex flex-wrap gap-2">
         {(
           [
@@ -681,7 +690,14 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
         ).map((t) => (
           <button
             key={t.id}
-            onClick={() => setActiveTab(t.id)}
+            onClick={() => {
+              setActiveTab(t.id);
+              try {
+                router.replace(`/teams/${encodeURIComponent(teamId)}?tab=${encodeURIComponent(t.id)}`, { scroll: false });
+              } catch {
+                // ignore
+              }
+            }}
             className={
               activeTab === t.id
                 ? "rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)]"

--- a/src/app/teams/[teamId]/team-editor.tsx
+++ b/src/app/teams/[teamId]/team-editor.tsx
@@ -661,7 +661,7 @@ export default function TeamEditor({ teamId }: { teamId: string }) {
   if (loading) return <div className="ck-glass mx-auto max-w-4xl p-6">Loading…</div>;
 
   return (
-    <div className="ck-glass mx-auto max-w-6xl p-6 sm:p-8">
+    <div className="ck-glass p-6 sm:p-8">
       <h1 className="text-2xl font-semibold tracking-tight">Team editor</h1>
       <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
         Bootstrap a <strong>custom team recipe</strong> for this installed team, without modifying builtin recipes.

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -234,8 +234,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           </div>
 
           <nav className="min-h-0 flex-1 overflow-auto p-2">
-            <div className={collapsed ? "mt-2 px-2 pb-2 pt-2 text-center text-[10px] font-semibold uppercase tracking-wide text-[color:var(--ck-text-tertiary)]" : "mt-2 px-2 pb-2 pt-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--ck-text-tertiary)]"}>
-              Global
+            <div className={collapsed ? "mt-2 px-2 pb-2 pt-2" : "mt-2 px-2 pb-2 pt-2"}>
+              {/* section label intentionally omitted */}
             </div>
             {globalNav.map((it) => (
               <SideNavLink

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -9,7 +9,7 @@ import { ToastProvider } from "@/components/ToastProvider";
 function Icon({ children }: { children: React.ReactNode }) {
   return (
     <span
-      className="grid size-5 place-items-center text-[color:var(--ck-text-secondary)]"
+      className="grid size-6 place-items-center text-[color:var(--ck-text-secondary)]"
       aria-hidden
     >
       {children}
@@ -36,8 +36,8 @@ function SideNavLink({
       title={label}
       className={
         active
-          ? "flex items-center gap-3 rounded-[var(--ck-radius-sm)] bg-white/10 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)]"
-          : "flex items-center gap-3 rounded-[var(--ck-radius-sm)] px-3 py-2 text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-white/5 hover:text-[color:var(--ck-text-primary)]"
+          ? "flex items-center gap-4 rounded-[var(--ck-radius-sm)] bg-white/10 px-4 py-3 text-sm font-medium text-[color:var(--ck-text-primary)]"
+          : "flex items-center gap-4 rounded-[var(--ck-radius-sm)] px-4 py-3 text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-white/5 hover:text-[color:var(--ck-text-primary)]"
       }
     >
       <span className={collapsed ? "mx-auto" : ""}>{icon}</span>
@@ -81,11 +81,23 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     (async () => {
       try {
-        const res = await fetch("/api/recipes", { cache: "no-store" });
+        const res = await fetch("/api/agents", { cache: "no-store" });
         const json = await res.json();
-        const items = Array.isArray(json.recipes) ? (json.recipes as Array<{ id: string; kind: string }>) : [];
-        const teams = items.filter((r) => r.kind === "team").map((r) => r.id).sort();
-        setTeamIds(teams);
+        const agents = Array.isArray(json.agents)
+          ? (json.agents as Array<{ workspace?: string }> )
+          : [];
+
+        const s = new Set<string>();
+        for (const a of agents) {
+          const ws = String(a.workspace ?? "");
+          const parts = ws.split("/").filter(Boolean);
+          const wsPart = parts.find((p) => p.startsWith("workspace-")) ?? "";
+          if (!wsPart) continue;
+          const teamId = wsPart.slice("workspace-".length);
+          if (teamId && teamId !== "workspace") s.add(teamId);
+        }
+
+        setTeamIds(Array.from(s).sort());
       } catch {
         setTeamIds([]);
       }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,15 +1,37 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { ToastProvider } from "@/components/ToastProvider";
 
-function NavLink({ href, label }: { href: string; label: string }) {
+function TopNavLink({ href, label }: { href: string; label: string }) {
+  return (
+    <Link
+      href={href}
+      className="rounded-[var(--ck-radius-sm)] px-3 py-1.5 text-sm font-medium transition-colors text-[color:var(--ck-text-secondary)] hover:bg-[color:var(--ck-bg-glass)] hover:text-[color:var(--ck-text-primary)]"
+    >
+      {label}
+    </Link>
+  );
+}
+
+function SideNavLink({
+  href,
+  label,
+  active,
+}: {
+  href: string;
+  label: string;
+  active: boolean;
+}) {
   return (
     <Link
       href={href}
       className={
-        "rounded-[var(--ck-radius-sm)] px-3 py-1.5 text-sm font-medium transition-colors text-[color:var(--ck-text-secondary)] hover:bg-[color:var(--ck-bg-glass)] hover:text-[color:var(--ck-text-primary)]"
+        active
+          ? "rounded-[var(--ck-radius-sm)] bg-white/10 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)]"
+          : "rounded-[var(--ck-radius-sm)] px-3 py-2 text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-white/5 hover:text-[color:var(--ck-text-primary)]"
       }
     >
       {label}
@@ -18,77 +40,32 @@ function NavLink({ href, label }: { href: string; label: string }) {
 }
 
 export function AppShell({ children }: { children: React.ReactNode }) {
-  return (
-    <ToastProvider>
-      <div className="flex h-dvh w-dvw bg-[color:var(--ck-bg)] text-[color:var(--ck-text-primary)]">
-        {/* Left nav (teams-first) */}
-        <aside className="hidden w-64 shrink-0 border-r border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] backdrop-blur-[var(--ck-glass-blur)] md:flex md:flex-col">
-          <div className="flex items-center justify-between gap-3 border-b border-[color:var(--ck-border-subtle)] px-4 py-3">
-            <Link href="/" className="text-sm font-semibold tracking-tight">
-              Claw Kitchen
-            </Link>
-          </div>
+  const pathname = usePathname() || "/";
 
-          <nav className="flex flex-1 flex-col gap-1 overflow-y-auto px-3 py-3">
-            <div className="px-2 pt-2 pb-1 text-xs font-semibold uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">
-              Teams
-            </div>
-            <NavLink href="/" label="Home" />
-            <NavLink href="/goals" label="Goals" />
+  // Incremental rollout: only team routes use the full-screen left-nav shell for now.
+  const useLeftNavShell = pathname.startsWith("/teams/");
 
-            <div className="mt-4 px-2 pt-2 pb-1 text-xs font-semibold uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">
-              Build
-            </div>
-            <NavLink href="/recipes" label="Recipes" />
-            <NavLink href="/tickets" label="Tickets" />
-            <NavLink href="/cron-jobs" label="Cron jobs" />
-            <NavLink href="/settings" label="Settings" />
-          </nav>
-
-          <div className="flex items-center justify-between gap-2 border-t border-[color:var(--ck-border-subtle)] px-4 py-3">
-            <a
-              href="https://github.com/JIGGAI/ClawRecipes/tree/main/docs"
-              target="_blank"
-              rel="noreferrer"
-              className="rounded-[var(--ck-radius-sm)] px-2 py-1 text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-[color:var(--ck-bg-glass)] hover:text-[color:var(--ck-text-primary)]"
-            >
-              Docs
-            </a>
-            <ThemeToggle />
-          </div>
-        </aside>
-
-        {/* Main region */}
-        <div className="flex min-w-0 flex-1 flex-col">
-          {/* Top bar (mobile + global actions) */}
+  if (!useLeftNavShell) {
+    return (
+      <ToastProvider>
+        <div className="min-h-screen">
           <header className="sticky top-0 z-50 border-b border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] backdrop-blur-[var(--ck-glass-blur)]">
-            <div className="flex items-center justify-between gap-4 px-4 py-3">
-              <div className="flex items-center gap-3 md:hidden">
+            <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3">
+              <div className="flex items-center gap-3">
                 <Link href="/" className="text-sm font-semibold tracking-tight">
                   Claw Kitchen
                 </Link>
-                <nav className="flex items-center gap-1">
-                  <NavLink href="/" label="Home" />
-                  <NavLink href="/recipes" label="Recipes" />
-                  <NavLink href="/tickets" label="Tickets" />
+                <nav className="hidden items-center gap-1 sm:flex">
+                  <TopNavLink href="/recipes" label="Recipes" />
+                  <TopNavLink href="/tickets" label="Tickets" />
+                  <TopNavLink href="/goals" label="Goals" />
+                  {/* Channels hidden for release */}
+                  <TopNavLink href="/cron-jobs" label="Cron jobs" />
+                  <TopNavLink href="/settings" label="Settings" />
                 </nav>
               </div>
 
-              <div className="ml-auto flex items-center gap-2 md:hidden">
-                <a
-                  href="https://github.com/JIGGAI/ClawRecipes/tree/main/docs"
-                  target="_blank"
-                  rel="noreferrer"
-                  className="rounded-[var(--ck-radius-sm)] px-3 py-1.5 text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-[color:var(--ck-bg-glass)] hover:text-[color:var(--ck-text-primary)]"
-                >
-                  Docs
-                </a>
-                <ThemeToggle />
-              </div>
-
-              {/* Desktop top bar can stay minimal; left nav is primary */}
-              <div className="hidden md:flex md:flex-1" />
-              <div className="hidden items-center gap-2 md:flex">
+              <div className="flex items-center gap-2">
                 <a
                   href="https://github.com/JIGGAI/ClawRecipes/tree/main/docs"
                   target="_blank"
@@ -102,7 +79,61 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             </div>
           </header>
 
-          <main className="min-h-0 flex-1 overflow-auto p-4 md:p-6">{children}</main>
+          <main className="mx-auto max-w-6xl px-4 py-8">{children}</main>
+        </div>
+      </ToastProvider>
+    );
+  }
+
+  const sideItems = [
+    { href: "/recipes", label: "Recipes" },
+    { href: "/tickets", label: "Tickets" },
+    { href: "/goals", label: "Goals" },
+    { href: "/cron-jobs", label: "Cron jobs" },
+    { href: "/settings", label: "Settings" },
+  ];
+
+  return (
+    <ToastProvider>
+      <div className="h-dvh w-dvw overflow-hidden">
+        <div className="flex h-full">
+          <aside className="flex w-64 shrink-0 flex-col border-r border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] backdrop-blur-[var(--ck-glass-blur)]">
+            <div className="flex h-14 items-center justify-between gap-2 border-b border-[color:var(--ck-border-subtle)] px-4">
+              <Link href="/" className="text-sm font-semibold tracking-tight">
+                Claw Kitchen
+              </Link>
+              <ThemeToggle />
+            </div>
+
+            <nav className="flex min-h-0 flex-1 flex-col gap-1 overflow-auto p-2">
+              <div className="px-2 pb-1 pt-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">
+                Navigation
+              </div>
+              {sideItems.map((it) => (
+                <SideNavLink
+                  key={it.href}
+                  href={it.href}
+                  label={it.label}
+                  active={pathname === it.href || pathname.startsWith(it.href + "/")}
+                />
+              ))}
+            </nav>
+
+            <div className="border-t border-[color:var(--ck-border-subtle)] p-3">
+              <a
+                href="https://github.com/JIGGAI/ClawRecipes/tree/main/docs"
+                target="_blank"
+                rel="noreferrer"
+                className="block rounded-[var(--ck-radius-sm)] px-3 py-2 text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-white/5 hover:text-[color:var(--ck-text-primary)]"
+              >
+                Docs
+              </a>
+            </div>
+          </aside>
+
+          <div className="flex min-w-0 flex-1 flex-col">
+            <main className="min-h-0 flex-1 overflow-auto">{children}</main>
+          </div>
         </div>
       </div>
     </ToastProvider>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -35,12 +35,15 @@ function SideNavLink({
       href={href}
       title={label}
       className={
-        active
-          ? "flex items-center gap-4 rounded-[var(--ck-radius-sm)] bg-white/10 px-4 py-3 text-sm font-medium text-[color:var(--ck-text-primary)]"
-          : "flex items-center gap-4 rounded-[var(--ck-radius-sm)] px-4 py-3 text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-white/5 hover:text-[color:var(--ck-text-primary)]"
+        (
+          active
+            ? "flex items-center rounded-[var(--ck-radius-sm)] bg-white/10 text-sm font-medium text-[color:var(--ck-text-primary)]"
+            : "flex items-center rounded-[var(--ck-radius-sm)] text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-white/5 hover:text-[color:var(--ck-text-primary)]"
+        ) +
+        (collapsed ? " justify-center px-0 py-3" : " gap-4 px-4 py-3")
       }
     >
-      <span className={collapsed ? "mx-auto" : ""}>{icon}</span>
+      {icon}
       {collapsed ? null : <span>{label}</span>}
     </Link>
   );

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -6,6 +6,17 @@ import { useEffect, useMemo, useState } from "react";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { ToastProvider } from "@/components/ToastProvider";
 
+function Icon({ children }: { children: React.ReactNode }) {
+  return (
+    <span
+      className="grid size-5 place-items-center text-[color:var(--ck-text-secondary)]"
+      aria-hidden
+    >
+      {children}
+    </span>
+  );
+}
+
 function SideNavLink({
   href,
   label,
@@ -25,8 +36,8 @@ function SideNavLink({
       title={label}
       className={
         active
-          ? "flex items-center gap-2 rounded-[var(--ck-radius-sm)] bg-white/10 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)]"
-          : "flex items-center gap-2 rounded-[var(--ck-radius-sm)] px-3 py-2 text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-white/5 hover:text-[color:var(--ck-text-primary)]"
+          ? "flex items-center gap-3 rounded-[var(--ck-radius-sm)] bg-white/10 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)]"
+          : "flex items-center gap-3 rounded-[var(--ck-radius-sm)] px-3 py-2 text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-white/5 hover:text-[color:var(--ck-text-primary)]"
       }
     >
       <span className={collapsed ? "mx-auto" : ""}>{icon}</span>
@@ -81,27 +92,79 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     })();
   }, []);
 
-  const teamNav = currentTeamId
-    ? [
-        { href: `/teams/${encodeURIComponent(currentTeamId)}?tab=recipe`, label: "Overview", icon: "🏷️" },
-        { href: `/teams/${encodeURIComponent(currentTeamId)}?tab=workflows`, label: "Workflows", icon: "🗺️" },
-        { href: `/teams/${encodeURIComponent(currentTeamId)}?tab=agents`, label: "Agents", icon: "🧑‍🍳" },
-        { href: `/teams/${encodeURIComponent(currentTeamId)}?tab=files`, label: "Files", icon: "📁" },
-        { href: `/teams/${encodeURIComponent(currentTeamId)}?tab=skills`, label: "Skills", icon: "🧰" },
-        { href: `/teams/${encodeURIComponent(currentTeamId)}?tab=cron`, label: "Cron", icon: "⏱️" },
-        { href: `/teams/${encodeURIComponent(currentTeamId)}?tab=orchestrator`, label: "Orchestrator", icon: "🎛️" },
-        { href: `/tickets`, label: "Tickets", icon: "🧾" },
-        { href: `/goals?team=${encodeURIComponent(currentTeamId)}`, label: "Goals", icon: "🎯" },
-      ]
-    : [];
-
   const globalNav = [
-    { href: `/`, label: "Home", icon: "🏠" },
-    { href: `/recipes`, label: "Recipes", icon: "📜" },
-    { href: `/tickets`, label: "Tickets", icon: "🧾" },
-    { href: `/goals`, label: "Goals", icon: "🎯" },
-    { href: `/cron-jobs`, label: "Cron jobs", icon: "⏱️" },
-    { href: `/settings`, label: "Settings", icon: "⚙️" },
+    {
+      href: `/`,
+      label: "Home",
+      icon: (
+        <Icon>
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M3 11l9-8 9 8" />
+            <path d="M5 10v10h14V10" />
+          </svg>
+        </Icon>
+      ),
+    },
+    {
+      href: `/recipes`,
+      label: "Recipes",
+      icon: (
+        <Icon>
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M6 4h12v16H6z" />
+            <path d="M9 8h6" />
+            <path d="M9 12h6" />
+          </svg>
+        </Icon>
+      ),
+    },
+    {
+      href: `/tickets`,
+      label: "Tickets",
+      icon: (
+        <Icon>
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M4 7h16v4a2 2 0 0 1 0 4v4H4v-4a2 2 0 0 0 0-4z" />
+          </svg>
+        </Icon>
+      ),
+    },
+    {
+      href: `/goals`,
+      label: "Goals",
+      icon: (
+        <Icon>
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="9" />
+            <path d="M12 7v5l3 3" />
+          </svg>
+        </Icon>
+      ),
+    },
+    {
+      href: `/cron-jobs`,
+      label: "Cron jobs",
+      icon: (
+        <Icon>
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="9" />
+            <path d="M12 7v5" />
+          </svg>
+        </Icon>
+      ),
+    },
+    {
+      href: `/settings`,
+      label: "Settings",
+      icon: (
+        <Icon>
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z" />
+            <path d="M19.4 15a7.9 7.9 0 0 0 .1-1l2-1.5-2-3.5-2.4.5a7.8 7.8 0 0 0-1.7-1L13.5 3h-4L8.6 6.5a7.8 7.8 0 0 0-1.7 1L4.5 7l-2 3.5 2 1.5a7.9 7.9 0 0 0 .1 1l-2 1.5 2 3.5 2.4-.5a7.8 7.8 0 0 0 1.7 1L10.5 21h4l.9-3.5a7.8 7.8 0 0 0 1.7-1l2.4.5 2-3.5-2-1.5Z" />
+          </svg>
+        </Icon>
+      ),
+    },
   ];
 
   const sideWidth = collapsed ? "w-16" : "w-72";
@@ -159,25 +222,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           </div>
 
           <nav className="min-h-0 flex-1 overflow-auto p-2">
-            {currentTeamId ? (
-              <>
-                <div className={collapsed ? "px-2 pb-2 pt-2 text-center text-[10px] font-semibold uppercase tracking-wide text-[color:var(--ck-text-tertiary)]" : "px-2 pb-2 pt-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--ck-text-tertiary)]"}>
-                  Team
-                </div>
-                {teamNav.map((it) => (
-                  <SideNavLink
-                    key={it.href}
-                    href={it.href}
-                    label={it.label}
-                    icon={<span aria-hidden>{it.icon}</span>}
-                    collapsed={collapsed}
-                    active={pathname.startsWith(`/teams/${encodeURIComponent(currentTeamId)}`) && it.href.includes("tab=") ? it.href.includes("tab=") : pathname === it.href}
-                  />
-                ))}
-              </>
-            ) : null}
-
-            <div className={collapsed ? "mt-4 px-2 pb-2 pt-2 text-center text-[10px] font-semibold uppercase tracking-wide text-[color:var(--ck-text-tertiary)]" : "mt-4 px-2 pb-2 pt-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--ck-text-tertiary)]"}>
+            <div className={collapsed ? "mt-2 px-2 pb-2 pt-2 text-center text-[10px] font-semibold uppercase tracking-wide text-[color:var(--ck-text-tertiary)]" : "mt-2 px-2 pb-2 pt-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--ck-text-tertiary)]"}>
               Global
             </div>
             {globalNav.map((it) => (

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -9,7 +9,7 @@ import { ToastProvider } from "@/components/ToastProvider";
 function Icon({ children }: { children: React.ReactNode }) {
   return (
     <span
-      className="grid size-6 place-items-center text-[color:var(--ck-text-secondary)]"
+      className="grid size-7 place-items-center text-[color:var(--ck-text-secondary)]"
       aria-hidden
     >
       {children}
@@ -110,7 +110,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       label: "Home",
       icon: (
         <Icon>
-          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+          <svg viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2">
             <path d="M3 11l9-8 9 8" />
             <path d="M5 10v10h14V10" />
           </svg>
@@ -122,7 +122,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       label: "Recipes",
       icon: (
         <Icon>
-          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+          <svg viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2">
             <path d="M6 4h12v16H6z" />
             <path d="M9 8h6" />
             <path d="M9 12h6" />
@@ -135,7 +135,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       label: "Tickets",
       icon: (
         <Icon>
-          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+          <svg viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2">
             <path d="M4 7h16v4a2 2 0 0 1 0 4v4H4v-4a2 2 0 0 0 0-4z" />
           </svg>
         </Icon>
@@ -146,7 +146,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       label: "Goals",
       icon: (
         <Icon>
-          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+          <svg viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2">
             <circle cx="12" cy="12" r="9" />
             <path d="M12 7v5l3 3" />
           </svg>
@@ -158,7 +158,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       label: "Cron jobs",
       icon: (
         <Icon>
-          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+          <svg viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2">
             <circle cx="12" cy="12" r="9" />
             <path d="M12 7v5" />
           </svg>
@@ -170,7 +170,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       label: "Settings",
       icon: (
         <Icon>
-          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+          <svg viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2">
             <path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z" />
             <path d="M19.4 15a7.9 7.9 0 0 0 .1-1l2-1.5-2-3.5-2.4.5a7.8 7.8 0 0 0-1.7-1L13.5 3h-4L8.6 6.5a7.8 7.8 0 0 0-1.7 1L4.5 7l-2 3.5 2 1.5a7.9 7.9 0 0 0 .1 1l-2 1.5 2 3.5 2.4-.5a7.8 7.8 0 0 0 1.7 1L10.5 21h4l.9-3.5a7.8 7.8 0 0 0 1.7-1l2.4.5 2-3.5-2-1.5Z" />
           </svg>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -20,39 +20,91 @@ function NavLink({ href, label }: { href: string; label: string }) {
 export function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <ToastProvider>
-      <div className="min-h-screen">
-      <header className="sticky top-0 z-50 border-b border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] backdrop-blur-[var(--ck-glass-blur)]">
-        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3">
-          <div className="flex items-center gap-3">
+      <div className="flex h-dvh w-dvw bg-[color:var(--ck-bg)] text-[color:var(--ck-text-primary)]">
+        {/* Left nav (teams-first) */}
+        <aside className="hidden w-64 shrink-0 border-r border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] backdrop-blur-[var(--ck-glass-blur)] md:flex md:flex-col">
+          <div className="flex items-center justify-between gap-3 border-b border-[color:var(--ck-border-subtle)] px-4 py-3">
             <Link href="/" className="text-sm font-semibold tracking-tight">
               Claw Kitchen
             </Link>
-            <nav className="hidden items-center gap-1 sm:flex">
-              <NavLink href="/recipes" label="Recipes" />
-              <NavLink href="/tickets" label="Tickets" />
-              <NavLink href="/goals" label="Goals" />
-              {/* Channels hidden for release */}
-              <NavLink href="/cron-jobs" label="Cron jobs" />
-              <NavLink href="/settings" label="Settings" />
-            </nav>
           </div>
 
-          <div className="flex items-center gap-2">
+          <nav className="flex flex-1 flex-col gap-1 overflow-y-auto px-3 py-3">
+            <div className="px-2 pt-2 pb-1 text-xs font-semibold uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">
+              Teams
+            </div>
+            <NavLink href="/" label="Home" />
+            <NavLink href="/goals" label="Goals" />
+
+            <div className="mt-4 px-2 pt-2 pb-1 text-xs font-semibold uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">
+              Build
+            </div>
+            <NavLink href="/recipes" label="Recipes" />
+            <NavLink href="/tickets" label="Tickets" />
+            <NavLink href="/cron-jobs" label="Cron jobs" />
+            <NavLink href="/settings" label="Settings" />
+          </nav>
+
+          <div className="flex items-center justify-between gap-2 border-t border-[color:var(--ck-border-subtle)] px-4 py-3">
             <a
               href="https://github.com/JIGGAI/ClawRecipes/tree/main/docs"
               target="_blank"
               rel="noreferrer"
-              className="rounded-[var(--ck-radius-sm)] px-3 py-1.5 text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-[color:var(--ck-bg-glass)] hover:text-[color:var(--ck-text-primary)]"
+              className="rounded-[var(--ck-radius-sm)] px-2 py-1 text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-[color:var(--ck-bg-glass)] hover:text-[color:var(--ck-text-primary)]"
             >
               Docs
             </a>
             <ThemeToggle />
           </div>
-        </div>
-      </header>
+        </aside>
 
-      <main className="mx-auto max-w-6xl px-4 py-8">{children}</main>
-    </div>
+        {/* Main region */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          {/* Top bar (mobile + global actions) */}
+          <header className="sticky top-0 z-50 border-b border-[color:var(--ck-border-subtle)] bg-[color:var(--ck-bg-glass)] backdrop-blur-[var(--ck-glass-blur)]">
+            <div className="flex items-center justify-between gap-4 px-4 py-3">
+              <div className="flex items-center gap-3 md:hidden">
+                <Link href="/" className="text-sm font-semibold tracking-tight">
+                  Claw Kitchen
+                </Link>
+                <nav className="flex items-center gap-1">
+                  <NavLink href="/" label="Home" />
+                  <NavLink href="/recipes" label="Recipes" />
+                  <NavLink href="/tickets" label="Tickets" />
+                </nav>
+              </div>
+
+              <div className="ml-auto flex items-center gap-2 md:hidden">
+                <a
+                  href="https://github.com/JIGGAI/ClawRecipes/tree/main/docs"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="rounded-[var(--ck-radius-sm)] px-3 py-1.5 text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-[color:var(--ck-bg-glass)] hover:text-[color:var(--ck-text-primary)]"
+                >
+                  Docs
+                </a>
+                <ThemeToggle />
+              </div>
+
+              {/* Desktop top bar can stay minimal; left nav is primary */}
+              <div className="hidden md:flex md:flex-1" />
+              <div className="hidden items-center gap-2 md:flex">
+                <a
+                  href="https://github.com/JIGGAI/ClawRecipes/tree/main/docs"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="rounded-[var(--ck-radius-sm)] px-3 py-1.5 text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:bg-[color:var(--ck-bg-glass)] hover:text-[color:var(--ck-text-primary)]"
+                >
+                  Docs
+                </a>
+                <ThemeToggle />
+              </div>
+            </div>
+          </header>
+
+          <main className="min-h-0 flex-1 overflow-auto p-4 md:p-6">{children}</main>
+        </div>
+      </div>
     </ToastProvider>
   );
 }


### PR DESCRIPTION
Implements ticket #0093 foundation: full-viewport AppShell (left nav + scrolling main content) for /teams/* routes, and removes max-width constraints so the Team editor + Workflows canvas can go full-bleed.\n\nWhat changed\n- AppShell: for /teams/* routes, render a 100dvh/100dvw left-nav shell with main content overflow scrolling.\n- Team page: uses the shell (no nested <main>), adds a light header + goals link.\n- TeamEditor: no mx-auto/max-w wrappers (w-full), so workflows canvas/editor can size to the available main area.\n\nVerification\n- ClawKitchen: npm run lint && npm run build (PASS).\n- Manual: visit a team page and confirm left nav appears; scroll inside main; open Workflows tab and ensure canvas uses full available width.\n\nNotes\n- Incremental rollout: only /teams/* uses left-nav shell for now to minimize risk.\n