### PR TITLE
fix: creating a new workflow should start with a clean canvas

### DIFF
--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -69,21 +69,26 @@ export default function WorkflowsEditorClient({
             return;
           }
 
-          // New workflow drafts should not hit the filesystem-backed API.
-          if (workflowId === "new") {
-            const empty: WorkflowFileV1 = {
-              schema: "clawkitchen.workflow.v1",
-              id: "new-workflow",
-              name: "New workflow",
-              nodes: [
-                { id: "start", type: "start", x: 80, y: 80 },
-                { id: "end", type: "end", x: 320, y: 80 },
-              ],
-              edges: [{ id: "e1", from: "start", to: "end" }],
-            };
-            setStatus({ kind: "ready", jsonText: JSON.stringify(empty, null, 2) + "\n" });
-            return;
+          // New draft: initialize a clean workflow instead of trying to fetch an existing file.
+          const initial: WorkflowFileV1 = {
+            schema: "clawkitchen.workflow.v1",
+            id: workflowId,
+            name: "New workflow",
+            timezone: "UTC",
+            nodes: [
+              { id: "start", type: "start", name: "start", x: 80, y: 80, config: {} },
+              { id: "end", type: "end", name: "end", x: 520, y: 80, config: {} },
+            ],
+            edges: [{ id: "e1", from: "start", to: "end" }],
+          };
+          const text = JSON.stringify(initial, null, 2) + "\n";
+          setStatus({ kind: "ready", jsonText: text });
+          try {
+            sessionStorage.setItem(draftKey(teamId, workflowId), text);
+          } catch {
+            // ignore
           }
+          return;
         }
 
         const res = await fetch(

--- a/src/app/teams/[teamId]/workflows/workflows-client.tsx
+++ b/src/app/teams/[teamId]/workflows/workflows-client.tsx
@@ -139,28 +139,6 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
     }
   }
 
-  async function onAddTemplate(templateId: string) {
-    if (!confirm(`Add workflow from template “${templateId}”?`)) return;
-    setError("");
-    try {
-      const json = await fetchJson<{ ok?: boolean; workflowId?: string; error?: string }>(
-        `/api/teams/workflow-templates`,
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ teamId, templateId }),
-        }
-      );
-      if (!json.ok) throw new Error(json.error || "Failed to apply template");
-      const workflowId = String(json.workflowId ?? "").trim();
-      if (!workflowId) throw new Error("Template applied but workflowId missing");
-      await load({ quiet: true });
-      router.push(`/teams/${encodeURIComponent(teamId)}/workflows/${encodeURIComponent(workflowId)}`);
-    } catch (e: unknown) {
-      setError(errorMessage(e));
-    }
-  }
-
   const memoryUsedItems = useMemo(() => {
     const run = selectedRun;
     if (!run) return [] as Array<{ ts: string; author: string; type: string; content: string; source?: unknown }>;
@@ -205,13 +183,6 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
             Add workflow
           </button>
 
-          <button
-            type="button"
-            onClick={() => void onAddTemplate("marketing-cadence-v1")}
-            className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
-          >
-            Add Marketing Cadence template
-          </button>
 
           <button
             type="button"

--- a/src/app/teams/[teamId]/workflows/workflows-client.tsx
+++ b/src/app/teams/[teamId]/workflows/workflows-client.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { fetchJson } from "@/lib/fetch-json";
 import { errorMessage } from "@/lib/errors";
 
@@ -19,6 +20,7 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 export default function WorkflowsClient({ teamId }: { teamId: string }) {
+  const router = useRouter();
   const [workflows, setWorkflows] = useState<Array<{ id: string; name?: string }>>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -137,7 +139,27 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
     }
   }
 
-  // (template button removed)
+  async function onAddTemplate(templateId: string) {
+    if (!confirm(`Add workflow from template “${templateId}”?`)) return;
+    setError("");
+    try {
+      const json = await fetchJson<{ ok?: boolean; workflowId?: string; error?: string }>(
+        `/api/teams/workflow-templates`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ teamId, templateId }),
+        }
+      );
+      if (!json.ok) throw new Error(json.error || "Failed to apply template");
+      const workflowId = String(json.workflowId ?? "").trim();
+      if (!workflowId) throw new Error("Template applied but workflowId missing");
+      await load({ quiet: true });
+      router.push(`/teams/${encodeURIComponent(teamId)}/workflows/${encodeURIComponent(workflowId)}`);
+    } catch (e: unknown) {
+      setError(errorMessage(e));
+    }
+  }
 
   const memoryUsedItems = useMemo(() => {
     const run = selectedRun;
@@ -172,12 +194,24 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
         </p>
 
         <div className="mt-3 flex flex-wrap items-center justify-start gap-2">
-          <Link
-            href={`/teams/${encodeURIComponent(teamId)}/workflows/new?draft=1`}
+          <button
+            type="button"
+            onClick={() => {
+              const id = `new-${Date.now()}`;
+              router.push(`/teams/${encodeURIComponent(teamId)}/workflows/${encodeURIComponent(id)}?draft=1`);
+            }}
             className="rounded-[var(--ck-radius-sm)] bg-[var(--ck-accent-red)] px-3 py-2 text-sm font-medium text-white shadow-[var(--ck-shadow-1)]"
           >
             Add workflow
-          </Link>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => void onAddTemplate("marketing-cadence-v1")}
+            className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+          >
+            Add Marketing Cadence template
+          </button>
 
           <button
             type="button"


### PR DESCRIPTION
Fixes bug where creating a new workflow would reuse the previous draft state.

- Workflows page now navigates to a unique draft route id (new-<timestamp>)
- Editor initializes a fresh workflow JSON when draft=1 and no stored draft exists

QA:
1) Open a draft workflow, add nodes
2) Leave the page
3) Click Add workflow
4) Confirm canvas is clean