### PR TITLE
fix(packaging): include tsconfig.json so @/ imports resolve in npm installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jiggai/kitchen",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": false,
   "openclaw": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "openclaw.plugin.json",
     "README.md",
     "next.config.ts",
+    "next-env.d.ts",
+    "tsconfig.json",
     "public/",
     "src/",
     ".next/BUILD_ID",


### PR DESCRIPTION
Users installing Kitchen via npm were seeing Next.js errors like: Module not found: Can't resolve '@/components/AppShell'.

Root cause: tsconfig.json (baseUrl + paths for @/*) was not included in the published npm package, so the alias wasn't applied after extraction.

Fix:
- Include tsconfig.json
- Include next-env.d.ts
in package.json files whitelist.