### PR TITLE
Fix destructive button contrast in light theme

### DIFF
--- a/src/app/agents/[agentId]/agent-editor.tsx
+++ b/src/app/agents/[agentId]/agent-editor.tsx
@@ -333,7 +333,7 @@ export default function AgentEditor({ agentId, returnTo }: { agentId: string; re
             setDeleteError(null);
             setDeleteOpen(true);
           }}
-          className="rounded-[var(--ck-radius-sm)] border border-red-400/40 bg-red-500/10 px-3 py-2 text-sm font-medium text-red-100 shadow-[var(--ck-shadow-1)] hover:bg-red-500/15 disabled:opacity-50"
+          className="rounded-[var(--ck-radius-sm)] border border-[color:rgba(255,59,48,0.45)] bg-[color:rgba(255,59,48,0.08)] px-3 py-2 text-sm font-medium text-[color:var(--ck-accent-red)] shadow-[var(--ck-shadow-1)] transition-colors hover:bg-[color:rgba(255,59,48,0.12)] disabled:opacity-50"
         >
           Delete agent
         </button>

--- a/src/app/channels/channels-client.tsx
+++ b/src/app/channels/channels-client.tsx
@@ -26,7 +26,9 @@ function Button({
 }) {
   let base = "rounded-[var(--ck-radius-sm)] px-3 py-2 text-sm font-medium transition disabled:opacity-50 ";
   if (kind === "primary") base += "bg-[var(--ck-accent-red)] text-white";
-  else if (kind === "danger") base += "border border-red-400/40 text-red-200 hover:bg-red-500/10";
+  else if (kind === "danger")
+    base +=
+      "border border-[color:rgba(255,59,48,0.45)] bg-[color:rgba(255,59,48,0.08)] text-[color:var(--ck-accent-red)] hover:bg-[color:rgba(255,59,48,0.12)]";
   else base += "border border-[color:var(--ck-border-subtle)] hover:bg-[color:var(--ck-bg-glass)]";
   return (
     <button className={base} onClick={onClick} disabled={disabled}>

--- a/src/app/cron-jobs/cron-jobs-client.tsx
+++ b/src/app/cron-jobs/cron-jobs-client.tsx
@@ -212,7 +212,7 @@ export default function CronJobsClient() {
                     title={isEnabled(j) ? "Disable this job before deleting." : "Delete cron job"}
                     onClick={() => openDelete(j)}
                     disabled={loading || isEnabled(j)}
-                    className="rounded-[var(--ck-radius-sm)] border border-red-400/40 bg-red-500/10 px-3 py-2 text-sm font-medium text-red-100 transition-colors hover:bg-red-500/15 disabled:opacity-40"
+                    className="rounded-[var(--ck-radius-sm)] border border-[color:rgba(255,59,48,0.45)] bg-[color:rgba(255,59,48,0.08)] px-3 py-2 text-sm font-medium text-[color:var(--ck-accent-red)] transition-colors hover:bg-[color:rgba(255,59,48,0.12)] disabled:opacity-40"
                   >
                     Delete
                   </button>

--- a/src/app/goals/[id]/goal-editor.tsx
+++ b/src/app/goals/[id]/goal-editor.tsx
@@ -141,7 +141,7 @@ export default function GoalEditor({ goalId }: { goalId: string }) {
           <button
             onClick={() => void deleteThisGoal()}
             disabled={saving || loading}
-            className="rounded-[var(--ck-radius-sm)] border border-red-500/40 px-3 py-2 text-sm font-medium text-red-200"
+            className="rounded-[var(--ck-radius-sm)] border border-[color:rgba(255,59,48,0.45)] bg-[color:rgba(255,59,48,0.08)] px-3 py-2 text-sm font-medium text-[color:var(--ck-accent-red)] transition-colors hover:bg-[color:rgba(255,59,48,0.12)]"
           >
             Delete
           </button>

--- a/src/app/teams/[teamId]/workflows/workflows-client.tsx
+++ b/src/app/teams/[teamId]/workflows/workflows-client.tsx
@@ -124,7 +124,7 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
                 <button
                   type="button"
                   onClick={() => void onDelete(w.id)}
-                  className="rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-100 hover:bg-red-500/15"
+                  className="rounded-[var(--ck-radius-sm)] border border-[color:rgba(255,59,48,0.45)] bg-[color:rgba(255,59,48,0.08)] px-3 py-1.5 text-sm font-medium text-[color:var(--ck-accent-red)] transition-colors hover:bg-[color:rgba(255,59,48,0.12)]"
                 >
                   Delete
                 </button>


### PR DESCRIPTION
Ticket: 0105\n\nWhat\n- Updated destructive/"Delete" button styling to use Kitchen accent red (CSS var) instead of Tailwind red-* tokens tuned for dark theme.\n- Applied to common surfaces: Goal editor action bar, Cron jobs list, Agent editor, Channels bindings, Workflows list.\n\nWhy\n- Tailwind red-100/red-200 were too low-contrast in light theme (Delete looked washed out / nearly invisible).\n\nVerification\n- npm run lint\n- npm run build\n- (pre-commit) vitest run\n\nNotes\n- No dark-theme regressions expected since styling now keys off --ck-accent-red.