### PR TITLE
ClawKitchen: global team context (no redirect) + /tickets team filter

### DIFF
--- a/src/app/api/__tests__/tickets-move-route.test.ts
+++ b/src/app/api/__tests__/tickets-move-route.test.ts
@@ -10,8 +10,15 @@ describe("api tickets move route", () => {
     vi.mocked(runOpenClaw).mockReset();
   });
 
+  it("returns 400 when teamId missing", async () => {
+    const res = await POST(new Request("https://test", { method: "POST", body: JSON.stringify({ ticket: "T-1", to: "done" }) }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Missing teamId");
+  });
+
   it("returns 400 when ticket missing", async () => {
-    const res = await POST(new Request("https://test", { method: "POST", body: JSON.stringify({}) }));
+    const res = await POST(new Request("https://test", { method: "POST", body: JSON.stringify({ teamId: "dev" }) }));
     expect(res.status).toBe(400);
     const json = await res.json();
     expect(json.error).toBe("Missing ticket");
@@ -21,8 +28,8 @@ describe("api tickets move route", () => {
     const res = await POST(
       new Request("https://test", {
         method: "POST",
-        body: JSON.stringify({ ticket: "T-1", to: "invalid" }),
-      })
+        body: JSON.stringify({ teamId: "dev", ticket: "T-1", to: "invalid" }),
+      }),
     );
     expect(res.status).toBe(400);
     const json = await res.json();
@@ -34,14 +41,14 @@ describe("api tickets move route", () => {
     const res = await POST(
       new Request("https://test", {
         method: "POST",
-        body: JSON.stringify({ ticket: "T-1", to: "in-progress" }),
-      })
+        body: JSON.stringify({ teamId: "dev", ticket: "T-1", to: "in-progress" }),
+      }),
     );
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.ok).toBe(true);
     expect(runOpenClaw).toHaveBeenCalledWith(
-      expect.arrayContaining(["recipes", "move-ticket", "--ticket", "T-1", "--to", "in-progress"])
+      expect.arrayContaining(["recipes", "move-ticket", "--team-id", "dev", "--ticket", "T-1", "--to", "in-progress"]),
     );
   });
 
@@ -50,8 +57,8 @@ describe("api tickets move route", () => {
     const res = await POST(
       new Request("https://test", {
         method: "POST",
-        body: JSON.stringify({ ticket: "T-1", to: "done" }),
-      })
+        body: JSON.stringify({ teamId: "dev", ticket: "T-1", to: "done" }),
+      }),
     );
     expect(res.status).toBe(500);
     const json = await res.json();

--- a/src/app/teams/[teamId]/tickets/page.tsx
+++ b/src/app/teams/[teamId]/tickets/page.tsx
@@ -11,5 +11,11 @@ export default async function TeamTicketsPage({
   const { teamId } = await params;
   const tickets = await listTickets(teamId);
 
-  return <TicketsBoardClient tickets={tickets} basePath={`/teams/${encodeURIComponent(teamId)}/tickets`} />;
+  return (
+    <TicketsBoardClient
+      tickets={tickets}
+      basePath={`/teams/${encodeURIComponent(teamId)}/tickets`}
+      selectedTeamId={teamId}
+    />
+  );
 }

--- a/src/app/tickets/TicketsBoardClient.tsx
+++ b/src/app/tickets/TicketsBoardClient.tsx
@@ -44,7 +44,7 @@ function formatAge(hours: number) {
   return `${Math.round(hours / 24)}d`;
 }
 
-export function TicketsBoardClient({ tickets }: { tickets: TicketSummary[] }) {
+export function TicketsBoardClient({ tickets, teamId }: { tickets: TicketSummary[]; teamId: string | null }) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
@@ -114,7 +114,7 @@ export function TicketsBoardClient({ tickets }: { tickets: TicketSummary[] }) {
     await fetchJson("/api/tickets/move", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ ticket: ticket.id, to }),
+      body: JSON.stringify({ teamId: ticket.teamId, ticket: ticket.id, to }),
     });
   }
 
