### PR TITLE
Workflows: Approval channel bindings dropdown (0101)

### DIFF
--- a/src/app/api/__tests__/channels-bindings-route.test.ts
+++ b/src/app/api/__tests__/channels-bindings-route.test.ts
@@ -6,17 +6,24 @@ vi.mock("@/lib/gateway", () => ({
   gatewayConfigPatch: vi.fn(),
 }));
 
+vi.mock("@/lib/paths", () => ({
+  readOpenClawConfig: vi.fn(),
+}));
+
 import { gatewayConfigGet, gatewayConfigPatch } from "@/lib/gateway";
+import { readOpenClawConfig } from "@/lib/paths";
 
 describe("api channels bindings route", () => {
   beforeEach(() => {
     vi.mocked(gatewayConfigGet).mockReset();
     vi.mocked(gatewayConfigPatch).mockReset();
+    vi.mocked(readOpenClawConfig).mockReset();
 
     vi.mocked(gatewayConfigGet).mockResolvedValue({
       raw: JSON.stringify({ channels: { telegram: { botToken: "x" } } }),
       hash: "abc",
     });
+    vi.mocked(readOpenClawConfig).mockResolvedValue({ bindings: [] } as never);
     vi.mocked(gatewayConfigPatch).mockResolvedValue(undefined);
   });
 
@@ -28,6 +35,7 @@ describe("api channels bindings route", () => {
       expect(json.ok).toBe(true);
       expect(json.channels).toEqual({ telegram: { botToken: "x" } });
       expect(json.hash).toBe("abc");
+      expect(json.bindings).toEqual([]);
     });
 
     it("returns empty channels when invalid JSON", async () => {

--- a/src/app/api/teams/workflow-runs/route.ts
+++ b/src/app/api/teams/workflow-runs/route.ts
@@ -551,7 +551,9 @@ export async function POST(req: Request) {
             };
 
             if (approvalNodeId) {
-              const { provider, target } = getApprovalSendConfig(wf, approvalNodeId);
+              // Resolve the channel we *intend* to send to so we can record outbound metadata,
+              // even though delivery is best-effort.
+              const { provider, target } = await resolveApprovalChannel({ workflow: wf, approvalNodeId });
 
               if (target) {
                 try {

--- a/src/app/api/teams/workflow-runs/route.ts
+++ b/src/app/api/teams/workflow-runs/route.ts
@@ -6,11 +6,10 @@ import { jsonOkRest, parseJsonBody } from "@/lib/api-route-helpers";
 import { handleWorkflowRunsGet } from "@/lib/workflows/api-handlers";
 import { errorMessage } from "@/lib/errors";
 import { toolsInvoke } from "@/lib/gateway";
-import { readOpenClawConfig } from "@/lib/paths";
+import { assertSafeRelativeFileName, getTeamWorkspaceDir, readOpenClawConfig } from "@/lib/paths";
 import { listWorkflowRuns, readWorkflowRun, writeWorkflowRun } from "@/lib/workflows/runs-storage";
 import type { WorkflowRunFileV1, WorkflowRunNodeResultV1 } from "@/lib/workflows/runs-types";
 import { readWorkflow } from "@/lib/workflows/storage";
-import { assertSafeRelativeFileName, getTeamWorkspaceDir } from "@/lib/paths";
 import type { WorkflowFileV1 } from "@/lib/workflows/types";
 
 function nowIso() {

--- a/src/app/api/teams/workflow-runs/route.ts
+++ b/src/app/api/teams/workflow-runs/route.ts
@@ -6,6 +6,7 @@ import { jsonOkRest, parseJsonBody } from "@/lib/api-route-helpers";
 import { handleWorkflowRunsGet } from "@/lib/workflows/api-handlers";
 import { errorMessage } from "@/lib/errors";
 import { toolsInvoke } from "@/lib/gateway";
+import { readOpenClawConfig } from "@/lib/paths";
 import { listWorkflowRuns, readWorkflowRun, writeWorkflowRun } from "@/lib/workflows/runs-storage";
 import type { WorkflowRunFileV1, WorkflowRunNodeResultV1 } from "@/lib/workflows/runs-types";
 import { readWorkflow } from "@/lib/workflows/storage";
@@ -164,16 +165,69 @@ function applyTemplate(template: string, vars: Record<string, string>) {
   return out;
 }
 
-function getApprovalSendConfig(workflow: WorkflowFileV1, approvalNodeId: string) {
+function getApprovalMessageTemplate(workflow: WorkflowFileV1, approvalNodeId: string) {
   const meta = isRecord(workflow.meta) ? workflow.meta : {};
   const node = Array.isArray(workflow.nodes) ? workflow.nodes.find((n) => n.id === approvalNodeId) : undefined;
-  const cfg = node && isRecord(node.config) ? node.config : {};
+  const cfg = isRecord(node?.config) ? node?.config : {};
 
-  const provider = String(cfg.provider ?? cfg.channel ?? meta.approvalProvider ?? "telegram").trim() || "telegram";
-  const target = String(cfg.target ?? cfg.chatId ?? meta.approvalTarget ?? "").trim();
-  const messageTemplate = String(cfg.messageTemplate ?? cfg.template ?? "").trim();
+  // Node overrides workflow meta.
+  return String(cfg.messageTemplate ?? cfg.template ?? meta.approvalMessageTemplate ?? "").trim();
+}
 
-  return { provider, target, messageTemplate };
+function bindingMatchToRef(match: unknown): { id: string; channel: string; target: string } | null {
+  if (!isRecord(match)) return null;
+  const channel = String(match.channel ?? "").trim();
+  if (!channel) return null;
+
+  const accountId = String(match.accountId ?? "").trim();
+  if (accountId) return { id: `${channel}:account:${accountId}`, channel, target: accountId };
+
+  const peer = isRecord(match.peer) ? match.peer : null;
+  const kind = peer ? String(peer.kind ?? "").trim() : "";
+  const peerId = peer ? String(peer.id ?? "").trim() : "";
+  if (kind && peerId) return { id: `${channel}:${kind}:${peerId}`, channel, target: peerId };
+
+  return null;
+}
+
+async function resolveApprovalChannel({
+  workflow,
+  approvalNodeId,
+}: {
+  workflow: WorkflowFileV1;
+  approvalNodeId: string;
+}): Promise<{ provider: string; target: string }> {
+  const meta = isRecord(workflow.meta) ? workflow.meta : {};
+  const wfBindingId = String(meta.approvalBindingId ?? "").trim();
+  const wfProvider = String(meta.approvalProvider ?? "telegram").trim() || "telegram";
+  const wfTarget = String(meta.approvalTarget ?? "").trim();
+
+  const node = Array.isArray(workflow.nodes) ? workflow.nodes.find((n) => n.id === approvalNodeId) : undefined;
+  const nodeCfg = isRecord(node?.config) ? node?.config : {};
+  const nodeBindingId = String(nodeCfg.approvalBindingId ?? "").trim();
+  const nodeProvider = String(nodeCfg.provider ?? "").trim();
+  const nodeTarget = String(nodeCfg.target ?? "").trim();
+
+  const desiredBindingId = nodeBindingId || wfBindingId;
+
+  if (desiredBindingId) {
+    try {
+      const cfg = await readOpenClawConfig();
+      const bindings = Array.isArray(cfg.bindings) ? cfg.bindings : [];
+      for (const b of bindings) {
+        if (!isRecord(b)) continue;
+        const ref = bindingMatchToRef(b.match);
+        if (ref && ref.id === desiredBindingId) return { provider: ref.channel, target: ref.target };
+      }
+    } catch {
+      // fall through to manual fields
+    }
+  }
+
+  // Manual precedence: node overrides workflow meta.
+  const provider = nodeProvider || wfProvider;
+  const target = nodeTarget || wfTarget;
+  return { provider, target };
 }
 
 async function maybeSendApprovalRequest({
@@ -187,7 +241,8 @@ async function maybeSendApprovalRequest({
   run: WorkflowRunFileV1;
   approvalNodeId: string;
 }) {
-  const { provider, target, messageTemplate } = getApprovalSendConfig(workflow, approvalNodeId);
+  const { provider, target } = await resolveApprovalChannel({ workflow, approvalNodeId });
+  const messageTemplate = getApprovalMessageTemplate(workflow, approvalNodeId);
   if (!target) return;
 
   const base = formatApprovalPacketMessage(workflow, run, approvalNodeId);

--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -45,6 +45,9 @@ export default function WorkflowsEditorClient({
   const [agents, setAgents] = useState<Array<{ id: string; identityName?: string }>>([]);
   const [agentsError, setAgentsError] = useState<string>("");
 
+  const [approvalBindings, setApprovalBindings] = useState<Array<{ id: string; label: string; channel: string; target: string }>>([]);
+  const [approvalBindingsError, setApprovalBindingsError] = useState<string>("");
+
   // Inspector state (parity with modal)
   const [workflowRuns, setWorkflowRuns] = useState<string[]>([]);
   const [workflowRunsLoading, setWorkflowRunsLoading] = useState(false);
@@ -122,6 +125,55 @@ export default function WorkflowsEditorClient({
       }
     })();
   }, [teamId]);
+
+  function isRecord(v: unknown): v is Record<string, unknown> {
+    return Boolean(v) && typeof v === "object" && !Array.isArray(v);
+  }
+
+  function bindingLabelAndTarget(b: unknown): { id: string; label: string; channel: string; target: string } | null {
+    // Expected OpenClaw binding shape:
+    // { agentId, match: { channel: "telegram", accountId?: string, peer?: { kind: "dm"|"group", id: string } } }
+    if (!isRecord(b)) return null;
+    const match = isRecord(b.match) ? b.match : null;
+    if (!match) return null;
+
+    const channel = String(match.channel ?? "").trim();
+    if (!channel) return null;
+
+    const accountId = String(match.accountId ?? "").trim();
+    if (accountId) {
+      const id = `${channel}:account:${accountId}`;
+      return { id, label: `${channel} · account:${accountId}`, channel, target: accountId };
+    }
+
+    const peer = isRecord(match.peer) ? match.peer : null;
+    const kind = peer ? String(peer.kind ?? "").trim() : "";
+    const peerId = peer ? String(peer.id ?? "").trim() : "";
+    if (kind && peerId) {
+      const id = `${channel}:${kind}:${peerId}`;
+      return { id, label: `${channel} · ${kind}:${peerId}`, channel, target: peerId };
+    }
+
+    return null;
+  }
+
+  useEffect(() => {
+    (async () => {
+      setApprovalBindingsError("");
+      try {
+        const res = await fetch("/api/channels/bindings", { cache: "no-store" });
+        const json = (await res.json()) as { ok?: boolean; bindings?: unknown[]; error?: string };
+        if (!res.ok || json.ok === false) throw new Error(json.error || "Failed to load bindings");
+
+        const list = Array.isArray(json.bindings) ? json.bindings : [];
+        const mapped = list.map(bindingLabelAndTarget).filter(Boolean) as Array<{ id: string; label: string; channel: string; target: string }>;
+        setApprovalBindings(mapped);
+      } catch (e: unknown) {
+        setApprovalBindingsError(e instanceof Error ? e.message : String(e));
+        setApprovalBindings([]);
+      }
+    })();
+  }, []);
 
   const parsed = useMemo(() => {
     if (status.kind !== "ready") return { wf: null as WorkflowFileV1 | null, err: "" };
@@ -975,6 +1027,7 @@ export default function WorkflowsEditorClient({
               const triggers = wf.triggers ?? [];
 
               const meta = wf.meta && typeof wf.meta === "object" && !Array.isArray(wf.meta) ? (wf.meta as Record<string, unknown>) : {};
+              const approvalBindingId = String(meta.approvalBindingId ?? "").trim();
               const approvalProvider = String(meta.approvalProvider ?? "telegram").trim() || "telegram";
               const approvalTarget = String(meta.approvalTarget ?? "").trim();
 
@@ -1014,33 +1067,76 @@ export default function WorkflowsEditorClient({
                     <summary className="cursor-pointer list-none px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)]">Approval Channel</summary>
                     <div className="px-3 pb-3 space-y-2">
                       <label className="block">
-                        <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">provider</div>
-                        <input
-                          value={approvalProvider}
+                        <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">binding (recommended)</div>
+                        <select
+                          value={approvalBindingId}
                           onChange={(e) => {
-                            const nextProvider = String(e.target.value || "").trim() || "telegram";
-                            setWorkflow({ ...wf, meta: { ...meta, approvalProvider: nextProvider } });
-                          }}
-                          className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-1 text-xs text-[color:var(--ck-text-primary)]"
-                          placeholder="telegram"
-                        />
-                      </label>
+                            const nextId = String(e.target.value || "").trim();
+                            const selected = approvalBindings.find((b) => b.id === nextId);
 
-                      <label className="block">
-                        <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">target</div>
-                        <input
-                          value={approvalTarget}
-                          onChange={(e) => {
-                            const nextTarget = String(e.target.value || "").trim();
-                            setWorkflow({ ...wf, meta: { ...meta, approvalTarget: nextTarget } });
+                            // Store a stable-ish reference id in the workflow so it's portable.
+                            // We also keep provider/target in sync for backward compatibility.
+                            if (selected) {
+                              setWorkflow({
+                                ...wf,
+                                meta: {
+                                  ...meta,
+                                  approvalBindingId: selected.id,
+                                  approvalProvider: selected.channel,
+                                  approvalTarget: selected.target,
+                                },
+                              });
+                            } else {
+                              setWorkflow({ ...wf, meta: { ...meta, approvalBindingId: "" } });
+                            }
                           }}
                           className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-1 text-xs text-[color:var(--ck-text-primary)]"
-                          placeholder="(e.g. Telegram chat id)"
-                        />
+                        >
+                          <option value="">(manual)</option>
+                          {approvalBindings.map((b) => (
+                            <option key={b.id} value={b.id}>
+                              {b.label}
+                            </option>
+                          ))}
+                        </select>
+                        {approvalBindingsError ? (
+                          <div className="mt-1 text-[10px] text-red-200">Failed to load bindings: {approvalBindingsError}</div>
+                        ) : null}
                         <div className="mt-1 text-[10px] text-[color:var(--ck-text-tertiary)]">
-                          If set, runs that reach a human-approval node can send an approval packet via the gateway message tool.
+                          Uses your existing OpenClaw bindings (recommended). Manual provider/target is an advanced override.
                         </div>
                       </label>
+
+                      <details className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/10">
+                        <summary className="cursor-pointer list-none px-2 py-1 text-[11px] font-medium text-[color:var(--ck-text-secondary)]">Advanced: manual override</summary>
+                        <div className="px-2 pb-2 pt-1 space-y-2">
+                          <label className="block">
+                            <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">provider</div>
+                            <input
+                              value={approvalProvider}
+                              onChange={(e) => {
+                                const nextProvider = String(e.target.value || "").trim() || "telegram";
+                                setWorkflow({ ...wf, meta: { ...meta, approvalBindingId: "", approvalProvider: nextProvider } });
+                              }}
+                              className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-1 text-xs text-[color:var(--ck-text-primary)]"
+                              placeholder="telegram"
+                            />
+                          </label>
+
+                          <label className="block">
+                            <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">target</div>
+                            <input
+                              value={approvalTarget}
+                              onChange={(e) => {
+                                const nextTarget = String(e.target.value || "").trim();
+                                setWorkflow({ ...wf, meta: { ...meta, approvalBindingId: "", approvalTarget: nextTarget } });
+                              }}
+                              className="mt-1 w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-1 text-xs text-[color:var(--ck-text-primary)]"
+                              placeholder="(e.g. Telegram chat id)"
+                            />
+                          </label>
+                        </div>
+                      </details>
                     </div>
                   </details>
 

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -15,6 +15,8 @@ type OpenClawConfig = {
     installs?: { recipes?: { installPath?: string; sourcePath?: string } };
     load?: { paths?: string[] };
   };
+  // OpenClaw message routing bindings (used for HITL approvals, etc.)
+  bindings?: unknown[];
 };
 
 export async function readOpenClawConfig(): Promise<OpenClawConfig> {


### PR DESCRIPTION
Implements RJ request on #0101: Approval routing should default to existing OpenClaw bindings.

Changes:
- /api/channels/bindings GET now includes  from ~/.openclaw/openclaw.json (no secrets)
- Workflows editor Approval Channel panel: new bindings dropdown (recommended) + Advanced manual provider/target override
- Workflow runner approval message sender resolves  (node overrides workflow meta) to provider/target; manual fallback preserved

Verification:
- npm run lint (warnings only)
- npm run build ✅
