### PR TITLE
Fix team editor layout during loading

### DIFF
--- a/src/app/teams/[teamId]/team-editor/TeamRecipeTab.tsx
+++ b/src/app/teams/[teamId]/team-editor/TeamRecipeTab.tsx
@@ -3,6 +3,7 @@
 import type { RecipeListItem } from "./types";
 
 type TeamRecipeTabProps = {
+  loading?: boolean;
   fromId: string;
   setFromId: (v: string) => void;
   toId: string;
@@ -36,7 +37,12 @@ export function TeamRecipeTab(props: TeamRecipeTabProps) {
     <>
       <div className="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-2">
         <div className="ck-glass-strong p-4">
-          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Custom recipe target</div>
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Custom recipe target</div>
+            {p.loading ? (
+              <div className="text-xs text-[color:var(--ck-text-tertiary)]">Loading team…</div>
+            ) : null}
+          </div>
           <label className="mt-3 block text-xs font-medium text-[color:var(--ck-text-secondary)]">Team id</label>
           <input
             value={p.toId}

--- a/src/app/teams/[teamId]/team-editor/index.tsx
+++ b/src/app/teams/[teamId]/team-editor/index.tsx
@@ -367,11 +367,6 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
         Bootstrap a <strong>custom team recipe</strong> for this installed team, without modifying builtin recipes.
       </p>
 
-      {loading ? (
-        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm text-[color:var(--ck-text-secondary)]">
-          Loading team…
-        </div>
-      ) : null}
 
       <div className="mt-6 flex flex-wrap gap-2">
         {TABS.map((t) => (
@@ -391,6 +386,7 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
 
       {activeTab === "recipe" && (
         <TeamRecipeTab
+          loading={loading}
           fromId={fromId}
           setFromId={setFromId}
           toId={toId}

--- a/src/app/teams/[teamId]/team-editor/index.tsx
+++ b/src/app/teams/[teamId]/team-editor/index.tsx
@@ -359,14 +359,18 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
     }
   }
 
-  if (loading) return <div className="ck-glass mx-auto max-w-4xl p-6">Loading</div>;
-
   return (
-    <div className="ck-glass mx-auto max-w-6xl p-6 sm:p-8">
+    <div className="ck-glass w-full p-6 sm:p-8">
       <h1 className="text-2xl font-semibold tracking-tight">Team editor</h1>
       <p className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
         Bootstrap a <strong>custom team recipe</strong> for this installed team, without modifying builtin recipes.
       </p>
+
+      {loading ? (
+        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm text-[color:var(--ck-text-secondary)]">
+          Loading team…
+        </div>
+      ) : null}
 
       <div className="mt-6 flex flex-wrap gap-2">
         {TABS.map((t) =>

--- a/src/app/teams/[teamId]/team-editor/index.tsx
+++ b/src/app/teams/[teamId]/team-editor/index.tsx
@@ -21,6 +21,7 @@ import { TeamCronTab } from "./TeamCronTab";
 import { TeamFilesTab } from "./TeamFilesTab";
 import { OrchestratorPanel } from "../OrchestratorPanel";
 import Link from "next/link";
+import WorkflowsClient from "../workflows/workflows-client";
 
 const TABS = [
   { id: "recipe" as const, label: "Recipe" },
@@ -32,7 +33,7 @@ const TABS = [
   { id: "workflows" as const, label: "Workflows" },
 ];
 
-type TabId = Exclude<(typeof TABS)[number]["id"], "workflows">;
+type TabId = (typeof TABS)[number]["id"];
 
 export default function TeamEditor({ teamId, initialTab }: { teamId: string; initialTab?: string }) {
   const router = useRouter();
@@ -373,20 +374,11 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
       ) : null}
 
       <div className="mt-6 flex flex-wrap gap-2">
-        {TABS.map((t) =>
-          t.id === "workflows" ? (
-            <Link
-              key={t.id}
-              href={`/teams/${encodeURIComponent(teamId)}/workflows`}
-              className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] hover:bg-white/10"
-            >
-              {t.label}
-            </Link>
-          ) : (
-            <button
-              key={t.id}
-              onClick={() => setActiveTab(t.id as TabId)}
-              className={
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setActiveTab(t.id as TabId)}
+            className={
               activeTab === t.id
                 ? "rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)]"
                 : "rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)] hover:bg-white/10"
@@ -394,8 +386,7 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
           >
             {t.label}
           </button>
-          )
-        )}
+        ))}
       </div>
 
       {activeTab === "recipe" && (
@@ -469,6 +460,12 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
           saving={saving}
           onCronAction={onCronAction}
         />
+      )}
+
+      {activeTab === "workflows" && (
+        <div className="mt-6">
+          <WorkflowsClient teamId={teamId} />
+        </div>
       )}
 
       {activeTab === "orchestrator" && <OrchestratorPanel teamId={teamId} />}

--- a/src/app/teams/[teamId]/team-editor/team-editor-data.ts
+++ b/src/app/teams/[teamId]/team-editor/team-editor-data.ts
@@ -124,6 +124,7 @@ export async function loadTeamEditorInitial(teamId: string, setters: LoadTeamEdi
     setters.setLockedFromId(null);
     setters.setLockedFromName(null);
     setters.setProvenanceMissing(true);
+    const list = (initialData.recipesData.recipes ?? []) as RecipeListItem[];
     const preferred = list.find((r) => r.kind === "team" && r.id === teamId);
     const fallback = list.find((r) => r.kind === "team");
     const pick = preferred ?? fallback;

--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -66,6 +66,22 @@ export default function WorkflowsEditorClient({
             setStatus({ kind: "ready", jsonText: stored });
             return;
           }
+
+          // New workflow drafts should not hit the filesystem-backed API.
+          if (workflowId === "new") {
+            const empty: WorkflowFileV1 = {
+              schema: "clawkitchen.workflow.v1",
+              id: "new-workflow",
+              name: "New workflow",
+              nodes: [
+                { id: "start", type: "start", x: 80, y: 80 },
+                { id: "end", type: "end", x: 320, y: 80 },
+              ],
+              edges: [{ id: "e1", from: "start", to: "end" }],
+            };
+            setStatus({ kind: "ready", jsonText: JSON.stringify(empty, null, 2) + "\n" });
+            return;
+          }
         }
 
         const res = await fetch(

--- a/src/app/teams/[teamId]/workflows/workflows-client.tsx
+++ b/src/app/teams/[teamId]/workflows/workflows-client.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { fetchJson } from "@/lib/fetch-json";
 import { errorMessage } from "@/lib/errors";
-import type { WorkflowFileV1 } from "@/lib/workflows/types";
 
 export default function WorkflowsClient({ teamId }: { teamId: string }) {
   const [workflows, setWorkflows] = useState<Array<{ id: string; name?: string }>>([]);
@@ -65,51 +64,7 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
     }
   }
 
-  async function onCreateMarketingCadenceTemplate() {
-    setError("");
-    const wf: WorkflowFileV1 = {
-      schema: "clawkitchen.workflow.v1",
-      id: "marketing-cadence",
-      name: "Marketing Cadence",
-      timezone: "America/New_York",
-      triggers: [
-        {
-          kind: "cron",
-          id: "cadence",
-          name: "Cadence",
-          enabled: true,
-          expr: "0 9 * * 1,3,5",
-          tz: "America/New_York",
-        },
-      ],
-      nodes: [
-        { id: "start", type: "start", x: 80, y: 80 },
-        { id: "draft", type: "llm", name: "Draft post", x: 320, y: 80, config: {} },
-        { id: "approve", type: "human_approval", name: "Approve", x: 560, y: 80, config: {} },
-        { id: "end", type: "end", x: 800, y: 80 },
-      ],
-      edges: [
-        { id: "e1", from: "start", to: "draft" },
-        { id: "e2", from: "draft", to: "approve" },
-        { id: "e3", from: "approve", to: "end" },
-      ],
-      meta: {
-        templateId: "marketing-cadence-v1",
-      },
-    };
-
-    try {
-      const json = await fetchJson<{ ok?: boolean; error?: string }>("/api/teams/workflows", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ teamId, workflow: wf }),
-      });
-      if (!json.ok) throw new Error(json.error || "Failed to create template");
-      await load({ quiet: true });
-    } catch (e: unknown) {
-      setError(errorMessage(e));
-    }
-  }
+  // (template button removed)
 
   if (loading) {
     return <div className="ck-glass p-4">Loading workflows…</div>;
@@ -117,15 +72,15 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
 
   return (
     <div className="ck-glass p-6">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div>
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="min-w-0 flex-1">
           <h2 className="text-lg font-semibold">Workflows (file-first)</h2>
           <p className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">
             Stored in <code>shared-context/workflows/&lt;id&gt;.workflow.json</code> inside the team workspace.
           </p>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
           <Link
             href={`/teams/${encodeURIComponent(teamId)}/workflows/new?draft=1`}
             className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)]"
@@ -133,13 +88,7 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
             Add workflow
           </Link>
 
-          <button
-            type="button"
-            onClick={onCreateMarketingCadenceTemplate}
-            className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)]"
-          >
-            Create Marketing Cadence template
-          </button>
+          {/* (Marketing Cadence template button removed) */}
 
           <button
             type="button"

--- a/src/app/teams/[teamId]/workflows/workflows-client.tsx
+++ b/src/app/teams/[teamId]/workflows/workflows-client.tsx
@@ -80,7 +80,7 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
           </p>
         </div>
 
-        <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
+        <div className="flex flex-wrap items-center justify-start gap-2">
           <Link
             href={`/teams/${encodeURIComponent(teamId)}/workflows/new?draft=1`}
             className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)]"

