### PR TITLE
fix: ticket status dropdown moves tickets + confirm

### DIFF
--- a/src/app/api/tickets/move/route.ts
+++ b/src/app/api/tickets/move/route.ts
@@ -1,6 +1,33 @@
+import fs from "node:fs/promises";
+
 import { NextResponse } from "next/server";
 
 import { runOpenClaw } from "@/lib/openclaw";
+import { getTicketMarkdown } from "@/lib/tickets";
+
+function todayUtc() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function appendDoneAuditComment(ticketIdOrNumber: string) {
+  const hit = await getTicketMarkdown(ticketIdOrNumber);
+  if (!hit) return;
+
+  const line = `- ${todayUtc()} (ClawKitchen UI): Marked done from ClawKitchen UI.`;
+  if (hit.markdown.includes(line)) return;
+
+  const hasComments = /\n## Comments\n/i.test(hit.markdown) || /^## Comments\n/im.test(hit.markdown);
+
+  let next = hit.markdown;
+  if (!hasComments) {
+    next = next.replace(/\s*$/, "\n\n## Comments\n");
+  }
+
+  // Append at end; this keeps the operation simple and avoids brittle section parsing.
+  next = next.replace(/\s*$/, "\n" + line + "\n");
+
+  await fs.writeFile(hit.file, next, "utf8");
+}
 
 export async function POST(req: Request) {
   try {
@@ -29,6 +56,10 @@ export async function POST(req: Request) {
 
     const res = await runOpenClaw(args);
     if (!res.ok) throw new Error(res.stderr || `openclaw exit ${res.exitCode}`);
+
+    if (to === "done") {
+      await appendDoneAuditComment(ticket);
+    }
 
     return NextResponse.json({ ok: true });
   } catch (err: unknown) {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -58,14 +58,18 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     return m ? decodeURIComponent(m[1]) : null;
   }, [pathname]);
 
-  const [collapsed, setCollapsed] = useState(() => {
+  const [collapsed, setCollapsed] = useState(false);
+
+  // Avoid hydration mismatch: render un-collapsed on the server, then sync from localStorage after mount.
+  useEffect(() => {
     try {
       const v = localStorage.getItem("ck-leftnav-collapsed");
-      return v === "1";
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setCollapsed(v === "1");
     } catch {
-      return false;
+      // ignore
     }
-  });
+  }, []);
 
   function toggleCollapsed() {
     setCollapsed((v) => {


### PR DESCRIPTION
Implements ticket status dropdown as an on-disk move action.

Changes:
- Adds confirmation modal when moving ticket status (esp. Done).
- Updates /api/tickets/move to delegate moves to  so assignment stubs are archived consistently.
- When moving to done via UI, appends audit comment: 

Verification:
- In Kitchen UI, pick a backlog ticket; change status to Done; confirm modal.
- Verify ticket file moved to work/done/ and no longer appears in work selection.
- Verify audit comment appended; assignment stub archived.

Ticket: 0103