### PR TITLE
fix: add main to OpenClaw plugin manifest

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -7,20 +7,58 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
-      "enabled": { "type": "boolean", "default": true },
-      "dev": { "type": "boolean", "default": false, "description": "Run Next.js in dev mode (not recommended for end users)." },
-      "host": { "type": "string", "default": "127.0.0.1" },
-      "port": { "type": "integer", "default": 7777, "minimum": 1, "maximum": 65535 },
-      "authToken": { "type": "string", "default": "" },
-      "qaToken": { "type": "string", "default": "" }
+      "enabled": {
+        "type": "boolean",
+        "default": true
+      },
+      "dev": {
+        "type": "boolean",
+        "default": false,
+        "description": "Run Next.js in dev mode (not recommended for end users)."
+      },
+      "host": {
+        "type": "string",
+        "default": "127.0.0.1"
+      },
+      "port": {
+        "type": "integer",
+        "default": 7777,
+        "minimum": 1,
+        "maximum": 65535
+      },
+      "authToken": {
+        "type": "string",
+        "default": ""
+      },
+      "qaToken": {
+        "type": "string",
+        "default": ""
+      }
     }
   },
   "uiHints": {
-    "enabled": { "label": "Enabled" },
-    "dev": { "label": "Dev mode", "help": "Not recommended. Prefer dev=false for stability (especially over Tailscale/remote)." },
-    "host": { "label": "Host", "help": "Default binds to localhost. For Tailscale remote access, bind to your Tailscale IP or 0.0.0.0 and set authToken." },
-    "port": { "label": "Port" },
-    "authToken": { "label": "Auth token", "help": "Required when host is not localhost. Used for HTTP Basic auth (username: kitchen)." },
-    "qaToken": { "label": "QA token (optional)", "help": "QA/dev-only. If set, visiting any URL with ?qaToken=<token> sets a short-lived cookie so headless browsers can access the UI without a Basic auth prompt." }
-  }
+    "enabled": {
+      "label": "Enabled"
+    },
+    "dev": {
+      "label": "Dev mode",
+      "help": "Not recommended. Prefer dev=false for stability (especially over Tailscale/remote)."
+    },
+    "host": {
+      "label": "Host",
+      "help": "Default binds to localhost. For Tailscale remote access, bind to your Tailscale IP or 0.0.0.0 and set authToken."
+    },
+    "port": {
+      "label": "Port"
+    },
+    "authToken": {
+      "label": "Auth token",
+      "help": "Required when host is not localhost. Used for HTTP Basic auth (username: kitchen)."
+    },
+    "qaToken": {
+      "label": "QA token (optional)",
+      "help": "QA/dev-only. If set, visiting any URL with ?qaToken=<token> sets a short-lived cookie so headless browsers can access the UI without a Basic auth prompt."
+    }
+  },
+  "main": "openclaw/index.ts"
 }


### PR DESCRIPTION
OpenClaw 2026.2.26 enforces stricter plugin manifest loading for local path plugins.\n\nThis adds a "main" entry to openclaw.plugin.json so Kitchen loads and its configSchema is applied (avoids config validation errors like: `plugins.entries.kitchen.config: must NOT have additional properties`).\n\n- main: openclaw/index.ts\n