### PR TITLE
feat: team memory tab (file-first shared-context/memory)

### DIFF
--- a/src/app/api/teams/memory/route.ts
+++ b/src/app/api/teams/memory/route.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { withTeamContextFromQuery } from "@/lib/api-route-helpers";
+import { errorMessage } from "@/lib/errors";
+
+type MemoryItem = {
+  ts: string;
+  author: string;
+  type: string;
+  content: string;
+  source?: unknown;
+  _file?: string;
+  _line?: number;
+};
+
+function safeParseJsonLine(line: string): unknown {
+  const t = line.trim();
+  if (!t) return null;
+  try {
+    return JSON.parse(t);
+  } catch {
+    return null;
+  }
+}
+
+function asMemoryItem(x: unknown): MemoryItem | null {
+  if (!x || typeof x !== "object" || Array.isArray(x)) return null;
+  const o = x as Record<string, unknown>;
+  const ts = String(o.ts ?? "").trim();
+  const author = String(o.author ?? "").trim();
+  const type = String(o.type ?? "").trim();
+  const content = String(o.content ?? "").trim();
+  if (!ts || !author || !type || !content) return null;
+  const source = o.source;
+  return { ts, author, type, content, source };
+}
+
+async function listJsonlFiles(dir: string): Promise<string[]> {
+  try {
+    const names = await fs.readdir(dir);
+    return names.filter((n) => n.toLowerCase().endsWith(".jsonl")).sort();
+  } catch {
+    return [];
+  }
+}
+
+export async function GET(req: Request) {
+  return withTeamContextFromQuery(req, async ({ teamId, teamDir }) => {
+    try {
+      const memoryDir = path.join(teamDir, "shared-context", "memory");
+      const files = await listJsonlFiles(memoryDir);
+
+      const items: MemoryItem[] = [];
+      for (const f of files) {
+        const full = path.join(memoryDir, f);
+        let text = "";
+        try {
+          text = await fs.readFile(full, "utf8");
+        } catch {
+          continue;
+        }
+
+        const lines = text.split(/\r?\n/);
+        for (let i = 0; i < lines.length; i++) {
+          const raw = safeParseJsonLine(lines[i] ?? "");
+          const item = asMemoryItem(raw);
+          if (!item) continue;
+          items.push({ ...item, _file: f, _line: i + 1 });
+        }
+      }
+
+      // Most recent first (lexical ISO timestamps).
+      items.sort((a, b) => String(b.ts).localeCompare(String(a.ts)));
+
+      return NextResponse.json({ ok: true, teamId, memoryDir, files, items: items.slice(0, 200) });
+    } catch (e: unknown) {
+      return NextResponse.json({ ok: false, error: errorMessage(e) }, { status: 500 });
+    }
+  });
+}
+
+export async function POST(req: Request) {
+  return withTeamContextFromQuery(req, async ({ teamId, teamDir }) => {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json({ ok: false, error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const o = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+    const ts = String(o.ts ?? "").trim();
+    const author = String(o.author ?? "").trim();
+    const type = String(o.type ?? "").trim();
+    const content = String(o.content ?? "").trim();
+    const source = o.source;
+    const file = String(o.file ?? "team.jsonl").trim() || "team.jsonl";
+
+    if (!ts || !author || !type || !content) {
+      return NextResponse.json(
+        { ok: false, error: "ts, author, type, and content are required" },
+        { status: 400 }
+      );
+    }
+
+    if (!/^[a-z0-9_.\-]+\.jsonl$/i.test(file)) {
+      return NextResponse.json({ ok: false, error: "Invalid file" }, { status: 400 });
+    }
+
+    try {
+      const memoryDir = path.join(teamDir, "shared-context", "memory");
+      await fs.mkdir(memoryDir, { recursive: true });
+      const full = path.join(memoryDir, file);
+      const item: MemoryItem = { ts, author, type, content, ...(source !== undefined ? { source } : {}) };
+      await fs.appendFile(full, JSON.stringify(item) + "\n", "utf8");
+      return NextResponse.json({ ok: true, teamId, file, item });
+    } catch (e: unknown) {
+      return NextResponse.json({ ok: false, error: errorMessage(e) }, { status: 500 });
+    }
+  });
+}

--- a/src/app/teams/[teamId]/team-editor/TeamMemoryTab.tsx
+++ b/src/app/teams/[teamId]/team-editor/TeamMemoryTab.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { errorMessage } from "@/lib/errors";
+
+type MemoryItem = {
+  ts: string;
+  author: string;
+  type: string;
+  content: string;
+  source?: unknown;
+  _file?: string;
+  _line?: number;
+};
+
+export function TeamMemoryTab({ teamId }: { teamId: string }) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [files, setFiles] = useState<string[]>([]);
+  const [items, setItems] = useState<MemoryItem[]>([]);
+
+  const [newType, setNewType] = useState("learning");
+  const [newContent, setNewContent] = useState("");
+  const [newSource, setNewSource] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  async function refresh() {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(`/api/teams/memory?teamId=${encodeURIComponent(teamId)}`, { cache: "no-store" });
+      const json = (await res.json()) as { ok?: boolean; error?: string; files?: string[]; items?: MemoryItem[] };
+      if (!res.ok || !json.ok) throw new Error(json.error || "Failed to load memory");
+      setFiles(Array.isArray(json.files) ? json.files : []);
+      setItems(Array.isArray(json.items) ? json.items : []);
+    } catch (e: unknown) {
+      setError(errorMessage(e));
+      setFiles([]);
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refresh is defined inline; teamId is the only intended trigger.
+  }, [teamId]);
+
+  const examples = useMemo(
+    () => [
+      { label: "decision", value: "decision" },
+      { label: "learning", value: "learning" },
+      { label: "bug", value: "bug" },
+      { label: "customer", value: "customer" },
+      { label: "release", value: "release" },
+    ],
+    []
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="ck-glass p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Team memory (file-first)</div>
+            <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+              Stored in <span className="font-mono">shared-context/memory/*.jsonl</span>. Items must be attributable.
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={refresh}
+            className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+          >
+            Refresh
+          </button>
+        </div>
+
+        {error ? <div className="mt-3 rounded border border-red-400/30 bg-red-500/10 p-2 text-sm text-red-100">{error}</div> : null}
+
+        <div className="mt-3 text-xs text-[color:var(--ck-text-secondary)]">
+          Files: {files.length ? files.join(", ") : "(none)"}
+        </div>
+      </div>
+
+      <div className="ck-glass p-4">
+        <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Add memory item</div>
+        <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2">
+          <label className="block">
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">type</div>
+            <select
+              value={newType}
+              onChange={(e) => setNewType(e.target.value)}
+              className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-2 text-sm text-[color:var(--ck-text-primary)]"
+            >
+              {examples.map((x) => (
+                <option key={x.value} value={x.value}>
+                  {x.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block">
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">source (ticket/pr/path)</div>
+            <input
+              value={newSource}
+              onChange={(e) => setNewSource(e.target.value)}
+              className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-2 text-sm text-[color:var(--ck-text-primary)]"
+              placeholder="e.g. ticket 0088, PR https://..., shared-context/DECISIONS.md"
+            />
+          </label>
+
+          <label className="block md:col-span-2">
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">content</div>
+            <textarea
+              value={newContent}
+              onChange={(e) => setNewContent(e.target.value)}
+              className="mt-1 h-[110px] w-full resize-none rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 p-2 text-sm text-[color:var(--ck-text-primary)]"
+              placeholder="Write a small, specific memory item…"
+            />
+          </label>
+
+          <div className="md:col-span-2">
+            <button
+              type="button"
+              disabled={saving || !newContent.trim()}
+              onClick={async () => {
+                setSaving(true);
+                setError("");
+                try {
+                  const payload = {
+                    ts: new Date().toISOString(),
+                    author: `${teamId}-lead`,
+                    type: newType,
+                    content: newContent.trim(),
+                    source: newSource.trim() ? { text: newSource.trim() } : undefined,
+                    file: "team.jsonl",
+                  };
+                  const res = await fetch(`/api/teams/memory?teamId=${encodeURIComponent(teamId)}`, {
+                    method: "POST",
+                    headers: { "content-type": "application/json" },
+                    body: JSON.stringify(payload),
+                  });
+                  const json = (await res.json()) as { ok?: boolean; error?: string };
+                  if (!res.ok || !json.ok) throw new Error(json.error || "Failed to append memory");
+                  setNewContent("");
+                  setNewSource("");
+                  await refresh();
+                } catch (e: unknown) {
+                  setError(errorMessage(e));
+                } finally {
+                  setSaving(false);
+                }
+              }}
+              className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)] disabled:opacity-50"
+            >
+              {saving ? "Saving…" : "Append to team.jsonl"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="ck-glass p-4">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-sm font-medium text-[color:var(--ck-text-primary)]">Recent memory</div>
+          <div className="text-xs text-[color:var(--ck-text-tertiary)]">Showing {items.length} (max 200)</div>
+        </div>
+
+        {loading ? <div className="mt-3 text-sm text-[color:var(--ck-text-secondary)]">Loading…</div> : null}
+
+        <div className="mt-3 space-y-3">
+          {items.length ? (
+            items.map((it) => (
+              <div key={`${it._file ?? "?"}:${it._line ?? 0}`} className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="text-xs text-[color:var(--ck-text-tertiary)]">
+                    <span className="font-mono">{it.ts}</span>
+                    <span className="mx-2">•</span>
+                    <span className="rounded bg-white/5 px-2 py-0.5 font-mono">{it.type}</span>
+                    <span className="mx-2">•</span>
+                    <span className="font-mono">{it.author}</span>
+                  </div>
+                  <div className="text-[10px] text-[color:var(--ck-text-tertiary)]">
+                    {it._file ? (
+                      <span className="font-mono">
+                        {it._file}:{it._line}
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div className="mt-2 whitespace-pre-wrap text-sm text-[color:var(--ck-text-primary)]">{it.content}</div>
+
+                {it.source ? (
+                  <pre className="mt-2 overflow-auto rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/30 p-2 text-[10px] text-[color:var(--ck-text-secondary)]">
+                    {JSON.stringify(it.source, null, 2)}
+                  </pre>
+                ) : null}
+              </div>
+            ))
+          ) : (
+            <div className="text-sm text-[color:var(--ck-text-secondary)]">No memory items yet.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/teams/[teamId]/team-editor/index.tsx
+++ b/src/app/teams/[teamId]/team-editor/index.tsx
@@ -19,8 +19,8 @@ import { TeamAgentsTab } from "./TeamAgentsTab";
 import { TeamSkillsTab } from "./TeamSkillsTab";
 import { TeamCronTab } from "./TeamCronTab";
 import { TeamFilesTab } from "./TeamFilesTab";
+import { TeamMemoryTab } from "./TeamMemoryTab";
 import { OrchestratorPanel } from "../OrchestratorPanel";
-import Link from "next/link";
 import WorkflowsClient from "../workflows/workflows-client";
 
 const TABS = [
@@ -29,6 +29,7 @@ const TABS = [
   { id: "skills" as const, label: "Skills" },
   { id: "cron" as const, label: "Cron" },
   { id: "files" as const, label: "Files" },
+  { id: "memory" as const, label: "Memory" },
   { id: "orchestrator" as const, label: "Orchestrator" },
   { id: "workflows" as const, label: "Workflows" },
 ];
@@ -47,7 +48,7 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
   const [content, setContent] = useState<string>("");
   const [loadedRecipeHash, setLoadedRecipeHash] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>(() => {
-    const valid: TabId[] = ["recipe", "agents", "skills", "cron", "files", "orchestrator"];
+    const valid: TabId[] = ["recipe", "agents", "skills", "cron", "files", "memory", "orchestrator", "workflows"];
     return valid.includes(initialTab as TabId) ? (initialTab as TabId) : "recipe";
   });
   const [loading, setLoading] = useState(true);
@@ -137,7 +138,7 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
     setTeamMetaRecipeHash(null);
     setPublishOpen(false);
     setDeleteOpen(false);
-    const valid: TabId[] = ["recipe", "agents", "skills", "cron", "files", "orchestrator"];
+    const valid: TabId[] = ["recipe", "agents", "skills", "cron", "files", "memory", "orchestrator", "workflows"];
     if (initialTab && valid.includes(initialTab as TabId)) {
       setActiveTab(initialTab as TabId);
     }
@@ -465,6 +466,12 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
       )}
 
       {activeTab === "orchestrator" && <OrchestratorPanel teamId={teamId} />}
+
+      {activeTab === "memory" && (
+        <div className="mt-6">
+          <TeamMemoryTab teamId={teamId} />
+        </div>
+      )}
 
       {activeTab === "files" && (
         <TeamFilesTab


### PR DESCRIPTION
Implements initial slice of ticket #0088 (team memory/info sharing):

- Adds /api/teams/memory (GET list + POST append) backed by shared-context/memory/*.jsonl
- Adds new Team Editor tab: Memory
  - shows recent memory items (parsed from JSONL)
  - allows appending a new memory item with source pointer

Notes:
- File-first + auditable (shows file:line)
- Next: wire "memory used in this run" attribution from workflow run outputs.

QA:
- Open team page → Memory tab
- Append a memory item
- Refresh; item appears in list