### PR TITLE
Fix cron trigger preset dropdown: allow (no preset) to clear expr

### DIFF
--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -1094,7 +1094,6 @@ export default function WorkflowsEditorClient({
                                       value={presets.some((p) => p.expr === expr) ? expr : ""}
                                       onChange={(e) => {
                                         const nextExpr = e.target.value;
-                                        if (!nextExpr) return;
                                         setWorkflow({
                                           ...wf,
                                           triggers: triggers.map((x, idx) => (idx === i && x.kind === "cron" ? { ...x, expr: nextExpr } : x)),


### PR DESCRIPTION
Fixes preset dropdown behavior for cron triggers: selecting (no preset) now clears the cron expression (expr="") instead of refusing to update.\n\nTicket: development-team#0089