### PR TITLE
Tickets: move-to-goals + delete actions on ticket detail

### DIFF
--- a/src/app/api/teams/[teamId]/tickets/delete/route.ts
+++ b/src/app/api/teams/[teamId]/tickets/delete/route.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { NextResponse } from "next/server";
+
+import { errorMessage } from "@/lib/errors";
+import { resolveTicket, teamWorkspace } from "@/lib/tickets";
+
+function pad4(n: number) {
+  return String(n).padStart(4, "0");
+}
+
+export async function POST(req: Request, ctx: { params: Promise<{ teamId: string }> }) {
+  try {
+    const { teamId } = await ctx.params;
+    const body = await req.json();
+    const ticket = String(body.ticket ?? "").trim();
+
+    if (!ticket) {
+      return NextResponse.json({ ok: false, error: "Missing ticket" }, { status: 400 });
+    }
+
+    const hit = await resolveTicket(teamId, ticket);
+    if (!hit) {
+      return NextResponse.json({ ok: false, error: `Ticket not found: ${ticket}` }, { status: 404 });
+    }
+
+    // Remove ticket file.
+    await fs.unlink(hit.file);
+
+    // Archive any assignment stubs (safer than deleting outright).
+    const assignmentsDir = path.join(teamWorkspace(teamId), "work/assignments");
+    const deletedDir = path.join(assignmentsDir, "deleted");
+    await fs.mkdir(deletedDir, { recursive: true });
+
+    const moved: string[] = [];
+    try {
+      const files = await fs.readdir(assignmentsDir);
+      const prefix = `${pad4(hit.number)}-assigned-`;
+      for (const f of files) {
+        if (!f.startsWith(prefix) || !f.endsWith(".md")) continue;
+        const from = path.join(assignmentsDir, f);
+        const to = path.join(deletedDir, f);
+        await fs.rename(from, to);
+        moved.push(f);
+      }
+    } catch {
+      // ignore
+    }
+
+    return NextResponse.json({ ok: true, archivedAssignments: moved });
+  } catch (e: unknown) {
+    return NextResponse.json({ ok: false, error: errorMessage(e) }, { status: 500 });
+  }
+}

--- a/src/app/api/teams/[teamId]/tickets/move-to-goals/route.ts
+++ b/src/app/api/teams/[teamId]/tickets/move-to-goals/route.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { NextResponse } from "next/server";
+
+import { errorMessage } from "@/lib/errors";
+import { resolveTicket, teamWorkspace } from "@/lib/tickets";
+
+function todayUtc() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function appendGoalsAuditComment(file: string) {
+  const md = await fs.readFile(file, "utf8");
+  const line = `- ${todayUtc()} (ClawKitchen UI): Moved to Goals from ClawKitchen UI.`;
+  if (md.includes(line)) return;
+
+  const hasComments = /\n## Comments\n/i.test(md) || /^## Comments\n/im.test(md);
+
+  let next = md;
+  if (!hasComments) {
+    next = next.replace(/\s*$/, "\n\n## Comments\n");
+  }
+  next = next.replace(/\s*$/, "\n" + line + "\n");
+
+  await fs.writeFile(file, next, "utf8");
+}
+
+export async function POST(req: Request, ctx: { params: Promise<{ teamId: string }> }) {
+  try {
+    const { teamId } = await ctx.params;
+    const body = await req.json();
+    const ticket = String(body.ticket ?? "").trim();
+
+    if (!ticket) {
+      return NextResponse.json({ ok: false, error: "Missing ticket" }, { status: 400 });
+    }
+
+    const hit = await resolveTicket(teamId, ticket);
+    if (!hit) {
+      return NextResponse.json({ ok: false, error: `Ticket not found: ${ticket}` }, { status: 404 });
+    }
+
+    const goalsDir = path.join(teamWorkspace(teamId), "work/goals");
+    await fs.mkdir(goalsDir, { recursive: true });
+
+    const dest = path.join(goalsDir, path.basename(hit.file));
+    await fs.rename(hit.file, dest);
+
+    await appendGoalsAuditComment(dest);
+
+    return NextResponse.json({ ok: true, to: dest });
+  } catch (e: unknown) {
+    return NextResponse.json({ ok: false, error: errorMessage(e) }, { status: 500 });
+  }
+}

