### PR TITLE
feat(kitchen): QA token bootstrap for headless auth

### DIFF
--- a/docs/QA_AUTH.md
+++ b/docs/QA_AUTH.md
@@ -1,0 +1,30 @@
+# ClawKitchen — QA / Headless Auth
+
+ClawKitchen is usually protected by HTTP Basic auth when it is bound to a non-localhost host (e.g. a Tailscale IP). This is intentional.
+
+For automated/headless QA (e.g. using OpenClaw `browser` tool), you can enable a **short-lived QA cookie** flow.
+
+## 1) Configure `qaToken`
+
+In your OpenClaw plugin config for Kitchen (plugin id: `kitchen`), set:
+
+- `authToken`: required when binding to a non-localhost host
+- `qaToken`: optional; enables the QA-cookie bypass
+
+Notes:
+- This is **disabled by default**. If `qaToken` is not set, the bypass is not available.
+- Intended for **local/dev environments only**.
+
+## 2) Use it (one-time URL)
+
+Visit any Kitchen URL once with `?qaToken=...`:
+
+- `http://<host>:<port>/tickets?qaToken=<QA_TOKEN>`
+
+Behavior:
+- If the token matches, Kitchen sets an `HttpOnly` cookie `kitchenQaToken` (valid for 15 minutes) and **302-redirects** to the same URL without the query param.
+- Subsequent requests will be authorized via the cookie.
+
+## 3) Automation tip
+
+When running browser automation, do a first navigation to a known page with the `qaToken` query param to establish the cookie, then navigate normally.

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -181,7 +181,26 @@ const kitchenPlugin = {
   id: "kitchen",
   name: "ClawKitchen",
   description: "Local UI for managing recipes, teams, agents, cron jobs, and skills.",
-  configSchema: { type: "object", additionalProperties: true, properties: {} },
+  configSchema: {
+    type: "object",
+    additionalProperties: true,
+    properties: {
+      enabled: { type: "boolean", description: "Enable/disable the Kitchen service." },
+      dev: { type: "boolean", description: "Run Next.js in dev mode (turbopack)." },
+      host: { type: "string", description: "Host to bind Kitchen to. Use 127.0.0.1 for localhost-only." },
+      port: { type: "number", description: "Port to bind Kitchen to." },
+      authToken: {
+        type: "string",
+        description:
+          "HTTP Basic auth token required when binding to a non-localhost host. Username is fixed to 'kitchen'.",
+      },
+      qaToken: {
+        type: "string",
+        description:
+          "Optional, disabled-by-default bypass intended ONLY for automated/headless QA. If set, you may visit any URL once with ?qaToken=<value> to receive a short-lived HttpOnly cookie (15 minutes).",
+      },
+    },
+  },
   register(api: OpenClawPluginApi) {
     // Expose the plugin API to the Next.js server runtime (runs in-process with the gateway).
     // This lets API routes call into OpenClaw runtime helpers without using child_process or env.


### PR DESCRIPTION
Implements ticket #0121 (ClawKitchen QA unblocker).

Summary:
- Exposes optional `qaToken` in Kitchen plugin config schema.
- When set, `?qaToken=<token>` sets a short-lived HttpOnly cookie (15 min) and redirects, allowing headless browser automation to access protected Kitchen pages without interactive Basic Auth prompts.
- Adds docs: `docs/QA_AUTH.md`.

Verification:
- `npm run lint` (warnings only)
- `npm run build` ✅