--- a/src/app/teams/[teamId]/workflows/workflows-client.tsx
+++ b/src/app/teams/[teamId]/workflows/workflows-client.tsx
@@ -1,83 +1,189 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { fetchJson } from "@/lib/fetch-json";
 import { errorMessage } from "@/lib/errors";
+import type { WorkflowFileV1 } from "@/lib/workflows/types";
 
 export default function WorkflowsClient({ teamId }: { teamId: string }) {
   const [workflows, setWorkflows] = useState<Array<{ id: string; name?: string }>>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string>("");
 
-  useEffect(() => {
-    let cancelled = false;
-    // Reset loading/error before fetch; standard data-fetch pattern
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset on teamId change
-    setLoading(true);
-    setError("");
-    fetchJson<{ ok?: boolean; files?: string[]; workflow?: { id: string; name?: string } }>(
-      `/api/teams/workflows?teamId=${encodeURIComponent(teamId)}`,
-      { cache: "no-store" }
-    )
-      .then((json) => {
-        if (cancelled) return;
+  const load = useCallback(
+    async (opts?: { quiet?: boolean }) => {
+      const quiet = Boolean(opts?.quiet);
+      setError("");
+      if (!quiet) setLoading(true);
+      try {
+        const json = await fetchJson<{ ok?: boolean; files?: string[] }>(
+          `/api/teams/workflows?teamId=${encodeURIComponent(teamId)}`,
+          { cache: "no-store" }
+        );
         if (!json.ok) throw new Error("Failed to load workflows");
         const files = Array.isArray(json.files) ? json.files : [];
         const ids = files
           .map((f) => (f.endsWith(".workflow.json") ? f.slice(0, -".workflow.json".length) : null))
           .filter((id): id is string => Boolean(id));
         setWorkflows(ids.map((id) => ({ id, name: id })));
-      })
-      .catch((e: unknown) => {
-        if (!cancelled) setError(errorMessage(e));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
+      } catch (e: unknown) {
+        setError(errorMessage(e));
+      } finally {
+        if (!quiet) setLoading(false);
+      }
+    },
+    [teamId]
+  );
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function onRefresh() {
+    setRefreshing(true);
+    try {
+      await load({ quiet: true });
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  async function onDelete(id: string) {
+    if (!confirm(`Delete workflow “${id}”? This removes the .workflow.json file from the team workspace.`)) return;
+    setError("");
+    try {
+      const json = await fetchJson<{ ok?: boolean; error?: string }>(
+        `/api/teams/workflows?teamId=${encodeURIComponent(teamId)}&id=${encodeURIComponent(id)}`,
+        { method: "DELETE" }
+      );
+      if (!json.ok) throw new Error(json.error || "Failed to delete workflow");
+      await load({ quiet: true });
+    } catch (e: unknown) {
+      setError(errorMessage(e));
+    }
+  }
+
+  async function onCreateMarketingCadenceTemplate() {
+    setError("");
+    const wf: WorkflowFileV1 = {
+      schema: "clawkitchen.workflow.v1",
+      id: "marketing-cadence",
+      name: "Marketing Cadence",
+      timezone: "America/New_York",
+      triggers: [
+        {
+          kind: "cron",
+          id: "cadence",
+          name: "Cadence",
+          enabled: true,
+          expr: "0 9 * * 1,3,5",
+          tz: "America/New_York",
+        },
+      ],
+      nodes: [
+        { id: "start", type: "start", x: 80, y: 80 },
+        { id: "draft", type: "llm", name: "Draft post", x: 320, y: 80, config: {} },
+        { id: "approve", type: "human_approval", name: "Approve", x: 560, y: 80, config: {} },
+        { id: "end", type: "end", x: 800, y: 80 },
+      ],
+      edges: [
+        { id: "e1", from: "start", to: "draft" },
+        { id: "e2", from: "draft", to: "approve" },
+        { id: "e3", from: "approve", to: "end" },
+      ],
+      meta: {
+        templateId: "marketing-cadence-v1",
+      },
     };
-  }, [teamId]);
+
+    try {
+      const json = await fetchJson<{ ok?: boolean; error?: string }>("/api/teams/workflows", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ teamId, workflow: wf }),
+      });
+      if (!json.ok) throw new Error(json.error || "Failed to create template");
+      await load({ quiet: true });
+    } catch (e: unknown) {
+      setError(errorMessage(e));
+    }
+  }
 
   if (loading) {
     return <div className="ck-glass p-4">Loading workflows…</div>;
   }
 
-  if (error) {
-    return (
-      <div className="ck-glass rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-4 text-sm text-red-100">
-        {error}
-      </div>
-    );
-  }
-
   return (
     <div className="ck-glass p-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
-        <h2 className="text-lg font-semibold">Workflow definitions</h2>
-        <Link
-          href={`/teams/${encodeURIComponent(teamId)}/workflows/new?draft=1`}
-          className="rounded-[var(--ck-radius-sm)] bg-[color:var(--ck-accent)] px-3 py-2 text-sm font-medium text-black"
-        >
-          Create workflow
-        </Link>
+        <div>
+          <h2 className="text-lg font-semibold">Workflows (file-first)</h2>
+          <p className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">
+            Stored in <code>shared-context/workflows/&lt;id&gt;.workflow.json</code> inside the team workspace.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            href={`/teams/${encodeURIComponent(teamId)}/workflows/new?draft=1`}
+            className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)]"
+          >
+            Add workflow
+          </Link>
+
+          <button
+            type="button"
+            onClick={onCreateMarketingCadenceTemplate}
+            className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)]"
+          >
+            Create Marketing Cadence template
+          </button>
+
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={refreshing}
+            className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10 disabled:opacity-60"
+          >
+            {refreshing ? "Refreshing…" : "Refresh"}
+          </button>
+        </div>
       </div>
 
