### PR TITLE
Workflows: approval gate node config + run approval actions

### DIFF
--- a/src/app/api/teams/workflow-runs/route.ts
+++ b/src/app/api/teams/workflow-runs/route.ts
@@ -132,6 +132,7 @@ export async function POST(req: Request) {
   const action = String(o.action ?? "").trim();
   const runIdFromBody = String(o.runId ?? "").trim();
   const note = typeof o.note === "string" ? o.note : undefined;
+  const decidedBy = typeof o.decidedBy === "string" ? o.decidedBy : undefined;
 
   if (!teamId) return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
   if (!workflowId) return NextResponse.json({ ok: false, error: "workflowId is required" }, { status: 400 });
@@ -170,6 +171,7 @@ export async function POST(req: Request) {
                   ...existingOutput,
                   decision: nextState,
                   note,
+                  decidedBy,
                 },
               };
             }
@@ -209,6 +211,7 @@ export async function POST(req: Request) {
           requestedAt: run.approval?.requestedAt,
           decidedAt: nextState === "changes_requested" ? undefined : decidedAt,
           note,
+          decidedBy,
         },
         nodes: nextNodes,
       };

--- a/src/app/api/teams/workflow-runs/route.ts
+++ b/src/app/api/teams/workflow-runs/route.ts
@@ -57,6 +57,26 @@ function formatApprovalPacketMessage(workflow: WorkflowFileV1, run: WorkflowRunF
   return body;
 }
 
