### PR TITLE
fix: set tsconfig baseUrl so @/ imports resolve

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -7,20 +7,58 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
-      "enabled": { "type": "boolean", "default": true },
-      "dev": { "type": "boolean", "default": false, "description": "Run Next.js in dev mode (not recommended for end users)." },
-      "host": { "type": "string", "default": "127.0.0.1" },
-      "port": { "type": "integer", "default": 7777, "minimum": 1, "maximum": 65535 },
-      "authToken": { "type": "string", "default": "" },
-      "qaToken": { "type": "string", "default": "" }
+      "enabled": {
+        "type": "boolean",
+        "default": true
+      },
+      "dev": {
+        "type": "boolean",
+        "default": false,
+        "description": "Run Next.js in dev mode (not recommended for end users)."
+      },
+      "host": {
+        "type": "string",
+        "default": "127.0.0.1"
+      },
+      "port": {
+        "type": "integer",
+        "default": 7777,
+        "minimum": 1,
+        "maximum": 65535
+      },
+      "authToken": {
+        "type": "string",
+        "default": ""
+      },
+      "qaToken": {
+        "type": "string",
+        "default": ""
+      }
     }
   },
   "uiHints": {
-    "enabled": { "label": "Enabled" },
-    "dev": { "label": "Dev mode", "help": "Not recommended. Prefer dev=false for stability (especially over Tailscale/remote)." },
-    "host": { "label": "Host", "help": "Default binds to localhost. For Tailscale remote access, bind to your Tailscale IP or 0.0.0.0 and set authToken." },
-    "port": { "label": "Port" },
-    "authToken": { "label": "Auth token", "help": "Required when host is not localhost. Used for HTTP Basic auth (username: kitchen)." },
-    "qaToken": { "label": "QA token (optional)", "help": "QA/dev-only. If set, visiting any URL with ?qaToken=<token> sets a short-lived cookie so headless browsers can access the UI without a Basic auth prompt." }
-  }
+    "enabled": {
+      "label": "Enabled"
+    },
+    "dev": {
+      "label": "Dev mode",
+      "help": "Not recommended. Prefer dev=false for stability (especially over Tailscale/remote)."
+    },
+    "host": {
+      "label": "Host",
+      "help": "Default binds to localhost. For Tailscale remote access, bind to your Tailscale IP or 0.0.0.0 and set authToken."
+    },
+    "port": {
+      "label": "Port"
+    },
+    "authToken": {
+      "label": "Auth token",
+      "help": "Required when host is not localhost. Used for HTTP Basic auth (username: kitchen)."
+    },
+    "qaToken": {
+      "label": "QA token (optional)",
+      "help": "QA/dev-only. If set, visiting any URL with ?qaToken=<token> sets a short-lived cookie so headless browsers can access the UI without a Basic auth prompt."
+    }
+  },
+  "main": "openclaw/index.ts"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jiggai/kitchen",
-      "version": "0.1.9",
+      "version": "0.2.0",
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "private": false,
   "openclaw": {
     "extensions": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,8 +23,11 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "baseUrl": "."
   },
   "include": [
     "next-env.d.ts",
@@ -30,5 +37,8 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "openclaw"]
+  "exclude": [
+    "node_modules",
+    "openclaw"
+  ]
 }


### PR DESCRIPTION
Fixes Next.js build error: Module not found: Can't resolve '@/components/AppShell'.

Adds compilerOptions.baseUrl='.' so tsconfig paths mapping (@/* -> ./src/*) is honored.