### PR TITLE
Runs dashboard MVP

### DIFF
--- a/src/app/api/teams/runs/route.ts
+++ b/src/app/api/teams/runs/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { errorMessage } from "@/lib/errors";
+// (no query helper)
+import { listWorkflows } from "@/lib/workflows/storage";
+import { listWorkflowRuns, readWorkflowRun } from "@/lib/workflows/runs-storage";
+
+type RunListItem = {
+  workflowId: string;
+  runId: string;
+  status?: string;
+  startedAt?: string;
+  endedAt?: string;
+  summary?: string;
+  triggerKind?: string;
+};
+
+function asInt(v: string | undefined, fallback: number) {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return Boolean(v) && typeof v === "object" && !Array.isArray(v);
+}
+
+export async function GET(req: Request) {
+  const sp = new URL(req.url).searchParams;
+
+  const teamId = String(sp.get("teamId") ?? "").trim();
+  const workflowId = String(sp.get("workflowId") ?? "").trim();
+  const status = String(sp.get("status") ?? "").trim();
+  const since = String(sp.get("since") ?? "").trim();
+  const until = String(sp.get("until") ?? "").trim();
+  const limit = asInt(String(sp.get("limit") ?? ""), 50);
+
+  if (!teamId) return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
+
+  try {
+    // NOTE: we list workflows first (source of truth), then gather their runs.
+    // For MVP, we read run files to extract fields; we cap by `limit` after sorting.
+    const wfFiles = await listWorkflows(teamId);
+    const workflowIds = wfFiles.files
+      .map((f) => (typeof f === "string" && f.endsWith(".workflow.json") ? f.slice(0, -".workflow.json".length) : null))
+      .filter((x): x is string => Boolean(x));
+
+    const candidates: Array<{ workflowId: string; runId: string }> = [];
+
+    for (const wfId of workflowIds) {
+      if (workflowId && wfId !== workflowId) continue;
+      const files = await listWorkflowRuns(teamId, wfId);
+      for (const f of files.files) {
+        const runId = typeof f === "string" && f.endsWith(".run.json") ? f.slice(0, -".run.json".length) : "";
+        if (runId) candidates.push({ workflowId: wfId, runId });
+      }
+    }
+
+    const items: RunListItem[] = [];
+
+    for (const c of candidates) {
+      const run = (await readWorkflowRun(teamId, c.workflowId, c.runId)).run;
+
+      const meta = isRecord(run.meta) ? run.meta : {};
+      const triggerKind = typeof meta.triggerKind === "string" ? meta.triggerKind : undefined;
+
+      const it: RunListItem = {
+        workflowId: c.workflowId,
+        runId: c.runId,
+        status: run.status,
+        startedAt: run.startedAt,
+        endedAt: run.endedAt,
+        summary: typeof run.summary === "string" ? run.summary : undefined,
+        triggerKind,
+      };
+
+      if (status && it.status !== status) continue;
+      if (since && it.startedAt && it.startedAt < since) continue;
+      if (until && it.startedAt && it.startedAt > until) continue;
+
+      items.push(it);
+    }
+
+    items.sort((a, b) => String(b.startedAt ?? "").localeCompare(String(a.startedAt ?? "")));
+
+    return NextResponse.json({ ok: true, runs: items.slice(0, limit) });
+  } catch (e: unknown) {
+    console.warn("/api/teams/runs failed", e);
+    return NextResponse.json({ ok: false, error: errorMessage(e) }, { status: 500 });
+  }
+}

