### PR TITLE
QA auth unblocker: expose qaToken + docs

### DIFF
--- a/docs/QA_AUTH.md
+++ b/docs/QA_AUTH.md
@@ -1,0 +1,62 @@
+# ClawKitchen QA Auth (headless-friendly)
+
+ClawKitchen can optionally be protected by HTTP Basic auth when binding to a non-localhost host (e.g. Tailscale IP).
+
+For automated/headless QA (Playwright, etc.), HTTP Basic auth prompts can be awkward.
+ClawKitchen supports an **optional QA-only bootstrap token** that sets a short-lived session cookie.
+
+## How it works
+
+If `qaToken` is configured:
+
+1. Visit any Kitchen URL with `?qaToken=<token>` once.
+2. Kitchen sets an HttpOnly cookie `kitchenQaToken` (15 minutes) and **redirects** to the same URL with `qaToken` removed.
+3. Subsequent requests include the cookie and are authorized without triggering the Basic auth prompt.
+
+Notes:
+- This is **disabled by default**.
+- The cookie lifetime is **15 minutes**.
+- Intended for **dev/QA only**.
+
+## Configure
+
+Set `qaToken` in the Kitchen plugin config (alongside `authToken`). Example:
+
+```json
+{
+  "kitchen": {
+    "enabled": true,
+    "host": "100.x.y.z",
+    "port": 7077,
+    "authToken": "<basic-auth-password>",
+    "qaToken": "<qa-bootstrap-token>"
+  }
+}
+```
+
+## Use (curl)
+
+```bash
+# First request seeds cookie (note: follow redirect and store cookies)
+curl -i -c cookies.txt 'http://HOST:PORT/tickets?qaToken=YOUR_QA_TOKEN'
+
+# Subsequent request uses cookie
+curl -i -b cookies.txt 'http://HOST:PORT/tickets'
+```
+
+## Use (Playwright)
+
+Navigate once to:
+
+```
+http://HOST:PORT/tickets?qaToken=YOUR_QA_TOKEN
+```
+
+Then proceed normally; the cookie is set for ~15 minutes.
+
+## Troubleshooting
+
+If you still get `401 Unauthorized` with `WWW-Authenticate: Basic`:
+
+- Verify `qaToken` is actually configured in the running Kitchen instance.
+- Ensure you are hitting the Kitchen server directly (not a separate reverse proxy applying Basic auth *before* Kitchen can read the query params).

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "kitchen",
   "name": "ClawKitchen",
   "description": "Local UI for managing OpenClaw recipes, teams, agents, cron jobs, and skills.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -11,7 +11,8 @@
       "dev": { "type": "boolean", "default": false, "description": "Run Next.js in dev mode (not recommended for end users)." },
       "host": { "type": "string", "default": "127.0.0.1" },
       "port": { "type": "integer", "default": 7777, "minimum": 1, "maximum": 65535 },
-      "authToken": { "type": "string", "default": "" }
+      "authToken": { "type": "string", "default": "" },
+      "qaToken": { "type": "string", "default": "" }
     }
   },
   "uiHints": {
@@ -19,6 +20,7 @@
     "dev": { "label": "Dev mode", "help": "Not recommended. Prefer dev=false for stability (especially over Tailscale/remote)." },
     "host": { "label": "Host", "help": "Default binds to localhost. For Tailscale remote access, bind to your Tailscale IP or 0.0.0.0 and set authToken." },
     "port": { "label": "Port" },
-    "authToken": { "label": "Auth token", "help": "Required when host is not localhost. Used for HTTP Basic auth (username: kitchen)." }
+    "authToken": { "label": "Auth token", "help": "Required when host is not localhost. Used for HTTP Basic auth (username: kitchen)." },
+    "qaToken": { "label": "QA token (optional)", "help": "QA/dev-only. If set, visiting any URL with ?qaToken=<token> sets a short-lived cookie so headless browsers can access the UI without a Basic auth prompt." }
   }
 }

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -208,7 +208,31 @@ const kitchenPlugin = {
   id: "kitchen",
   name: "ClawKitchen",
   description: "Local UI for managing recipes, teams, agents, cron jobs, and skills.",
-  configSchema: { type: "object", additionalProperties: true, properties: {} },
+  configSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      enabled: { type: "boolean", default: true },
+      dev: {
+        type: "boolean",
+        default: false,
+        description: "Run Next.js in dev mode (not recommended for end users).",
+      },
+      host: { type: "string", default: "127.0.0.1" },
+      port: { type: "integer", default: 7777, minimum: 1, maximum: 65535 },
+      authToken: {
+        type: "string",
+        default: "",
+        description: "Required when host is not localhost. Used for HTTP Basic auth (username: kitchen).",
+      },
+      qaToken: {
+        type: "string",
+        default: "",
+        description:
+          "Optional QA-only bypass token. If set, visiting any URL with ?qaToken=<token> sets a short-lived cookie for headless/automated access.",
+      },
+    },
+  },
   register(api: OpenClawPluginApi) {
     // Expose the plugin API to the Next.js server runtime (runs in-process with the gateway).
     // This lets API routes call into OpenClaw runtime helpers without using child_process or env.


### PR DESCRIPTION
Implements ticket #0121: exposes Kitchen `qaToken` in plugin config schema + documents headless QA flow.

Changes:
- Adds `qaToken` to `openclaw/index.ts` `configSchema` and updates `openclaw.plugin.json`
- Adds docs: `docs/QA_AUTH.md`

QA usage:
1) Set `kitchen.qaToken` in the gateway plugin config (disabled-by-default).
2) Visit any Kitchen page once with `?qaToken=<token>` to set the 15-min HttpOnly cookie, then you’ll be redirected to the same URL without the token.
3) Subsequent requests should be authorized by the cookie (no Basic auth prompt), enabling headless browser automation.
