### PR TITLE
Workflows editor UI: match mock (collapsible panels, back button, tools collapse)

### DIFF
--- a/src/app/teams/[teamId]/workflows/[workflowId]/page.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { unstable_noStore as noStore } from "next/cache";
 import WorkflowsEditorClient from "./workflows-editor-client";
 
@@ -19,20 +18,10 @@ export default async function WorkflowEditorPage({
   const draftRaw = sp.draft;
   const draft = Array.isArray(draftRaw) ? draftRaw[0] : draftRaw;
 
+  // Full-bleed workflows editor (no extra top row / padding / border).
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="px-6 pt-6">
-        <Link
-          href={`/teams/${encodeURIComponent(teamId)}?tab=workflows`}
-          className="text-sm font-medium hover:underline"
-        >
-          ← Back
-        </Link>
-      </div>
-
-      <div className="flex min-h-0 flex-1 flex-col p-6 pt-4">
-        <WorkflowsEditorClient teamId={teamId} workflowId={workflowId} draft={draft === "1"} />
-      </div>
+      <WorkflowsEditorClient teamId={teamId} workflowId={workflowId} draft={draft === "1"} />
     </div>
   );
 }


### PR DESCRIPTION
Implements ticket #0110.

Changes:
- Full-bleed editor page (removes extra top padding/chrome)
- Back button label + placement per mock
- Right-side panels are collapsible via native <details>
- Tools palette can collapse into a small rail
- Fixes node drag regression via pointer capture

Verification:
- npm run lint (warnings only)
- npm run build ✅