### PR TITLE
chore: enforce plugin manifest version matches package.json

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "kitchen",
   "name": "ClawKitchen",
   "description": "Local UI for managing OpenClaw recipes, teams, agents, cron jobs, and skills.",
-  "version": "0.1.7",
+  "version": "0.3.3",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "refactor:report": "node scripts/refactor-report.mjs",
     "smoke:goals": "node scripts/goals-smoke.mjs",
     "prepare": "husky",
-    "prepack": "npm run build"
+    "prepack": "npm run -s sync:plugin-version && npm run -s check:plugin-version",
+    "sync:plugin-version": "node scripts/sync-openclaw-plugin-version.mjs",
+    "check:plugin-version": "node scripts/check-openclaw-plugin-version.mjs",
+    "prepublishOnly": "npm run -s sync:plugin-version && npm run -s check:plugin-version"
   },
   "files": [
     "openclaw/",

--- a/scripts/check-openclaw-plugin-version.mjs
+++ b/scripts/check-openclaw-plugin-version.mjs
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+const repoRoot = process.cwd();
+const pkgPath = path.join(repoRoot, "package.json");
+const pluginPath = path.join(repoRoot, "openclaw.plugin.json");
+
+const pkg = readJson(pkgPath);
+const plugin = readJson(pluginPath);
+
+const pkgVer = String(pkg.version || "").trim();
+const pluginVer = String(plugin.version || "").trim();
+
+if (!pkgVer) {
+  console.error(`[version-check] package.json is missing version (${pkgPath})`);
+  process.exit(1);
+}
+if (!pluginVer) {
+  console.error(`[version-check] openclaw.plugin.json is missing version (${pluginPath})`);
+  process.exit(1);
+}
+
+if (pkgVer !== pluginVer) {
+  console.error(
+    [
+      "[version-check] Version mismatch:",
+      `- package.json version:         ${pkgVer}`,
+      `- openclaw.plugin.json version: ${pluginVer}`,
+      "",
+      "Fix: bump openclaw.plugin.json.version to match package.json before publishing.",
+    ].join("\n")
+  );
+  process.exit(1);
+}
+
+console.log(`[version-check] OK: ${pkg.name}@${pkgVer} (manifest version matches)`);

--- a/scripts/sync-openclaw-plugin-version.mjs
+++ b/scripts/sync-openclaw-plugin-version.mjs
@@ -1,0 +1,28 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+const repoRoot = process.cwd();
+const pkgPath = path.join(repoRoot, "package.json");
+const pluginPath = path.join(repoRoot, "openclaw.plugin.json");
+
+const pkg = readJson(pkgPath);
+const plugin = readJson(pluginPath);
+
+const pkgVer = String(pkg.version || "").trim();
+if (!pkgVer) {
+  console.error(`[version-sync] package.json is missing version (${pkgPath})`);
+  process.exit(1);
+}
+
+const prev = String(plugin.version || "").trim();
+if (prev !== pkgVer) {
+  plugin.version = pkgVer;
+  fs.writeFileSync(pluginPath, JSON.stringify(plugin, null, 2) + "\n");
+  console.log(`[version-sync] updated openclaw.plugin.json version: ${prev || "(missing)"} -> ${pkgVer}`);
+} else {
+  console.log(`[version-sync] OK: openclaw.plugin.json already matches ${pkgVer}`);
+}


### PR DESCRIPTION
OpenClaw reports plugin version from openclaw.plugin.json (not package.json). This adds sync+check hooks (prepack/prepublishOnly) so the manifest version always matches the npm version.

Also syncs openclaw.plugin.json.version to the current package.json.version.