### PR TITLE
ci: fix canary republish by using unique version per run

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -40,8 +40,17 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Bump prerelease version (no git tag)
-        run: npm version prerelease --preid canary --no-git-tag-version
+      - name: Bump prerelease version (unique per run; no git tag)
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          # npm forbids republishing the same version.
+          # github.run_attempt only changes on re-runs of the same workflow run; a new run starts at attempt=1.
+          # So include run_number (monotonic per repo) to guarantee uniqueness across runs.
+          PREID="canary.${PR_NUMBER}.${RUN_NUMBER}.${RUN_ATTEMPT}"
+          npm version prerelease --preid "$PREID" --no-git-tag-version
 
       - name: Publish to npm (tag = canary-<pr>)
         env:


### PR DESCRIPTION
Fix E403 canary publish retries: npm forbids republishing the same version. Use PR + github.run_number + github.run_attempt in prerelease preid so every run publishes a unique semver, while keeping dist-tag stable as canary-<PR#>.