+      {error ? (
+        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-4 text-sm text-red-100">
+          {error}
+        </div>
+      ) : null}
+
       {workflows.length === 0 ? (
-        <p className="mt-4 text-sm text-[color:var(--ck-text-secondary)]">
-          No workflows yet. Create one to get started.
-        </p>
+        <p className="mt-4 text-sm text-[color:var(--ck-text-secondary)]">No workflows yet.</p>
       ) : (
-        <ul className="mt-4 space-y-2">
+        <ul className="mt-4 divide-y divide-white/10 overflow-hidden rounded-[var(--ck-radius-sm)] border border-white/10">
           {workflows.map((w) => (
-            <li key={w.id}>
-              <Link
-                href={`/teams/${encodeURIComponent(teamId)}/workflows/${encodeURIComponent(w.id)}`}
-                className="block rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-white/5 px-4 py-3 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
-              >
-                {w.name || w.id}
-              </Link>
+            <li key={w.id} className="flex items-center justify-between gap-3 bg-white/5 px-4 py-3">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium text-[color:var(--ck-text-primary)]">{w.name || w.id}</div>
+                <div className="truncate text-xs text-[color:var(--ck-text-tertiary)]">{w.id}</div>
+              </div>
+
+              <div className="flex shrink-0 items-center gap-2">
+                <Link
+                  href={`/teams/${encodeURIComponent(teamId)}/workflows/${encodeURIComponent(w.id)}`}
+                  className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-2 py-1 text-xs font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+                >
+                  Edit
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => void onDelete(w.id)}
+                  className="rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 px-2 py-1 text-xs font-medium text-red-100 hover:bg-red-500/15"
+                >
+                  Delete
+                </button>
+              </div>
             </li>
           ))}
         </ul>

--- a/src/app/teams/[teamId]/workflows/workflows-client.tsx
+++ b/src/app/teams/[teamId]/workflows/workflows-client.tsx
@@ -117,14 +117,14 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
               <div className="flex shrink-0 items-center gap-2">
                 <Link
                   href={`/teams/${encodeURIComponent(teamId)}/workflows/${encodeURIComponent(w.id)}`}
-                  className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-2 py-1 text-xs font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+                  className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-1.5 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
                 >
                   Edit
                 </Link>
                 <button
                   type="button"
                   onClick={() => void onDelete(w.id)}
-                  className="rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 px-2 py-1 text-xs font-medium text-red-100 hover:bg-red-500/15"
+                  className="rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-100 hover:bg-red-500/15"
                 >
                   Delete
                 </button>

--- a/src/app/teams/[teamId]/workflows/workflows-client.tsx
+++ b/src/app/teams/[teamId]/workflows/workflows-client.tsx
@@ -72,23 +72,19 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
 
   return (
     <div className="ck-glass p-6">
-      <div className="flex flex-wrap items-center gap-4">
-        <div className="min-w-0 flex-1">
-          <h2 className="text-lg font-semibold">Workflows (file-first)</h2>
-          <p className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">
-            Stored in <code>shared-context/workflows/&lt;id&gt;.workflow.json</code> inside the team workspace.
-          </p>
-        </div>
+      <div>
+        <h2 className="text-lg font-semibold">Workflows (file-first)</h2>
+        <p className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">
+          Stored in <code>shared-context/workflows/&lt;id&gt;.workflow.json</code> inside the team workspace.
+        </p>
 
-        <div className="flex flex-wrap items-center justify-start gap-2">
+        <div className="mt-3 flex flex-wrap items-center justify-start gap-2">
           <Link
             href={`/teams/${encodeURIComponent(teamId)}/workflows/new?draft=1`}
             className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)]"
           >
             Add workflow
           </Link>
-
-          {/* (Marketing Cadence template button removed) */}
 
           <button
             type="button"


### PR DESCRIPTION
Fixes Teams view UX regression after merge: render full Team Editor shell immediately (no tiny centered Loading box), and let it fill available width so the right side space is used. Adds a subtle "Loading team…" banner instead while data hydrates.