### PR TITLE
fix(v0.1.8): add tsconfig baseUrl for @/ imports (release 0.1.12)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -7,18 +7,50 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
-      "enabled": { "type": "boolean", "default": true },
-      "dev": { "type": "boolean", "default": false, "description": "Run Next.js in dev mode (not recommended for end users)." },
-      "host": { "type": "string", "default": "127.0.0.1" },
-      "port": { "type": "integer", "default": 7777, "minimum": 1, "maximum": 65535 },
-      "authToken": { "type": "string", "default": "" }
+      "enabled": {
+        "type": "boolean",
+        "default": true
+      },
+      "dev": {
+        "type": "boolean",
+        "default": false,
+        "description": "Run Next.js in dev mode (not recommended for end users)."
+      },
+      "host": {
+        "type": "string",
+        "default": "127.0.0.1"
+      },
+      "port": {
+        "type": "integer",
+        "default": 7777,
+        "minimum": 1,
+        "maximum": 65535
+      },
+      "authToken": {
+        "type": "string",
+        "default": ""
+      }
     }
   },
   "uiHints": {
-    "enabled": { "label": "Enabled" },
-    "dev": { "label": "Dev mode", "help": "Not recommended. Prefer dev=false for stability (especially over Tailscale/remote)." },
-    "host": { "label": "Host", "help": "Default binds to localhost. For Tailscale remote access, bind to your Tailscale IP or 0.0.0.0 and set authToken." },
-    "port": { "label": "Port" },
-    "authToken": { "label": "Auth token", "help": "Required when host is not localhost. Used for HTTP Basic auth (username: kitchen)." }
-  }
+    "enabled": {
+      "label": "Enabled"
+    },
+    "dev": {
+      "label": "Dev mode",
+      "help": "Not recommended. Prefer dev=false for stability (especially over Tailscale/remote)."
+    },
+    "host": {
+      "label": "Host",
+      "help": "Default binds to localhost. For Tailscale remote access, bind to your Tailscale IP or 0.0.0.0 and set authToken."
+    },
+    "port": {
+      "label": "Port"
+    },
+    "authToken": {
+      "label": "Auth token",
+      "help": "Required when host is not localhost. Used for HTTP Basic auth (username: kitchen)."
+    }
+  },
+  "main": "openclaw/index.ts"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jiggai/kitchen",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jiggai/kitchen",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jiggai/kitchen",
-      "version": "0.1.8",
+      "version": "0.1.10",
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": false,
   "openclaw": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": false,
   "openclaw": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "private": false,
   "openclaw": {
     "extensions": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,8 +23,11 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "baseUrl": "."
   },
   "include": [
     "next-env.d.ts",
@@ -30,5 +37,8 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "openclaw"]
+  "exclude": [
+    "node_modules",
+    "openclaw"
+  ]
 }


### PR DESCRIPTION
Backport a Next.js/TS path alias fix onto the v0.1.8 hotfix line.\n\n- Add compilerOptions.baseUrl="." so tsconfig paths ("@/*": ["./src/*"]) are honored and imports like @/components/AppShell resolve.\n- Release: 0.1.12 (tag v0.1.12).\n\nNote: do NOT merge into main; publish from this hotfix branch.