### PR TITLE
ci: publish canary builds per PR

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,0 +1,72 @@
+name: Publish Canary (PR)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: canary-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Publish canary tag for PR
+    runs-on: ubuntu-latest
+
+    # Don't publish from forks.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Bump prerelease version (no git tag)
+        run: npm version prerelease --preid canary --no-git-tag-version
+
+      - name: Publish to npm (tag = canary-<pr>)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          TAG="canary-${{ github.event.pull_request.number }}"
+          npm publish --tag "$TAG"
+
+      - name: Comment install command
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const tag = `canary-${pr.number}`;
+            const pkg = '@jiggai/kitchen';
+            const body = [
+              '✅ Published npm canary build for this PR.',
+              '',
+              `Install: \`npm i ${pkg}@${tag}\``,
+              '',
+              'Note: `@canary` is not used here so multiple PR canaries can coexist.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });

--- a/src/app/teams/[teamId]/OrchestratorPanel.tsx
+++ b/src/app/teams/[teamId]/OrchestratorPanel.tsx
@@ -175,6 +175,42 @@ export function OrchestratorPanel({ teamId }: { teamId: string }) {
       </section>
 
       <section className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3">
+        <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">CLI quick actions</div>
+        <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+          The orchestrator is designed to be driven from the CLI (and usually tmux). Common commands:
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-[color:var(--ck-text-secondary)]">
+          <li>
+            <span className="font-mono text-xs">tmux ls</span>
+            <span className="ml-2 text-xs text-[color:var(--ck-text-tertiary)]">(list sessions)</span>
+          </li>
+          <li>
+            <span className="font-mono text-xs">tmux attach -t &lt;session&gt;</span>
+            <span className="ml-2 text-xs text-[color:var(--ck-text-tertiary)]">(jump into a running swarm)</span>
+          </li>
+          <li>
+            <span className="font-mono text-xs">git -C {state.agent.workspace} worktree list</span>
+            <span className="ml-2 text-xs text-[color:var(--ck-text-tertiary)]">(inspect worktrees)</span>
+          </li>
+        </ul>
+        <p className="mt-3 text-xs text-[color:var(--ck-text-tertiary)]">
+          Note: ClawKitchen is read-only here; it surfaces status and pointers, but does not run or attach to tmux.
+        </p>
+      </section>
+
+      <section className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3">
+        <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Human approval gate (recommended)</div>
+        <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+          For workflows that publish, deploy, or send outbound messages, keep a <strong>human approval step</strong>.
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-[color:var(--ck-text-secondary)]">
+          <li>Generate a proposed change/post as a draft.</li>
+          <li>Send the draft to a bound messaging channel (e.g. Telegram) for approval.</li>
+          <li>Only execute the final action after explicit approve/deny.</li>
+        </ul>
+      </section>
+
+      <section className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3">
         <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Where to change settings</div>
         <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
           These are the common knobs for a swarm/orchestrator scaffold (read-only references):


### PR DESCRIPTION
Adds a GitHub Actions workflow that publishes @jiggai/kitchen canary builds on PRs as dist-tags like canary-<PR#>, and comments the install command. Requires repo secret NPM_TOKEN.