@@ -201,6 +201,8 @@ export function TicketsBoardClient({ tickets }: { tickets: TicketSummary[] }) {
                     {String(t.number).padStart(4, "0")} — {t.title}
                   </a>
                   <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[color:var(--ck-text-secondary)]">
+                    <span className="rounded bg-white/5 px-1.5 py-0.5">{t.teamId}</span>
+                    <span>·</span>
                     <span>{t.owner ? `Owner: ${t.owner}` : "Owner: —"}</span>
                     <span>·</span>
                     <span>Age: {formatAge(t.ageHours)}</span>
@@ -234,7 +236,16 @@ export function TicketsBoardClient({ tickets }: { tickets: TicketSummary[] }) {
       </div>
 
       <p className="text-xs text-[color:var(--ck-text-tertiary)]">
-        Source of truth: development-team markdown tickets (via openclaw recipes move-ticket).
+        Source of truth: <code>workspace-&lt;teamId&gt;</code> markdown tickets (via openclaw recipes move-ticket).{" "}
+        {teamId ? (
+          <>
+            Viewing: <span className="font-medium text-[color:var(--ck-text-secondary)]">{teamId}</span>
+          </>
+        ) : (
+          <>
+            Viewing: <span className="font-medium text-[color:var(--ck-text-secondary)]">all</span>
+          </>
+        )}
       </p>
 
       {confirmMove ? (

--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -4,7 +4,8 @@ import { TicketsBoardClient } from "@/app/tickets/TicketsBoardClient";
 // Tickets reflect live filesystem state; do not cache.
 export const dynamic = "force-dynamic";
 
-export default async function TicketsPage() {
-  const tickets = await listTickets();
-  return <TicketsBoardClient tickets={tickets} />;
+export default async function TicketsPage({ searchParams }: { searchParams?: { team?: string } }) {
+  const teamId = typeof searchParams?.team === "string" ? searchParams.team : undefined;
+  const tickets = await listTickets({ teamId });
+  return <TicketsBoardClient tickets={tickets} teamId={teamId ?? null} />;
 }

--- a/src/lib/__tests__/tickets.test.ts
+++ b/src/lib/__tests__/tickets.test.ts
@@ -19,10 +19,11 @@ vi.mock("node:fs/promises", () => ({
 describe("tickets", () => {
   describe("stageDir", () => {
     it("maps each stage to correct path", () => {
-      expect(stageDir("backlog")).toContain("work/backlog");
-      expect(stageDir("in-progress")).toContain("work/in-progress");
-      expect(stageDir("testing")).toContain("work/testing");
-      expect(stageDir("done")).toContain("work/done");
+      const teamDir = "/home/x/.openclaw/workspace-dev";
+      expect(stageDir(teamDir, "backlog")).toContain("work/backlog");
+      expect(stageDir(teamDir, "in-progress")).toContain("work/in-progress");
+      expect(stageDir(teamDir, "testing")).toContain("work/testing");
+      expect(stageDir(teamDir, "done")).toContain("work/done");
     });
   });
 
@@ -81,7 +82,7 @@ describe("tickets", () => {
         mtimeMs: new Date("2026-01-15T10:00:00Z").getTime(),
       } as ReturnType<typeof fs.stat> extends Promise<infer T> ? T : never);
 
-      const result = await listTickets();
+      const result = await listTickets({ teamId: "dev" });
       expect(result).toHaveLength(1);
       expect(result[0].number).toBe(33);
       expect(result[0].id).toBe("0033-fix-login");
@@ -97,7 +98,7 @@ describe("tickets", () => {
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([]);
 
-      const result = await listTickets();
+      const result = await listTickets({ teamId: "dev" });
       expect(result).toEqual([]);
     });
 
@@ -114,7 +115,7 @@ describe("tickets", () => {
         mtimeMs: Date.now(),
       } as ReturnType<typeof fs.stat> extends Promise<infer T> ? T : never);
 
-      const result = await listTickets();
+      const result = await listTickets({ teamId: "dev" });
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe("0033-a");
     });
@@ -137,21 +138,21 @@ describe("tickets", () => {
     });
 
     it("finds by id and returns markdown", async () => {
-      const result = await getTicketMarkdown("0033-fix");
+      const result = await getTicketMarkdown("0033-fix", { teamId: "dev" });
       expect(result).not.toBeNull();
       expect(result!.id).toBe("0033-fix");
       expect(result!.markdown).toContain("Fix it");
     });
 
     it("finds by number", async () => {
-      const result = await getTicketMarkdown("33");
+      const result = await getTicketMarkdown("33", { teamId: "dev" });
       expect(result).not.toBeNull();
       expect(result!.id).toBe("0033-fix");
     });
 
     it("returns null when not found", async () => {
       vi.mocked(fs.readdir).mockReset().mockResolvedValue([]);
-      const result = await getTicketMarkdown("9999");
+      const result = await getTicketMarkdown("9999", { teamId: "dev" });
       expect(result).toBeNull();
     });
   });


### PR DESCRIPTION
Implements a persistent global team context selector (left-nav dropdown) without redirect, persisted in localStorage, with ?team= deep-link override. Updates /tickets list to default to selected team and adds all-teams fallback.

Ticket: development-team #0116