+function applyTemplate(template: string, vars: Record<string, string>) {
+  let out = template;
+  for (const [k, v] of Object.entries(vars)) {
+    out = out.replaceAll(`{{${k}}}`, v);
+  }
+  return out;
+}
+
+function getApprovalSendConfig(workflow: WorkflowFileV1, approvalNodeId: string) {
+  const meta = isRecord(workflow.meta) ? workflow.meta : {};
+  const node = Array.isArray(workflow.nodes) ? workflow.nodes.find((n) => n.id === approvalNodeId) : undefined;
+  const cfg = node && isRecord(node.config) ? node.config : {};
+
+  const provider = String(cfg.provider ?? cfg.channel ?? meta.approvalProvider ?? "telegram").trim() || "telegram";
+  const target = String(cfg.target ?? cfg.chatId ?? meta.approvalTarget ?? "").trim();
+  const messageTemplate = String(cfg.messageTemplate ?? cfg.template ?? "").trim();
+
+  return { provider, target, messageTemplate };
+}
+
 async function maybeSendApprovalRequest({
   teamId,
   workflow,
@@ -68,12 +88,18 @@ async function maybeSendApprovalRequest({
   run: WorkflowRunFileV1;
   approvalNodeId: string;
 }) {
-  const meta = isRecord(workflow.meta) ? workflow.meta : {};
-  const provider = String(meta.approvalProvider ?? "telegram").trim() || "telegram";
-  const target = String(meta.approvalTarget ?? "").trim();
+  const { provider, target, messageTemplate } = getApprovalSendConfig(workflow, approvalNodeId);
   if (!target) return;
 
-  const message = formatApprovalPacketMessage(workflow, run, approvalNodeId);
+  const base = formatApprovalPacketMessage(workflow, run, approvalNodeId);
+  const message = messageTemplate
+    ? `${applyTemplate(messageTemplate, {
+        workflowName: workflow.name || workflow.id,
+        workflowId: workflow.id,
+        runId: run.id,
+        nodeId: approvalNodeId,
+      })}\n\n${base}`
+    : base;
 
   // Best-effort: message delivery failures should not block file-first persistence.
   await toolsInvoke({
@@ -360,9 +386,7 @@ export async function POST(req: Request) {
             };
 
             if (approvalNodeId) {
-              const meta = isRecord(wf.meta) ? wf.meta : {};
-              const provider = String(meta.approvalProvider ?? "telegram").trim() || "telegram";
-              const target = String(meta.approvalTarget ?? "").trim();
+              const { provider, target } = getApprovalSendConfig(wf, approvalNodeId);
 
               if (target) {
                 try {

--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -683,6 +683,64 @@ export default function WorkflowsEditorClient({
                         />
                       </label>
 
+                      {node.type === "human_approval" ? (
+                        <div className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-2">
+                          <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">approval config</div>
+
+                          <div className="mt-2 space-y-2">
+                            <label className="block">
+                              <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">provider</div>
+                              <input
+                                value={String((cfg as Record<string, unknown>).provider ?? "")}
+                                onChange={(e) => {
+                                  const v = String(e.target.value || "").trim();
+                                  const nextCfg = { ...cfg, ...(v ? { provider: v } : {}) };
+                                  if (!v) delete (nextCfg as Record<string, unknown>).provider;
+                                  setWorkflow({ ...wf, nodes: wf.nodes.map((n) => (n.id === node.id ? { ...n, config: nextCfg } : n)) });
+                                }}
+                                className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-1 text-xs text-[color:var(--ck-text-primary)]"
+                                placeholder="telegram"
+                              />
+                            </label>
+
+                            <label className="block">
+                              <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">target</div>
+                              <input
+                                value={String((cfg as Record<string, unknown>).target ?? "")}
+                                onChange={(e) => {
+                                  const v = String(e.target.value || "").trim();
+                                  const nextCfg = { ...cfg, ...(v ? { target: v } : {}) };
+                                  if (!v) delete (nextCfg as Record<string, unknown>).target;
+                                  setWorkflow({ ...wf, nodes: wf.nodes.map((n) => (n.id === node.id ? { ...n, config: nextCfg } : n)) });
+                                }}
+                                className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-1 text-xs text-[color:var(--ck-text-primary)]"
+                                placeholder="(e.g. Telegram chat id)"
+                              />
+                              <div className="mt-1 text-[10px] text-[color:var(--ck-text-tertiary)]">Overrides workflow-level default when set.</div>
+                            </label>
+
+                            <label className="block">
+                              <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">messageTemplate (optional)</div>
+                              <textarea
+                                value={String((cfg as Record<string, unknown>).messageTemplate ?? "")}
+                                onChange={(e) => {
+                                  const v = String(e.target.value || "");
+                                  const nextCfg = { ...cfg, ...(v.trim() ? { messageTemplate: v } : {}) };
+                                  if (!v.trim()) delete (nextCfg as Record<string, unknown>).messageTemplate;
+                                  setWorkflow({ ...wf, nodes: wf.nodes.map((n) => (n.id === node.id ? { ...n, config: nextCfg } : n)) });
+                                }}
+                                className="mt-1 h-[70px] w-full resize-none rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 p-2 font-mono text-[10px] text-[color:var(--ck-text-primary)]"
+                                placeholder="Approval needed for {{workflowName}} (run {{runId}})"
+                                spellCheck={false}
+                              />
+                              <div className="mt-1 text-[10px] text-[color:var(--ck-text-tertiary)]">
+                                Vars: {"{{workflowName}}"}, {"{{workflowId}}"}, {"{{runId}}"}, {"{{nodeId}}"}
+                              </div>
+                            </label>
+                          </div>
+                        </div>
+                      ) : null}
+
                       <label className="block">
                         <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">config (json)</div>
                         <textarea

--- a/src/lib/workflows/runs-types.ts
+++ b/src/lib/workflows/runs-types.ts
@@ -14,6 +14,16 @@ export type WorkflowRunApprovalV1 = {
   decidedAt?: string;
   /** Freeform notes from the approver (optional) */
   note?: string;
+  /** Who made the decision (MVP: typically "ClawKitchen UI" or channel metadata) */
+  decidedBy?: string;
+  /** Outbound delivery metadata for the approval request (best-effort) */
+  outbound?: {
+    provider: string;
+    target: string;
+    sentAt?: string;
+    attemptedAt?: string;
+    error?: string;
+  };
 };
 
 export type WorkflowRunFileV1 = {


### PR DESCRIPTION
Implements MVP for #0101 (HITL approval node):\n\n- Node-level config for human_approval nodes (provider/target/template) in workflow editor\n- Workflow runs API sends approval request using node config (workflow meta fallback)\n- Runs detail UI now shows approval audit fields + outbound metadata\n- Runs detail provides Approve / Request changes / Cancel actions (file-first), writes decision + note\n\nVerification:\n- npm run lint (warnings only)\n- npm run build (pass)\n- In /teams/<teamId>/workflows: open a workflow, create sample run with a human_approval node, confirm it shows Awaiting Approval + actions\n\nNotes:\n- decidedBy is MVP set to "ClawKitchen UI" (no auth yet).