### PR TITLE
Workflows: add Marketing Cadence template

### DIFF
--- a/src/app/api/teams/workflow-templates/route.ts
+++ b/src/app/api/teams/workflow-templates/route.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { jsonOkRest, parseJsonBody } from "@/lib/api-route-helpers";
+import { errorMessage } from "@/lib/errors";
+import { getTeamWorkspaceDir } from "@/lib/paths";
+import { listWorkflows, writeWorkflow } from "@/lib/workflows/storage";
+import { marketingCadenceWorkflowV1 } from "@/lib/workflows/templates";
+
+async function exists(p: string) {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function nextAvailableId(baseId: string, existing: Set<string>) {
+  if (!existing.has(baseId)) return baseId;
+  for (let i = 2; i < 1000; i++) {
+    const id = `${baseId}-${i}`;
+    if (!existing.has(id)) return id;
+  }
+  return `${baseId}-${Date.now()}`;
+}
+
+async function ensureFile(p: string, content: string) {
+  if (await exists(p)) return;
+  await fs.mkdir(path.dirname(p), { recursive: true });
+  await fs.writeFile(p, content, "utf8");
+}
+
+export async function POST(req: Request) {
+  const parsed = await parseJsonBody(req);
+  if (parsed instanceof NextResponse) return parsed;
+  const { body: o } = parsed;
+
+  const teamId = String(o.teamId ?? "").trim();
+  const templateId = String(o.templateId ?? "").trim();
+
+  if (!teamId) return NextResponse.json({ ok: false, error: "teamId is required" }, { status: 400 });
+  if (!templateId) return NextResponse.json({ ok: false, error: "templateId is required" }, { status: 400 });
+
+  try {
+    if (templateId !== "marketing-cadence-v1") {
+      return NextResponse.json({ ok: false, error: `Unknown templateId: ${templateId}` }, { status: 400 });
+    }
+
+    const listed = await listWorkflows(teamId);
+    const existingIds = new Set(
+      listed.files
+        .map((f) => (typeof f === "string" && f.endsWith(".workflow.json") ? f.slice(0, -".workflow.json".length) : null))
+        .filter((x): x is string => Boolean(x))
+    );
+
+    const id = nextAvailableId("marketing-cadence-v1", existingIds);
+
+    const wf = marketingCadenceWorkflowV1({ id, approvalProvider: "telegram", approvalTarget: "" });
+    const writeRes = await writeWorkflow(teamId, wf);
+
+    // Ensure canonical file-first destinations exist so demo doesn't 404.
+    const teamDir = await getTeamWorkspaceDir(teamId);
+    await ensureFile(path.join(teamDir, "shared-context", "marketing", "POST_LOG.md"), "");
+    await ensureFile(path.join(teamDir, "shared-context", "memory", "marketing_learnings.jsonl"), "");
+
+    return jsonOkRest({ ...writeRes, workflowId: wf.id, templateId });
+  } catch (err: unknown) {
+    return NextResponse.json({ ok: false, error: errorMessage(err) }, { status: 500 });
+  }
+}

--- a/src/app/teams/[teamId]/workflows/workflows-client.tsx
+++ b/src/app/teams/[teamId]/workflows/workflows-client.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { fetchJson } from "@/lib/fetch-json";
 import { errorMessage } from "@/lib/errors";
 
@@ -19,6 +20,7 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 export default function WorkflowsClient({ teamId }: { teamId: string }) {
+  const router = useRouter();
   const [workflows, setWorkflows] = useState<Array<{ id: string; name?: string }>>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -139,6 +141,25 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
 
   // (template button removed)
 
+  async function onAddTemplate(templateId: string) {
+    if (!confirm(`Add workflow from template “${templateId}”?`)) return;
+    setError("");
+    try {
+      const json = await fetchJson<{ ok?: boolean; workflowId?: string; error?: string }>("/api/teams/workflow-templates", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ teamId, templateId }),
+      });
+      if (!json.ok) throw new Error(json.error || "Failed to apply template");
+      const workflowId = String(json.workflowId ?? "").trim();
+      if (!workflowId) throw new Error("Template applied but workflowId missing");
+      await load({ quiet: true });
+      router.push(`/teams/${encodeURIComponent(teamId)}/workflows/${encodeURIComponent(workflowId)}`);
+    } catch (e: unknown) {
+      setError(errorMessage(e));
+    }
+  }
+
   const memoryUsedItems = useMemo(() => {
     const run = selectedRun;
     if (!run) return [] as Array<{ ts: string; author: string; type: string; content: string; source?: unknown }>;
@@ -178,6 +199,14 @@ export default function WorkflowsClient({ teamId }: { teamId: string }) {
           >
             Add workflow
           </Link>
+
+          <button
+            type="button"
+            onClick={() => void onAddTemplate("marketing-cadence-v1")}
+            className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+          >
+            Add Marketing Cadence template
+          </button>
 
           <button
             type="button"

--- a/src/lib/workflows/templates/index.ts
+++ b/src/lib/workflows/templates/index.ts
@@ -1,0 +1,1 @@
+export { marketingCadenceWorkflowV1 } from "@/lib/workflows/templates/marketing-cadence-v1";

--- a/src/lib/workflows/templates/marketing-cadence-v1.ts
+++ b/src/lib/workflows/templates/marketing-cadence-v1.ts
@@ -1,0 +1,142 @@
+import type { WorkflowFileV1 } from "@/lib/workflows/types";
+
+export function marketingCadenceWorkflowV1(opts?: { id?: string; approvalProvider?: string; approvalTarget?: string }): WorkflowFileV1 {
+  const id = String(opts?.id ?? "marketing-cadence-v1").trim() || "marketing-cadence-v1";
+  const approvalProvider = String(opts?.approvalProvider ?? "telegram").trim() || "telegram";
+  const approvalTarget = String(opts?.approvalTarget ?? "").trim();
+
+  return {
+    schema: "clawkitchen.workflow.v1",
+    id,
+    name: "Marketing Cadence (v1)",
+    version: 1,
+    timezone: "America/New_York",
+    triggers: [
+      {
+        kind: "cron",
+        id: "t-weekdays-9",
+        name: "Weekdays 09:00",
+        enabled: true,
+        expr: "0 9 * * 1-5",
+        tz: "America/New_York",
+      },
+    ],
+    meta: {
+      templateId: "marketing-cadence-v1",
+      approvalProvider,
+      approvalTarget,
+      writeback: {
+        postLogPath: "shared-context/marketing/POST_LOG.md",
+        learningsJsonlPath: "shared-context/memory/marketing_learnings.jsonl",
+      },
+      platforms: ["x", "instagram", "tiktok", "youtube"],
+    },
+    nodes: [
+      { id: "start", type: "start", name: "Start", x: 60, y: 120, config: {} },
+      {
+        id: "research",
+        type: "llm",
+        name: "Research + idea",
+        x: 300,
+        y: 80,
+        config: {
+          agentId: "marketing-research",
+          promptTemplate:
+            "Do competitive + trend research. Produce: 5 angles + supporting bullets. Output JSON: {angles:[...], sources:[...]}" as string,
+        },
+      },
+      {
+        id: "draft_assets",
+        type: "llm",
+        name: "Draft platform assets",
+        x: 560,
+        y: 80,
+        config: {
+          agentId: "marketing-writer",
+          promptTemplate:
+            "Using the research output, draft platform-specific variants for X/Instagram/TikTok/YouTube. Output JSON: {platforms:{x:{hook,body},instagram:{hook,body,assetNotes},tiktok:{hook,script,assetNotes},youtube:{hook,script,assetNotes}}}" as string,
+        },
+      },
+      {
+        id: "qc_brand",
+        type: "llm",
+        name: "QC / brand consistency",
+        x: 820,
+        y: 80,
+        config: {
+          agentId: "brand-qc",
+          promptTemplate:
+            "Review drafts for consistency. Apply corrections. Ensure: mention ClawRecipes before OpenClaw; no posting without approval. Output JSON: {platforms:{...}, notes:[...]}" as string,
+        },
+      },
+      {
+        id: "approval",
+        type: "human_approval",
+        name: "Human approval",
+        x: 1080,
+        y: 80,
+        config: {
+          provider: approvalProvider,
+          target: approvalTarget || "(set in UI)",
+          messageTemplate:
+            "{{workflow.name}} — Approval needed\nRun: {{run.id}}\n\n{{packet.note}}" as string,
+        },
+      },
+      {
+        id: "post_to_platforms",
+        type: "tool",
+        name: "Post (after approval)",
+        x: 1340,
+        y: 80,
+        config: {
+          tool: "marketing.post_all",
+          args: {
+            platforms: ["x", "instagram", "tiktok", "youtube"],
+            draftsFromNode: "qc_brand",
+          },
+        },
+      },
+      {
+        id: "write_post_log",
+        type: "tool",
+        name: "Append POST_LOG.md",
+        x: 1600,
+        y: 60,
+        config: {
+          tool: "fs.append",
+          args: {
+            path: "shared-context/marketing/POST_LOG.md",
+            content: "- {{date}} {{platforms}} posted. Run={{run.id}}\\n" as string,
+          },
+        },
+      },
+      {
+        id: "write_learnings",
+        type: "tool",
+        name: "Append marketing_learnings.jsonl",
+        x: 1600,
+        y: 140,
+        config: {
+          tool: "fs.append",
+          args: {
+            path: "shared-context/memory/marketing_learnings.jsonl",
+            content:
+              "{\"ts\":\"{{date}}\",\"runId\":\"{{run.id}}\",\"notes\":{{qc_brand.notes_json}}}\\n" as string,
+          },
+        },
+      },
+      { id: "end", type: "end", name: "End", x: 1860, y: 120, config: {} },
+    ],
+    edges: [
+      { id: "e-start-research", from: "start", to: "research" },
+      { id: "e-research-draft", from: "research", to: "draft_assets" },
+      { id: "e-draft-qc", from: "draft_assets", to: "qc_brand" },
+      { id: "e-qc-approval", from: "qc_brand", to: "approval" },
+      { id: "e-approval-post", from: "approval", to: "post_to_platforms" },
+      { id: "e-post-log", from: "post_to_platforms", to: "write_post_log" },
+      { id: "e-post-learnings", from: "post_to_platforms", to: "write_learnings" },
+      { id: "e-log-end", from: "write_post_log", to: "end" },
+      { id: "e-learnings-end", from: "write_learnings", to: "end" },
+    ],
+  };
+}


### PR DESCRIPTION
Implements ticket #0102 follow-up: adds a first-class Marketing Cadence (v1) workflow template in ClawKitchen.\n\nWhat\n- Adds /api/teams/workflow-templates POST endpoint (currently supports marketing-cadence-v1).\n- Adds workflow template builder (marketingCadenceWorkflowV1) matching the canonical spec in dev-team ticket #0102.\n- Workflows list UI: adds "Add Marketing Cadence template" button to create the workflow file and navigate to it.\n- Ensures canonical writeback destinations exist (creates empty shared-context/marketing/POST_LOG.md and shared-context/memory/marketing_learnings.jsonl if missing).\n\nVerification\n- In Kitchen: Teams → Workflows → click "Add Marketing Cadence template".\n- Confirm a new workflow appears (marketing-cadence-v1 or -2 if already exists) and opens in editor.\n- Confirm POST_LOG.md + marketing_learnings.jsonl exist in the team workspace.\n- npm run lint (warnings only), npm run build (pass).\n