--- a/src/app/api/tickets/move/route.ts
+++ b/src/app/api/tickets/move/route.ts
@@ -10,7 +10,7 @@ function todayUtc() {
 }
 
 async function appendDoneAuditComment(ticketIdOrNumber: string) {
-  const hit = await getTicketMarkdown("development-team", ticketIdOrNumber);
+  const hit = await getTicketMarkdown(ticketIdOrNumber);
   if (!hit) return;
 
   const line = `- ${todayUtc()} (ClawKitchen UI): Marked done from ClawKitchen UI.`;

--- a/src/app/api/tickets/move/route.ts
+++ b/src/app/api/tickets/move/route.ts
@@ -10,7 +10,7 @@ function todayUtc() {
 }
 
 async function appendDoneAuditComment(ticketIdOrNumber: string) {
-  const hit = await getTicketMarkdown(ticketIdOrNumber);
+  const hit = await getTicketMarkdown("development-team", ticketIdOrNumber);
   if (!hit) return;
 
   const line = `- ${todayUtc()} (ClawKitchen UI): Marked done from ClawKitchen UI.`;

--- a/src/app/teams/[teamId]/tickets/[ticket]/page.tsx
+++ b/src/app/teams/[teamId]/tickets/[ticket]/page.tsx
@@ -1,16 +1,14 @@
 import { getTicketMarkdown } from "@/lib/tickets";
 import { TicketDetailClient } from "@/app/tickets/TicketDetailClient";
 
-// Ticket detail should always reflect current stage/file; do not cache.
 export const dynamic = "force-dynamic";
 
-export default async function TicketDetailPage({
+export default async function TeamTicketDetailPage({
   params,
 }: {
-  params: Promise<{ ticket: string }>;
+  params: Promise<{ teamId: string; ticket: string }>;
 }) {
-  const { ticket } = await params;
-  const teamId = "development-team";
+  const { teamId, ticket } = await params;
   const data = await getTicketMarkdown(teamId, ticket);
 
   if (!data) {
@@ -25,6 +23,12 @@ export default async function TicketDetailPage({
   }
 
   return (
-    <TicketDetailClient teamId={teamId} ticketId={data.id} file={data.file} markdown={data.markdown} />
+    <TicketDetailClient
+      teamId={teamId}
+      ticketId={data.id}
+      file={data.file}
+      markdown={data.markdown}
+      backHref={`/teams/${encodeURIComponent(teamId)}/tickets`}
+    />
   );
 }

--- a/src/app/teams/[teamId]/tickets/page.tsx
+++ b/src/app/teams/[teamId]/tickets/page.tsx
@@ -1,0 +1,14 @@
+import { listTickets } from "@/lib/tickets";
+import { TicketsBoardClient } from "@/app/tickets/TicketsBoardClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function TeamTicketsPage({
+  params,
+}: {
+  params: Promise<{ teamId: string }>;
+}) {
+  const { teamId } = await params;
+  const tickets = await listTickets(teamId);
+  return <TicketsBoardClient tickets={tickets} basePath={`/teams/${encodeURIComponent(teamId)}/tickets`} />;
+}

--- a/src/app/tickets/TicketDetailClient.tsx
+++ b/src/app/tickets/TicketDetailClient.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { errorMessage } from "@/lib/errors";
+import { fetchJson } from "@/lib/fetch-json";
+
+export function TicketDetailClient(props: {
+  teamId: string;
+  ticketId: string;
+  file: string;
+  markdown: string;
+  backHref?: string;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [confirm, setConfirm] = useState<null | { kind: "goals" | "delete" }>(null);
+
+  async function moveToGoals() {
+    setError(null);
+    await fetchJson(`/api/teams/${encodeURIComponent(props.teamId)}/tickets/move-to-goals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ticket: props.ticketId }),
+    });
+  }
+
+  async function deleteTicket() {
+    setError(null);
+    await fetchJson(`/api/teams/${encodeURIComponent(props.teamId)}/tickets/delete`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ticket: props.ticketId }),
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <Link href={props.backHref ?? "/tickets"} className="text-sm font-medium hover:underline">
+          ← Back
+        </Link>
+        <span className="text-xs text-[color:var(--ck-text-tertiary)]">{props.file}</span>
+      </div>
+
+      {error ? (
+        <div className="ck-glass border border-[color:var(--ck-border-strong)] p-3 text-sm text-[color:var(--ck-text-primary)]">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="ck-glass p-4">
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <button
+            className="rounded border border-[color:var(--ck-border-subtle)] px-3 py-1.5 text-xs font-medium text-[color:var(--ck-text-secondary)] hover:border-[color:var(--ck-border-strong)]"
+            onClick={() => setConfirm({ kind: "goals" })}
+            disabled={isPending}
+          >
+            Move to Goals
+          </button>
+          <button
+            className="rounded border border-[color:var(--ck-accent-red)] bg-[color:var(--ck-accent-red-soft)] px-3 py-1.5 text-xs font-medium text-[color:var(--ck-accent-red)] hover:bg-[color:var(--ck-accent-red-soft-strong)]"
+            onClick={() => setConfirm({ kind: "delete" })}
+            disabled={isPending}
+          >
+            Delete Ticket
+          </button>
+        </div>
+      </div>
+
+      <div className="ck-glass p-6">
+        <pre className="whitespace-pre-wrap break-words text-sm leading-6 text-[color:var(--ck-text-primary)]">
+          {props.markdown}
+        </pre>
+      </div>
+
+      {confirm ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <div className="ck-glass w-full max-w-lg rounded-[var(--ck-radius-md)] border border-[color:var(--ck-border-strong)] p-4">
+            <div className="text-sm font-semibold text-[color:var(--ck-text-primary)]">
+              {confirm.kind === "goals" ? "Move to Goals" : "Delete ticket"}
+            </div>
+
+            <div className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+              {confirm.kind === "goals" ? (
+                <>This will move the ticket out of the work lanes into <code>work/goals/</code> so it won’t be picked up by automation.</>
+              ) : (
+                <>This will permanently remove the ticket markdown file. Assignment stubs (if any) will be archived.</>
+              )}
+            </div>
+
+            <div className="mt-4 flex items-center justify-end gap-2">
+              <button
+                className="rounded border border-[color:var(--ck-border-subtle)] px-3 py-1.5 text-xs text-[color:var(--ck-text-secondary)]"
+                onClick={() => setConfirm(null)}
+                disabled={isPending}
+              >
+                Cancel
+              </button>
+              <button
+                className={
+                  confirm.kind === "delete"
+                    ? "rounded bg-[color:var(--ck-accent-red)] px-3 py-1.5 text-xs font-medium text-white"
+                    : "rounded bg-[color:var(--ck-accent)] px-3 py-1.5 text-xs font-medium text-black"
+                }
+                onClick={() => {
+                  const kind = confirm.kind;
+                  setConfirm(null);
+                  startTransition(() => {
+                    const op = kind === "goals" ? moveToGoals() : deleteTicket();
+                    op
+                      .then(() => {
+                        if (kind === "delete") {
+                          router.push(props.backHref ?? "/tickets");
+                        } else {
+                          router.refresh();
+                        }
+                      })
+                      .catch((e: unknown) => setError(errorMessage(e)));
+                  });
+                }}
+                disabled={isPending}
+              >
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/tickets/TicketDetailClient.tsx
+++ b/src/app/tickets/TicketDetailClient.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 
+import { useToast } from "@/components/ToastProvider";
 import { errorMessage } from "@/lib/errors";
 import { fetchJson } from "@/lib/fetch-json";
 
@@ -15,6 +16,7 @@ export function TicketDetailClient(props: {
   backHref?: string;
 }) {
   const router = useRouter();
+  const toast = useToast();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [confirm, setConfirm] = useState<null | { kind: "goals" | "delete" }>(null);
@@ -113,6 +115,10 @@ export function TicketDetailClient(props: {
                     const op = kind === "goals" ? moveToGoals() : deleteTicket();
                     op
                       .then(() => {
+                        toast.push({
+                          kind: "success",
+                          message: kind === "delete" ? "Ticket deleted." : "Moved to Goals.",
+                        });
                         if (kind === "delete") {
                           router.push(props.backHref ?? "/tickets");
                         } else {

--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -5,6 +5,6 @@ import { TicketsBoardClient } from "@/app/tickets/TicketsBoardClient";
 export const dynamic = "force-dynamic";
 
 export default async function TicketsPage() {
-  const tickets = await listTickets();
-  return <TicketsBoardClient tickets={tickets} />;
+  const tickets = await listTickets("development-team");
+  return <TicketsBoardClient tickets={tickets} basePath="/tickets" />;
 }

--- a/src/lib/__tests__/tickets.test.ts
+++ b/src/lib/__tests__/tickets.test.ts
@@ -137,21 +137,21 @@ describe("tickets", () => {
     });
 
     it("finds by id and returns markdown", async () => {
-      const result = await getTicketMarkdown("0033-fix");
+      const result = await getTicketMarkdown("development-team", "0033-fix");
       expect(result).not.toBeNull();
       expect(result!.id).toBe("0033-fix");
       expect(result!.markdown).toContain("Fix it");
     });
 
     it("finds by number", async () => {
-      const result = await getTicketMarkdown("33");
+      const result = await getTicketMarkdown("development-team", "33");
       expect(result).not.toBeNull();
       expect(result!.id).toBe("0033-fix");
     });
 
     it("returns null when not found", async () => {
       vi.mocked(fs.readdir).mockReset().mockResolvedValue([]);
-      const result = await getTicketMarkdown("9999");
+      const result = await getTicketMarkdown("development-team", "9999");
       expect(result).toBeNull();
     });
   });


### PR DESCRIPTION
Implements ticket UX changes from dev-team ticket 0104.

Changes:
- Tickets board: removed per-ticket status dropdown (browse-only list).
- Ticket detail: added Move to Goals + Delete Ticket actions with confirmation modals.
- Team-scoped server actions:
  - POST /api/teams/[teamId]/tickets/move-to-goals (moves ticket to work/goals/ and appends audit comment)
  - POST /api/teams/[teamId]/tickets/delete (deletes ticket; archives assignment stubs to work/assignments/deleted/)
  - POST /api/teams/[teamId]/tickets/move (team-scoped version of existing move)
- Added team-scoped routes:
  - /teams/[teamId]/tickets
  - /teams/[teamId]/tickets/[ticket]

Checks:
- npm run lint (warnings only)
- npm run build ✅