--- a/src/app/teams/[teamId]/runs/[workflowId]/[runId]/page.tsx
+++ b/src/app/teams/[teamId]/runs/[workflowId]/[runId]/page.tsx
@@ -1,0 +1,17 @@
+import RunDetailClient from "./run-detail-client";
+
+export default async function RunDetailPage({
+  params,
+}: {
+  params: Promise<{ teamId: string; workflowId: string; runId: string }>;
+}) {
+  const { teamId, workflowId, runId } = await params;
+
+  return (
+    <div className="p-6">
+      <div className="ck-glass p-6">
+        <RunDetailClient teamId={teamId} workflowId={workflowId} runId={runId} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/teams/[teamId]/runs/[workflowId]/[runId]/run-detail-client.tsx
+++ b/src/app/teams/[teamId]/runs/[workflowId]/[runId]/run-detail-client.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { fetchJson } from "@/lib/fetch-json";
+import { errorMessage } from "@/lib/errors";
+
+type NodeResult = {
+  nodeId: string;
+  status: string;
+  startedAt?: string;
+  endedAt?: string;
+  output?: unknown;
+  error?: unknown;
+};
+
+type RunFile = {
+  id: string;
+  workflowId: string;
+  status: string;
+  startedAt: string;
+  endedAt?: string;
+  summary?: string;
+  nodes?: NodeResult[];
+  approval?: unknown;
+  meta?: unknown;
+};
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return Boolean(v) && typeof v === "object" && !Array.isArray(v);
+}
+
+export default function RunDetailClient({
+  teamId,
+  workflowId,
+  runId,
+}: {
+  teamId: string;
+  workflowId: string;
+  runId: string;
+}) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>("");
+  const [run, setRun] = useState<RunFile | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+
+    try {
+      const json = await fetchJson<{ ok?: boolean; run?: unknown; error?: string }>(
+        `/api/teams/workflow-runs?teamId=${encodeURIComponent(teamId)}&workflowId=${encodeURIComponent(workflowId)}&runId=${encodeURIComponent(runId)}`,
+        { cache: "no-store" }
+      );
+      if (!json.ok) throw new Error(json.error || "Failed to load run");
+      if (!isRecord(json.run)) throw new Error("Invalid run format");
+
+      const r = json.run as Record<string, unknown>;
+      const nodesRaw = Array.isArray(r.nodes) ? r.nodes : [];
+
+      setRun({
+        id: String(r.id ?? runId),
+        workflowId: String(r.workflowId ?? workflowId),
+        status: String(r.status ?? ""),
+        startedAt: String(r.startedAt ?? ""),
+        endedAt: typeof r.endedAt === "string" ? r.endedAt : undefined,
+        summary: typeof r.summary === "string" ? r.summary : undefined,
+        nodes: nodesRaw
+          .map((n) => (isRecord(n) ? n : null))
+          .filter(Boolean)
+          .map((n) => ({
+            nodeId: String((n as Record<string, unknown>).nodeId ?? "").trim(),
+            status: String((n as Record<string, unknown>).status ?? "").trim(),
+            startedAt: typeof (n as Record<string, unknown>).startedAt === "string" ? ((n as Record<string, unknown>).startedAt as string) : undefined,
+            endedAt: typeof (n as Record<string, unknown>).endedAt === "string" ? ((n as Record<string, unknown>).endedAt as string) : undefined,
+            output: (n as Record<string, unknown>).output,
+            error: (n as Record<string, unknown>).error,
+          }))
+          .filter((n) => Boolean(n.nodeId)),
+        approval: r.approval,
+        meta: r.meta,
+      });
+    } catch (e: unknown) {
+      setError(errorMessage(e));
+      setRun(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [teamId, workflowId, runId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const nodes = run?.nodes ?? [];
+
+  const approvalState = useMemo(() => {
+    if (!run || !isRecord(run.approval)) return null;
+    const o = run.approval as Record<string, unknown>;
+    return {
+      nodeId: String(o.nodeId ?? "").trim(),
+      state: String(o.state ?? "").trim(),
+      requestedAt: typeof o.requestedAt === "string" ? o.requestedAt : undefined,
+      decidedAt: typeof o.decidedAt === "string" ? o.decidedAt : undefined,
+      note: typeof o.note === "string" ? o.note : undefined,
+    };
+  }, [run]);
+
+  async function doApprovalAction(action: "approve" | "request_changes" | "cancel") {
+    if (!confirm(`${action.replace(/_/g, " ")}? This will update the run file.`)) return;
+
+    try {
+      const json = await fetchJson<{ ok?: boolean; error?: string }>("/api/teams/workflow-runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ teamId, workflowId, runId, action }),
+      });
+      if (!json.ok) throw new Error(json.error || "Failed to update run");
+      await load();
+    } catch (e: unknown) {
+      alert(errorMessage(e));
+    }
+  }
+
+  if (loading) {
+    return <div className="text-sm text-[color:var(--ck-text-secondary)]">Loading run…</div>;
+  }
+
+  if (error) {
+    return (
+      <div>
+        <div className="text-sm text-red-100">{error}</div>
+        <div className="mt-4">
+          <Link
+            href={`/teams/${encodeURIComponent(teamId)}/runs`}
+            className="text-sm text-[color:var(--ck-text-secondary)] underline"
+          >
+            Back to runs
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (!run) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-xs text-[color:var(--ck-text-tertiary)]">
+            <Link href={`/teams/${encodeURIComponent(teamId)}/runs`} className="underline">
+              Runs
+            </Link>
+            <span> / </span>
+            <span className="font-mono">{workflowId}</span>
+          </div>
+          <h1 className="mt-1 text-lg font-semibold text-[color:var(--ck-text-primary)]">Run detail</h1>
+          <div className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">
+            <span className="font-mono">{run.id}</span> • <span className="font-mono">{run.status}</span>
+          </div>
+          <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+            Started: <span className="font-mono">{run.startedAt}</span>
+            {run.endedAt ? (
+              <>
+                {" "}• Ended: <span className="font-mono">{run.endedAt}</span>
+              </>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/teams/${encodeURIComponent(teamId)}/workflows/${encodeURIComponent(workflowId)}`}
+            className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+          >
+            Open workflow
+          </Link>
+
+          <button
+            type="button"
+            disabled
+            title="Rerun is not wired to a real execution engine yet (sample runs only)."
+            className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] opacity-60"
+          >
+            Rerun
+          </button>
+        </div>
+      </div>
+
+      {run.summary ? (
+        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3 text-sm text-[color:var(--ck-text-secondary)]">
+          {run.summary}
+        </div>
+      ) : null}
+
+      {approvalState && approvalState.state === "pending" ? (
+        <div className="mt-6 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-4">
+          <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Approval</div>
+          <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+            Waiting on node: <span className="font-mono">{approvalState.nodeId}</span>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void doApprovalAction("approve")}
+              className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white"
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              onClick={() => void doApprovalAction("request_changes")}
+              className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+            >
+              Request changes
+            </button>
+            <button
+              type="button"
+              onClick={() => void doApprovalAction("cancel")}
+              className="rounded-[var(--ck-radius-sm)] border border-[color:rgba(255,59,48,0.45)] bg-[color:rgba(255,59,48,0.08)] px-3 py-2 text-sm font-medium text-[color:var(--ck-accent-red)] hover:bg-[color:rgba(255,59,48,0.12)]"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-4">
+          <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Step timeline</div>
+          {nodes.length ? (
+            <ol className="mt-3 space-y-2">
+              {nodes.map((n, idx) => (
+                <li key={`${n.nodeId}-${idx}`} className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium text-[color:var(--ck-text-primary)]">
+                        <span className="font-mono">{n.nodeId}</span>
+                      </div>
+                      <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+                        {n.startedAt ? <span className="font-mono">{n.startedAt}</span> : ""}
+                        {n.endedAt ? (
+                          <>
+                            {" "}→ <span className="font-mono">{n.endedAt}</span>
+                          </>
+                        ) : null}
+                      </div>
+                    </div>
+                    <div className="shrink-0 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-[11px] text-[color:var(--ck-text-secondary)]">
+                      {n.status}
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <div className="mt-2 text-sm text-[color:var(--ck-text-tertiary)]">No nodes recorded for this run yet.</div>
+          )}
+        </div>
+
+        <div className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-4">
+          <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Logs / outputs</div>
+          {nodes.length ? (
+            <div className="mt-3 space-y-3">
+              {nodes.map((n, idx) => (
+                <div key={`${n.nodeId}-${idx}`} className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 p-3">
+                  <div className="text-xs text-[color:var(--ck-text-tertiary)]">
+                    Node: <span className="font-mono">{n.nodeId}</span>
+                  </div>
+
+                  {n.error !== undefined ? (
+                    <pre className="mt-2 overflow-auto rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-2 text-[11px] text-red-100">
+                      {JSON.stringify(n.error, null, 2)}
+                    </pre>
+                  ) : null}
+
+                  {n.output !== undefined ? (
+                    <pre className="mt-2 overflow-auto rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/30 p-2 text-[11px] text-[color:var(--ck-text-secondary)]">
+                      {JSON.stringify(n.output, null, 2)}
+                    </pre>
+                  ) : (
+                    <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">(No output recorded.)</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="mt-2 text-sm text-[color:var(--ck-text-tertiary)]">No logs yet.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/teams/[teamId]/runs/page.tsx
+++ b/src/app/teams/[teamId]/runs/page.tsx
@@ -1,0 +1,24 @@
+import RunsClient from "./runs-client";
+
+export default async function RunsPage({ params }: { params: Promise<{ teamId: string }> }) {
+  const { teamId } = await params;
+
+  return (
+    <div className="p-6">
+      <div className="ck-glass p-6">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">Runs</h1>
+            <p className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">
+              Recent workflow runs for this team (file-first).
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6">
+          <RunsClient teamId={teamId} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/teams/[teamId]/runs/runs-client.tsx
+++ b/src/app/teams/[teamId]/runs/runs-client.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { fetchJson } from "@/lib/fetch-json";
+import { errorMessage } from "@/lib/errors";
+
+type RunsListItem = {
+  workflowId: string;
+  runId: string;
+  status?: string;
+  startedAt?: string;
+  endedAt?: string;
+  summary?: string;
+  triggerKind?: string;
+};
+
+type WorkflowItem = { id: string };
+
+function isoDaysAgo(days: number) {
+  const d = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  return d.toISOString();
+}
+
+export default function RunsClient({ teamId }: { teamId: string }) {
+  const [workflows, setWorkflows] = useState<WorkflowItem[]>([]);
+  const [loadingWorkflows, setLoadingWorkflows] = useState(true);
+
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string>("");
+
+  const [items, setItems] = useState<RunsListItem[]>([]);
+
+  const [workflowId, setWorkflowId] = useState<string>("");
+  const [status, setStatus] = useState<string>("");
+  const [range, setRange] = useState<string>("7d");
+
+  const sinceIso = useMemo(() => {
+    if (range === "24h") return isoDaysAgo(1);
+    if (range === "7d") return isoDaysAgo(7);
+    if (range === "30d") return isoDaysAgo(30);
+    return "";
+  }, [range]);
+
+  const loadWorkflows = useCallback(async () => {
+    setLoadingWorkflows(true);
+    try {
+      const json = await fetchJson<{ ok?: boolean; files?: string[] }>(
+        `/api/teams/workflows?teamId=${encodeURIComponent(teamId)}`,
+        { cache: "no-store" }
+      );
+      const files = Array.isArray(json.files) ? json.files : [];
+      const ids = files
+        .map((f) => (typeof f === "string" && f.endsWith(".workflow.json") ? f.slice(0, -".workflow.json".length) : null))
+        .filter((x): x is string => Boolean(x));
+      setWorkflows(ids.map((id) => ({ id })));
+    } finally {
+      setLoadingWorkflows(false);
+    }
+  }, [teamId]);
+
+  const loadRuns = useCallback(
+    async (opts?: { quiet?: boolean }) => {
+      const quiet = Boolean(opts?.quiet);
+      setError("");
+      if (!quiet) setLoading(true);
+
+      try {
+        const qs = new URLSearchParams();
+        qs.set("teamId", teamId);
+        if (workflowId) qs.set("workflowId", workflowId);
+        if (status) qs.set("status", status);
+        if (sinceIso) qs.set("since", sinceIso);
+        qs.set("limit", "100");
+
+        const json = await fetchJson<{ ok?: boolean; runs?: RunsListItem[]; error?: string }>(
+          `/api/teams/runs?${qs.toString()}`,
+          { cache: "no-store" }
+        );
+        if (!json.ok) throw new Error(json.error || "Failed to load runs");
+        setItems(Array.isArray(json.runs) ? json.runs : []);
+      } catch (e: unknown) {
+        setError(errorMessage(e));
+        setItems([]);
+      } finally {
+        if (!quiet) setLoading(false);
+      }
+    },
+    [teamId, workflowId, status, sinceIso]
+  );
+
+  useEffect(() => {
+    void loadWorkflows();
+  }, [loadWorkflows]);
+
+  useEffect(() => {
+    void loadRuns();
+  }, [loadRuns]);
+
+  async function onRefresh() {
+    setRefreshing(true);
+    try {
+      await Promise.all([loadWorkflows(), loadRuns({ quiet: true })]);
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  const statusOptions = useMemo(
+    () => ["running", "waiting_for_approval", "success", "error", "canceled"],
+    []
+  );
+
+  if (loading) {
+    return <div className="text-sm text-[color:var(--ck-text-secondary)]">Loading runs…</div>;
+  }
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="block">
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">workflow</div>
+            <select
+              value={workflowId}
+              onChange={(e) => setWorkflowId(String(e.target.value || ""))}
+              disabled={loadingWorkflows}
+              className="mt-1 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-2 text-sm text-[color:var(--ck-text-primary)] disabled:opacity-60"
+            >
+              <option value="">All workflows</option>
+              {workflows.map((w) => (
+                <option key={w.id} value={w.id}>
+                  {w.id}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block">
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">status</div>
+            <select
+              value={status}
+              onChange={(e) => setStatus(String(e.target.value || ""))}
+              className="mt-1 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-2 text-sm text-[color:var(--ck-text-primary)]"
+            >
+              <option value="">All statuses</option>
+              {statusOptions.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block">
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">time range</div>
+            <select
+              value={range}
+              onChange={(e) => setRange(String(e.target.value || "7d"))}
+              className="mt-1 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-2 text-sm text-[color:var(--ck-text-primary)]"
+            >
+              <option value="24h">Last 24h</option>
+              <option value="7d">Last 7d</option>
+              <option value="30d">Last 30d</option>
+              <option value="all">All</option>
+            </select>
+          </label>
+        </div>
+
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={refreshing}
+          className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10 disabled:opacity-60"
+        >
+          {refreshing ? "Refreshing…" : "Refresh"}
+        </button>
+      </div>
+
+      {error ? (
+        <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-4 text-sm text-red-100">
+          {error}
+        </div>
+      ) : null}
+
+      {items.length === 0 ? (
+        <div className="mt-6 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-4 text-sm text-[color:var(--ck-text-secondary)]">
+          No runs found for the selected filters.
+          <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
+            Tip: open a workflow and click <span className="font-mono">+ Sample run</span> to generate a demo run file.
+          </div>
+        </div>
+      ) : (
+        <div className="mt-6 overflow-hidden rounded-[var(--ck-radius-sm)] border border-white/10">
+          <div className="grid grid-cols-12 gap-2 bg-white/5 px-3 py-2 text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">
+            <div className="col-span-4">Run</div>
+            <div className="col-span-3">Workflow</div>
+            <div className="col-span-2">Status</div>
+            <div className="col-span-3">Started</div>
+          </div>
+
+          <ul className="divide-y divide-white/10">
+            {items.map((it) => (
+              <li key={`${it.workflowId}:${it.runId}`} className="bg-black/10 hover:bg-white/5">
+                <Link
+                  href={`/teams/${encodeURIComponent(teamId)}/runs/${encodeURIComponent(it.workflowId)}/${encodeURIComponent(it.runId)}`}
+                  className="grid grid-cols-12 gap-2 px-3 py-2"
+                >
+                  <div className="col-span-4 truncate font-mono text-xs text-[color:var(--ck-text-primary)]">{it.runId}</div>
+                  <div className="col-span-3 truncate text-xs text-[color:var(--ck-text-secondary)]">{it.workflowId}</div>
+                  <div className="col-span-2 truncate text-xs text-[color:var(--ck-text-secondary)]">{it.status ?? ""}</div>
+                  <div className="col-span-3 truncate text-xs text-[color:var(--ck-text-tertiary)]">{it.startedAt ?? ""}</div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -722,10 +722,15 @@ export default function WorkflowsEditorClient({
               const approvalProvider = String(meta.approvalProvider ?? "telegram").trim() || "telegram";
               const approvalTarget = String(meta.approvalTarget ?? "").trim();
 
+              // Cron schedule suggestions.
+              // Note: dev-team automation defaults should avoid the 02:00–07:00 America/New_York blackout window.
+              // We keep presets in "safe" hours by default.
               const presets = [
                 { label: "(no preset)", expr: "" },
+                { label: "Weekdays 09:00 local", expr: "0 9 * * 1-5" },
                 { label: "Mon/Wed/Fri 09:00 local", expr: "0 9 * * 1,3,5" },
                 { label: "Daily 08:00 local", expr: "0 8 * * *" },
+                { label: "Daily 12:00 local", expr: "0 12 * * *" },
                 { label: "Mon 09:30 local", expr: "30 9 * * 1" },
               ];
 
@@ -889,7 +894,6 @@ export default function WorkflowsEditorClient({
                                       value={presets.some((p) => p.expr === expr) ? expr : ""}
                                       onChange={(e) => {
                                         const nextExpr = e.target.value;
-                                        if (!nextExpr) return;
                                         setWorkflow({
                                           ...wf,
                                           triggers: triggers.map((x, idx) => (idx === i && x.kind === "cron" ? { ...x, expr: nextExpr } : x)),

--- a/src/app/teams/[teamId]/workflows/page.tsx
+++ b/src/app/teams/[teamId]/workflows/page.tsx
@@ -32,6 +32,15 @@ export default async function WorkflowsPage({
             Create and edit workflow definitions for this team.
           </p>
         </div>
+
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/teams/${encodeURIComponent(teamId)}/runs`}
+            className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+          >
+            View runs
+          </Link>
+        </div>
       </div>
 
       <WorkflowsClient teamId={teamId} />

--- a/src/app/teams/[teamId]/workflows/workflows-client.tsx
+++ b/src/app/teams/[teamId]/workflows/workflows-client.tsx
@@ -179,6 +179,13 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
             Add workflow
           </Link>
 
+          <Link
+            href={`/teams/${encodeURIComponent(teamId)}/runs`}
+            className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+          >
+            Runs
+          </Link>
+
           <button
             type="button"
             onClick={onRefresh}


### PR DESCRIPTION
Implements ticket #0100 (Runs dashboard MVP).\n\nWhat\n- Adds a team Runs surface:\n  - /teams/[teamId]/runs (list w/ filters: workflow, status, time range)\n  - /teams/[teamId]/runs/[workflowId]/[runId] (detail with step timeline + per-node outputs/errors)\n- Adds API: /api/teams/runs (aggregates runs across workflows; file-first)\n- Adds links from Workflows page + Workflows tab to Runs.\n- Rerun button is present but disabled (execution engine not wired; sample runs only).\n\nVerification\n1) Open a workflow and click '+ Sample run' to create a run file.\n2) Visit /teams/<teamId>/runs and confirm run appears.\n3) Filter by workflow + status; confirm list updates.\n4) Click a run and confirm timeline + logs render.