### PR TITLE
fix: Kitchen cron APIs use openclaw cron CLI (no cron tool dependency)

### DIFF
--- a/src/app/api/__tests__/cron-delete-route.test.ts
+++ b/src/app/api/__tests__/cron-delete-route.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { POST } from "../cron/delete/route";
 
 vi.mock("@/lib/gateway", () => ({ toolsInvoke: vi.fn() }));
+vi.mock("@/lib/openclaw", () => ({ runOpenClaw: vi.fn() }));
 vi.mock("node:fs/promises", () => ({
   default: {
     readdir: vi.fn(),
@@ -12,11 +13,13 @@ vi.mock("node:fs/promises", () => ({
 }));
 
 import { toolsInvoke } from "@/lib/gateway";
+import { runOpenClaw } from "@/lib/openclaw";
 import fs from "node:fs/promises";
 
 describe("api cron delete route", () => {
   beforeEach(() => {
     vi.mocked(toolsInvoke).mockReset();
+    vi.mocked(runOpenClaw).mockReset();
     vi.mocked(fs.readdir).mockReset();
     vi.mocked(fs.stat).mockReset();
     vi.mocked(fs.readFile).mockReset();
@@ -33,7 +36,7 @@ describe("api cron delete route", () => {
   });
 
   it("returns 200 and invokes cron remove", async () => {
-    vi.mocked(toolsInvoke).mockResolvedValue({ ok: true });
+    vi.mocked(runOpenClaw).mockResolvedValue({ ok: true, exitCode: 0, stdout: "{}", stderr: "" });
 
     const res = await POST(
       new Request("https://test", { method: "POST", body: JSON.stringify({ id: "job-1" }) })
@@ -42,11 +45,12 @@ describe("api cron delete route", () => {
     const json = await res.json();
     expect(json.ok).toBe(true);
     expect(json.id).toBe("job-1");
-    expect(toolsInvoke).toHaveBeenCalledWith({ tool: "cron", args: { action: "remove", jobId: "job-1" } });
+    expect(runOpenClaw).toHaveBeenCalledWith(["cron", "rm", "job-1", "--json"]);
   });
 
   it("marks orphaned entries in cron-jobs.json when mapping references job", async () => {
     const baseHome = "/mock/base";
+    vi.mocked(runOpenClaw).mockResolvedValue({ ok: true, exitCode: 0, stdout: "{}", stderr: "" });
     vi.mocked(toolsInvoke)
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({

--- a/src/app/api/__tests__/cron-delete-route.test.ts
+++ b/src/app/api/__tests__/cron-delete-route.test.ts
@@ -1,14 +1,31 @@
+// @vitest-environment node
+
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { POST } from "../cron/delete/route";
 
 vi.mock("@/lib/gateway", () => ({ toolsInvoke: vi.fn() }));
 vi.mock("@/lib/openclaw", () => ({ runOpenClaw: vi.fn() }));
+
+// Vitest runs some suites in a browser-like environment; explicitly mock the Node builtins
+// this route uses so the orphan-marking logic is testable.
 vi.mock("node:fs/promises", () => ({
   default: {
     readdir: vi.fn(),
     stat: vi.fn(),
     readFile: vi.fn(),
     writeFile: vi.fn(),
+  },
+}));
+vi.mock("node:path", () => ({
+  default: {
+    resolve: (p: string, up: string) => {
+      // minimal resolver for this test: resolve("/a/b", "..") -> "/a"
+      if (up !== "..") return String(p);
+      const parts = String(p).split("/").filter(Boolean);
+      parts.pop();
+      return "/" + parts.join("/");
+    },
+    join: (...parts: string[]) => parts.map(String).join("/"),
   },
 }));
 
@@ -50,23 +67,26 @@ describe("api cron delete route", () => {
 
   it("marks orphaned entries in cron-jobs.json when mapping references job", async () => {
     const baseHome = "/mock/base";
+
     vi.mocked(runOpenClaw).mockResolvedValue({ ok: true, exitCode: 0, stdout: "{}", stderr: "" });
-    vi.mocked(toolsInvoke)
-      .mockResolvedValueOnce({ ok: true })
-      .mockResolvedValueOnce({
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({
-              result: {
-                raw: JSON.stringify({
-                  agents: { defaults: { workspace: baseHome + "/agents" } },
-                }),
-              },
-            }),
-          },
-        ],
-      });
+
+    // Used by getBaseWorkspaceFromGateway(toolsInvoke)
+    vi.mocked(toolsInvoke).mockResolvedValueOnce({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            result: {
+              raw: JSON.stringify({
+                agents: { defaults: { workspace: baseHome + "/agents" } },
+              }),
+            },
+          }),
+        },
+      ],
+    });
+
+    // baseHome is computed from baseWorkspace + "..". Ensure it finds one workspace dir.
     vi.mocked(fs.readdir).mockResolvedValue([
       { name: "workspace-team1", isDirectory: () => true } as never,
     ]);
@@ -87,9 +107,11 @@ describe("api cron delete route", () => {
     );
     expect(res.status).toBe(200);
     const json = await res.json();
+
     expect(json.orphanedIn).toHaveLength(1);
     expect(json.orphanedIn[0].teamId).toBe("team1");
     expect(json.orphanedIn[0].keys).toContain("recipe-1");
+
     expect(fs.writeFile).toHaveBeenCalled();
     const written = JSON.parse(vi.mocked(fs.writeFile).mock.calls[0][1] as string);
     expect(written.entries["recipe-1"].orphaned).toBe(true);

--- a/src/app/api/__tests__/cron-job-route.test.ts
+++ b/src/app/api/__tests__/cron-job-route.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { POST } from "../cron/job/route";
 
-vi.mock("@/lib/gateway", () => ({ toolsInvoke: vi.fn() }));
+vi.mock("@/lib/openclaw", () => ({ runOpenClaw: vi.fn() }));
 
-import { toolsInvoke } from "@/lib/gateway";
+import { runOpenClaw } from "@/lib/openclaw";
 
 describe("api cron job route", () => {
   beforeEach(() => {
-    vi.mocked(toolsInvoke).mockReset();
-    vi.mocked(toolsInvoke).mockResolvedValue({ ok: true });
+    vi.mocked(runOpenClaw).mockReset();
+    vi.mocked(runOpenClaw).mockResolvedValue({ ok: true, exitCode: 0, stdout: "{}", stderr: "" });
   });
 
   it("returns 400 when id or action missing", async () => {
@@ -31,7 +31,7 @@ describe("api cron job route", () => {
     expect((await r2.json()).error).toBe("action must be enable|disable|run");
   });
 
-  it("calls toolsInvoke for enable", async () => {
+  it("calls openclaw cron enable", async () => {
     const res = await POST(
       new Request("https://test", {
         method: "POST",
@@ -39,13 +39,10 @@ describe("api cron job route", () => {
       })
     );
     expect(res.status).toBe(200);
-    expect(toolsInvoke).toHaveBeenCalledWith({
-      tool: "cron",
-      args: { action: "update", jobId: "job-1", patch: { enabled: true } },
-    });
+    expect(runOpenClaw).toHaveBeenCalledWith(["cron", "enable", "job-1"]);
   });
 
-  it("calls toolsInvoke for disable", async () => {
+  it("calls openclaw cron disable", async () => {
     const res = await POST(
       new Request("https://test", {
         method: "POST",
@@ -53,14 +50,11 @@ describe("api cron job route", () => {
       })
     );
     expect(res.status).toBe(200);
-    expect(toolsInvoke).toHaveBeenCalledWith({
-      tool: "cron",
-      args: { action: "update", jobId: "job-1", patch: { enabled: false } },
-    });
+    expect(runOpenClaw).toHaveBeenCalledWith(["cron", "disable", "job-1"]);
   });
 
-  it("calls toolsInvoke for run", async () => {
-    vi.mocked(toolsInvoke).mockResolvedValue({ ok: true, result: { ran: true } });
+  it("calls openclaw cron run", async () => {
+    vi.mocked(runOpenClaw).mockResolvedValue({ ok: true, exitCode: 0, stdout: JSON.stringify({ ran: true }), stderr: "" });
     const res = await POST(
       new Request("https://test", {
         method: "POST",
@@ -68,11 +62,8 @@ describe("api cron job route", () => {
       })
     );
     expect(res.status).toBe(200);
-    expect(toolsInvoke).toHaveBeenCalledWith({
-      tool: "cron",
-      args: { action: "run", jobId: "job-1" },
-    });
+    expect(runOpenClaw).toHaveBeenCalledWith(["cron", "run", "job-1", "--json"]);
     const json = await res.json();
-    expect(json.result).toEqual({ ok: true, result: { ran: true } });
+    expect(json.result.ok).toBe(true);
   });
 });

--- a/src/app/api/__tests__/cron-jobs-route.test.ts
+++ b/src/app/api/__tests__/cron-jobs-route.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/lib/paths", async (importOriginal) => {
     readOpenClawConfig: vi.fn().mockResolvedValue({ agents: { defaults: { workspace: "/home/test/.openclaw/agents" } } }),
   };
 });
-vi.mock("@/lib/openclaw", () => ({ runOpenClaw: vi.fn().mockResolvedValue({ ok: true, stdout: "[]" }) }));
+vi.mock("@/lib/openclaw", () => ({ runOpenClaw: vi.fn().mockResolvedValue({ ok: true, exitCode: 0, stdout: JSON.stringify({ jobs: [] }), stderr: "" }) }));
 vi.mock("node:fs/promises", () => ({
   default: {
     readFile: vi.fn(),
@@ -23,20 +23,22 @@ vi.mock("node:fs/promises", () => ({
 }));
 
 import { toolsInvoke } from "@/lib/gateway";
+import { runOpenClaw } from "@/lib/openclaw";
 import { getTeamWorkspaceDir } from "@/lib/paths";
 import fs from "node:fs/promises";
 
 describe("api cron jobs route", () => {
   beforeEach(() => {
     vi.mocked(toolsInvoke).mockReset();
+    vi.mocked(runOpenClaw).mockReset();
     vi.mocked(getTeamWorkspaceDir).mockReset();
     vi.mocked(fs.readFile).mockReset();
     vi.mocked(fs.readdir).mockReset();
     vi.mocked(fs.readdir).mockResolvedValue([]);
   });
 
-  it("returns empty jobs when toolsInvoke has no text", async () => {
-    vi.mocked(toolsInvoke).mockResolvedValue({ content: [] });
+  it("returns empty jobs when cron list returns empty jobs", async () => {
+    vi.mocked(runOpenClaw).mockResolvedValue({ ok: true, exitCode: 0, stdout: JSON.stringify({ jobs: [] }), stderr: "" });
 
     const res = await GET(new Request("https://test"));
     expect(res.status).toBe(200);
@@ -47,9 +49,7 @@ describe("api cron jobs route", () => {
 
   it("returns jobs when no teamId", async () => {
     const jobs = [{ id: "j1", name: "Job 1" }];
-    vi.mocked(toolsInvoke).mockResolvedValue({
-      content: [{ type: "text", text: JSON.stringify({ jobs }) }],
-    });
+    vi.mocked(runOpenClaw).mockResolvedValue({ ok: true, exitCode: 0, stdout: JSON.stringify({ jobs }), stderr: "" });
 
     const res = await GET(new Request("https://test"));
     expect(res.status).toBe(200);
@@ -64,9 +64,7 @@ describe("api cron jobs route", () => {
       { id: "j2" },
       { id: "j3" },
     ];
-    vi.mocked(toolsInvoke).mockResolvedValue({
-      content: [{ type: "text", text: JSON.stringify({ jobs: allJobs }) }],
-    });
+    vi.mocked(runOpenClaw).mockResolvedValue({ ok: true, exitCode: 0, stdout: JSON.stringify({ jobs: allJobs }), stderr: "" });
     vi.mocked(getTeamWorkspaceDir).mockResolvedValue("/home/x/.openclaw/workspace-my-team");
     vi.mocked(fs.readFile).mockResolvedValue(
       JSON.stringify({
@@ -90,9 +88,7 @@ describe("api cron jobs route", () => {
   });
 
   it("returns empty filtered jobs when provenance file missing", async () => {
-    vi.mocked(toolsInvoke).mockResolvedValue({
-      content: [{ type: "text", text: JSON.stringify({ jobs: [{ id: "j1" }] }) }],
-    });
+    vi.mocked(runOpenClaw).mockResolvedValue({ ok: true, exitCode: 0, stdout: JSON.stringify({ jobs: [{ id: "j1" }] }), stderr: "" });
     vi.mocked(getTeamWorkspaceDir).mockResolvedValue("/home/x/.openclaw/workspace-t");
     vi.mocked(fs.readFile).mockRejectedValue(new Error("ENOENT"));
 
@@ -105,8 +101,8 @@ describe("api cron jobs route", () => {
     expect(json.installedIds).toEqual([]);
   });
 
-  it("returns 500 when toolsInvoke throws", async () => {
-    vi.mocked(toolsInvoke).mockRejectedValue(new Error("Gateway unavailable"));
+  it("returns 500 when cron list fails", async () => {
+    vi.mocked(runOpenClaw).mockResolvedValue({ ok: false, exitCode: 1, stdout: "", stderr: "Gateway unavailable" });
 
     const res = await GET(new Request("https://test"));
     expect(res.status).toBe(500);

--- a/src/app/api/__tests__/cron-recipe-installed-route.test.ts
+++ b/src/app/api/__tests__/cron-recipe-installed-route.test.ts
@@ -6,8 +6,10 @@ vi.mock("@/lib/gateway", async (importOriginal) => {
   return { ...actual, toolsInvoke: vi.fn() };
 });
 vi.mock("node:fs/promises", () => ({ default: { readFile: vi.fn() } }));
+vi.mock("@/lib/openclaw", () => ({ runOpenClaw: vi.fn() }));
 
 import { toolsInvoke } from "@/lib/gateway";
+import { runOpenClaw } from "@/lib/openclaw";
 import fs from "node:fs/promises";
 
 describe("api cron recipe-installed route", () => {
@@ -30,10 +32,10 @@ describe("api cron recipe-installed route", () => {
   beforeEach(() => {
     vi.mocked(toolsInvoke).mockReset();
     vi.mocked(fs.readFile).mockReset();
+    vi.mocked(runOpenClaw).mockReset();
 
-    vi.mocked(toolsInvoke)
-      .mockResolvedValueOnce(gatewayConfigResponse as never)
-      .mockResolvedValueOnce({ jobs: [] } as never);
+    vi.mocked(toolsInvoke).mockResolvedValueOnce(gatewayConfigResponse as never);
+    vi.mocked(runOpenClaw).mockResolvedValue({ ok: true, exitCode: 0, stdout: JSON.stringify({ jobs: [] }), stderr: "" });
   });
 
   it("returns 400 when teamId missing", async () => {
@@ -80,13 +82,13 @@ describe("api cron recipe-installed route", () => {
     vi.mocked(toolsInvoke)
       .mockReset()
       .mockResolvedValueOnce(gatewayConfigResponse as never)
-      .mockResolvedValueOnce({
-        jobs: [
+      
+    ;
+    vi.mocked(runOpenClaw).mockResolvedValueOnce({ ok: true, exitCode: 0, stdout: JSON.stringify({ jobs: [
           { id: "cron-1", name: "J1" },
           { id: "cron-2", name: "J2" },
           { id: "cron-3", name: "J3" },
-        ],
-      } as never);
+        ] }), stderr: "" });
 
     const res = await GET(
       new Request("https://test?teamId=my-team")

--- a/src/app/api/cron/delete/route.ts
+++ b/src/app/api/cron/delete/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { toolsInvoke } from "@/lib/gateway";
+import { runOpenClaw } from "@/lib/openclaw";
 import { getBaseWorkspaceFromGateway, markOrphanedInTeamWorkspaces } from "../helpers";
 
 export async function POST(req: Request) {
@@ -7,7 +8,11 @@ export async function POST(req: Request) {
   const id = String(body.id ?? "").trim();
   if (!id) return NextResponse.json({ ok: false, error: "id is required" }, { status: 400 });
 
-  const result = await toolsInvoke({ tool: "cron", args: { action: "remove", jobId: id } });
+  const result = await runOpenClaw(["cron", "rm", id, "--json"]);
+
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, error: result.stderr || result.stdout }, { status: 500 });
+  }
 
   let orphanedIn: Array<{ teamId: string; mappingPath: string; keys: string[] }> = [];
   try {

--- a/src/app/api/cron/job/route.ts
+++ b/src/app/api/cron/job/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { toolsInvoke } from "@/lib/gateway";
+import { runOpenClaw } from "@/lib/openclaw";
 
 export async function POST(req: Request) {
   const body = (await req.json()) as { id?: string; action?: string };
@@ -12,11 +13,12 @@ export async function POST(req: Request) {
   }
 
   if (action === "run") {
-    const result = await toolsInvoke({ tool: "cron", args: { action: "run", jobId: id } });
+    const result = await runOpenClaw(["cron", "run", id, "--json"]);
+    if (!result.ok) return NextResponse.json({ ok: false, error: result.stderr || result.stdout }, { status: 500 });
     return NextResponse.json({ ok: true, action, id, result });
   }
 
-  const patch = { enabled: action === "enable" };
-  const result = await toolsInvoke({ tool: "cron", args: { action: "update", jobId: id, patch } });
+  const result = await runOpenClaw(["cron", action, id]);
+  if (!result.ok) return NextResponse.json({ ok: false, error: result.stderr || result.stdout }, { status: 500 });
   return NextResponse.json({ ok: true, action, id, result });
 }

--- a/src/app/api/cron/job/route.ts
+++ b/src/app/api/cron/job/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-import { toolsInvoke } from "@/lib/gateway";
 import { runOpenClaw } from "@/lib/openclaw";
 
 export async function POST(req: Request) {

--- a/src/app/api/cron/jobs/route.ts
+++ b/src/app/api/cron/jobs/route.ts
@@ -1,12 +1,10 @@
 import path from "node:path";
 import { NextResponse } from "next/server";
-import { toolsInvoke } from "@/lib/gateway";
 import { runOpenClaw } from "@/lib/openclaw";
 import { readOpenClawConfig, getTeamWorkspaceDir } from "@/lib/paths";
 import { errorMessage } from "@/lib/errors";
 import { buildIdToScopeMap, getInstalledIdsForTeam, enrichJobsWithScope } from "../helpers";
 
-type CronToolResult = { content: Array<{ type: string; text?: string }> };
 
 export async function GET(req: Request) {
   try {

--- a/src/app/api/cron/jobs/route.ts
+++ b/src/app/api/cron/jobs/route.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { NextResponse } from "next/server";
 import { toolsInvoke } from "@/lib/gateway";
+import { runOpenClaw } from "@/lib/openclaw";
 import { readOpenClawConfig, getTeamWorkspaceDir } from "@/lib/paths";
 import { errorMessage } from "@/lib/errors";
 import { buildIdToScopeMap, getInstalledIdsForTeam, enrichJobsWithScope } from "../helpers";
@@ -11,26 +12,12 @@ export async function GET(req: Request) {
   try {
     const url = new URL(req.url);
     const teamId = String(url.searchParams.get("teamId") ?? "").trim();
+    const res = await runOpenClaw(["cron", "list", "--all", "--json"]);
+    if (!res.ok) {
+      return NextResponse.json({ ok: false, error: res.stderr || res.stdout }, { status: 500 });
+    }
 
-    const result = await toolsInvoke<CronToolResult>({
-      tool: "cron",
-      args: { action: "list", includeDisabled: true },
-    });
-
-    // Tool responses may come back as either:
-    // - {type:"text", text:"{...}"} (stringified JSON)
-    // - {type:"json", json:{...}} (already-parsed)
-    const text = result?.content?.find((c) => c.type === "text")?.text;
-    const jsonPayload = (result?.content as Array<{ type: string; text?: string; json?: unknown }> | undefined)?.find(
-      (c) => c.type === "json" && c.json,
-    )?.json;
-
-    const parsed = ((): { jobs?: unknown[] } => {
-      if (jsonPayload && typeof jsonPayload === "object") return jsonPayload as { jobs?: unknown[] };
-      if (text && text.trim()) return JSON.parse(text) as { jobs?: unknown[] };
-      return { jobs: [] };
-    })();
-
+    const parsed = JSON.parse(String(res.stdout || "{}")) as { jobs?: unknown[] };
     const jobs = Array.isArray(parsed.jobs) ? parsed.jobs : [];
 
     const baseWorkspace = String((await readOpenClawConfig()).agents?.defaults?.workspace ?? "").trim();

--- a/src/app/api/cron/recipe-installed/route.ts
+++ b/src/app/api/cron/recipe-installed/route.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { NextResponse } from "next/server";
 import { cronJobId, type CronJobShape } from "@/lib/cron";
 import { getContentText, toolsInvoke } from "@/lib/gateway";
+import { runOpenClaw } from "@/lib/openclaw";
 import { teamDirFromBaseWorkspace } from "@/lib/paths";
 
 type MappingStateV1 = {
@@ -55,10 +56,11 @@ export async function GET(req: Request) {
       .map((e) => e.installedCronId)
   );
 
-  const parsed = (await toolsInvoke<{ jobs: unknown[] }>({
-    tool: "cron",
-    args: { action: "list", includeDisabled: true },
-  })) as { jobs: unknown[] };
+  const res = await runOpenClaw(["cron", "list", "--all", "--json"]);
+  if (!res.ok) {
+    return NextResponse.json({ ok: false, error: res.stderr || res.stdout }, { status: 500 });
+  }
+  const parsed = JSON.parse(String(res.stdout || "{}")) as { jobs?: unknown[] };
   const jobs = (parsed.jobs ?? []).filter((j) => ids.has(cronJobId(j as CronJobShape)));
 
   return NextResponse.json({ ok: true, teamId, teamDir, mappingPath, jobCount: jobs.length, jobs });


### PR DESCRIPTION
Fixes Kitchen cron UI regression on OpenClaw 2026.2.26 where toolsInvoke({tool:'cron'}) fails ('cron tool not found').

Changes:
- /api/cron/jobs: use runOpenClaw(['cron','list','--all','--json'])
- /api/cron/job: use runOpenClaw for enable/disable/run
- /api/cron/delete: use runOpenClaw(['cron','rm', id, '--json'])
- /api/cron/recipe-installed: use runOpenClaw cron list

Also updates the related API route tests to mock runOpenClaw.