### PR TITLE
fix(kitchen): default dev mode to false for stable routing

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -40,7 +40,9 @@ async function startKitchen(api: OpenClawPluginApi, cfg: KitchenConfig) {
 
   const host = String(cfg.host || "127.0.0.1").trim();
   const port = Number(cfg.port || 7777);
-  const dev = cfg.dev !== false;
+  // Default to production/stable mode unless explicitly enabled.
+  // Dev mode (turbopack) can transiently 404 routes until compilation finishes.
+  const dev = cfg.dev === true;
   const authToken = String(cfg.authToken || "");
 
   if (!isLocalhost(host) && !authToken.trim()) {


### PR DESCRIPTION
Fixes a footgun in the Kitchen plugin: we were defaulting to dev/turbopack mode when cfg.dev was omitted (const dev = cfg.dev !== false).\n\nDev mode can transiently 404 non-root routes on cold loads until compilation finishes, which breaks deep-link refreshes (reported during #0094 QA).\n\nChange:\n- Default to production/stable mode unless explicitly enabled: const dev = cfg.dev === true\n\nVerification:\n- npm run lint (PASS)\n- npm run build (PASS)\n\nFollow-up:\n- After merge, set plugins.entries.kitchen.config.dev=false in gateway config for stability (optional if omitted).