### PR TITLE
fix(packaging): exclude src/tests from published npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+# Don't ship tests or dev artifacts
+**/__tests__/**
+**/*.test.*
+**/*.spec.*
+
+# Don't ship coverage/reports
+coverage/
+report/
+
+# VCS
+.git/
+.github/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jiggai/kitchen",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "openclaw": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "next-env.d.ts",
     "tsconfig.json",
     "public/",
-    "src/",
     ".next/BUILD_ID",
     ".next/server/",
     ".next/static/",


### PR DESCRIPTION
Customers installing Kitchen via npm don't need source/tests shipped. Shipping src/ triggers OpenClaw security scanner heuristics (file read + network send) and bloats install.

This updates package.json files whitelist to exclude src/ so __tests__ are not published, and adds a basic .npmignore for extra safety.