### PR TITLE
ClawKitchen: global team context (no redirect) + /tickets team filter (0116)

### DIFF
--- a/src/app/api/__tests__/tickets-move-route.test.ts
+++ b/src/app/api/__tests__/tickets-move-route.test.ts
@@ -10,8 +10,15 @@ describe("api tickets move route", () => {
     vi.mocked(runOpenClaw).mockReset();
   });
 
+  it("returns 400 when teamId missing", async () => {
+    const res = await POST(new Request("https://test", { method: "POST", body: JSON.stringify({ ticket: "T-1", to: "done" }) }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Missing teamId");
+  });
+
   it("returns 400 when ticket missing", async () => {
-    const res = await POST(new Request("https://test", { method: "POST", body: JSON.stringify({}) }));
+    const res = await POST(new Request("https://test", { method: "POST", body: JSON.stringify({ teamId: "dev" }) }));
     expect(res.status).toBe(400);
     const json = await res.json();
     expect(json.error).toBe("Missing ticket");
@@ -21,8 +28,8 @@ describe("api tickets move route", () => {
     const res = await POST(
       new Request("https://test", {
         method: "POST",
-        body: JSON.stringify({ ticket: "T-1", to: "invalid" }),
-      })
+        body: JSON.stringify({ teamId: "dev", ticket: "T-1", to: "invalid" }),
+      }),
     );
     expect(res.status).toBe(400);
     const json = await res.json();
@@ -34,14 +41,14 @@ describe("api tickets move route", () => {
     const res = await POST(
       new Request("https://test", {
         method: "POST",
-        body: JSON.stringify({ ticket: "T-1", to: "in-progress" }),
-      })
+        body: JSON.stringify({ teamId: "dev", ticket: "T-1", to: "in-progress" }),
+      }),
     );
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.ok).toBe(true);
     expect(runOpenClaw).toHaveBeenCalledWith(
-      expect.arrayContaining(["recipes", "move-ticket", "--ticket", "T-1", "--to", "in-progress"])
+      expect.arrayContaining(["recipes", "move-ticket", "--team-id", "dev", "--ticket", "T-1", "--to", "in-progress"]),
     );
   });
 
@@ -50,8 +57,8 @@ describe("api tickets move route", () => {
     const res = await POST(
       new Request("https://test", {
         method: "POST",
-        body: JSON.stringify({ ticket: "T-1", to: "done" }),
-      })
+        body: JSON.stringify({ teamId: "dev", ticket: "T-1", to: "done" }),
+      }),
     );
     expect(res.status).toBe(500);
     const json = await res.json();

--- a/src/app/cron-jobs/cron-jobs-client.tsx
+++ b/src/app/cron-jobs/cron-jobs-client.tsx
@@ -33,8 +33,9 @@ function isEnabled(j: CronJob): boolean {
   return Boolean(j.enabled ?? (j as { state?: { enabled?: unknown } }).state?.enabled);
 }
 
-export default function CronJobsClient() {
+export default function CronJobsClient({ teamId }: { teamId: string | null }) {
   const toast = useToast();
+  const teamFilter = (teamId ?? "").trim();
   const [loading, setLoading] = useState(false);
   const [jobs, setJobs] = useState<CronJob[]>([]);
   const [msg, setMsg] = useState<string>("");
@@ -59,7 +60,8 @@ export default function CronJobsClient() {
     setLoading(true);
     setMsg("");
     try {
-      const json = await fetchJson<{ jobs?: CronJob[] }>("/api/cron/jobs", { cache: "no-store" });
+      const url = teamFilter ? `/api/cron/jobs?teamId=${encodeURIComponent(teamFilter)}` : "/api/cron/jobs";
+      const json = await fetchJson<{ jobs?: CronJob[] }>(url, { cache: "no-store" });
       setJobs(json.jobs ?? []);
       if ((json.jobs ?? []).length === 0) {
         setMsg("No cron jobs found.");
@@ -74,7 +76,8 @@ export default function CronJobsClient() {
 
   useEffect(() => {
     refresh();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refresh closes over teamFilter
+  }, [teamFilter]);
 
   async function act(id: string, action: "enable" | "disable" | "run") {
     setLoading(true);

--- a/src/app/cron-jobs/page.tsx
+++ b/src/app/cron-jobs/page.tsx
@@ -1,7 +1,14 @@
 import CronJobsClient from "./cron-jobs-client";
 import Link from "next/link";
 
-export default function CronJobsPage() {
+export default async function CronJobsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const team = typeof sp.team === "string" ? sp.team.trim() : "";
+
   return (
     <div className="ck-glass w-full p-6 sm:p-8">
       <div className="flex items-baseline justify-between gap-4">
@@ -27,7 +34,7 @@ export default function CronJobsPage() {
       </p>
 
       <div className="mt-6">
-        <CronJobsClient />
+        <CronJobsClient teamId={team || null} />
       </div>
     </div>
   );

--- a/src/app/teams/[teamId]/tickets/page.tsx
+++ b/src/app/teams/[teamId]/tickets/page.tsx
@@ -11,5 +11,11 @@ export default async function TeamTicketsPage({
   const { teamId } = await params;
   const tickets = await listTickets(teamId);
 
-  return <TicketsBoardClient tickets={tickets} basePath={`/teams/${encodeURIComponent(teamId)}/tickets`} />;
+  return (
+    <TicketsBoardClient
+      tickets={tickets}
+      basePath={`/teams/${encodeURIComponent(teamId)}/tickets`}
+      selectedTeamId={teamId}
+    />
+  );
 }

--- a/src/app/tickets/TicketsBoardClient.tsx
+++ b/src/app/tickets/TicketsBoardClient.tsx
@@ -44,7 +44,7 @@ function formatAge(hours: number) {
   return `${Math.round(hours / 24)}d`;
 }
 
-export function TicketsBoardClient({ tickets }: { tickets: TicketSummary[] }) {
+export function TicketsBoardClient({ tickets, teamId }: { tickets: TicketSummary[]; teamId: string | null }) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
@@ -114,7 +114,7 @@ export function TicketsBoardClient({ tickets }: { tickets: TicketSummary[] }) {
     await fetchJson("/api/tickets/move", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ ticket: ticket.id, to }),
+      body: JSON.stringify({ teamId: ticket.teamId, ticket: ticket.id, to }),
     });
   }
 
@@ -201,6 +201,8 @@ export function TicketsBoardClient({ tickets }: { tickets: TicketSummary[] }) {
                     {String(t.number).padStart(4, "0")} — {t.title}
                   </a>
                   <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[color:var(--ck-text-secondary)]">
+                    <span className="rounded bg-white/5 px-1.5 py-0.5">{t.teamId}</span>
+                    <span>·</span>
                     <span>{t.owner ? `Owner: ${t.owner}` : "Owner: —"}</span>
                     <span>·</span>
                     <span>Age: {formatAge(t.ageHours)}</span>
@@ -234,7 +236,16 @@ export function TicketsBoardClient({ tickets }: { tickets: TicketSummary[] }) {
       </div>
 
       <p className="text-xs text-[color:var(--ck-text-tertiary)]">
-        Source of truth: development-team markdown tickets (via openclaw recipes move-ticket).
+        Source of truth: <code>workspace-&lt;teamId&gt;</code> markdown tickets (via openclaw recipes move-ticket).{" "}
+        {teamId ? (
+          <>
+            Viewing: <span className="font-medium text-[color:var(--ck-text-secondary)]">{teamId}</span>
+          </>
+        ) : (
+          <>
+            Viewing: <span className="font-medium text-[color:var(--ck-text-secondary)]">all</span>
+          </>
+        )}
       </p>
 
       {confirmMove ? (

--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -4,7 +4,8 @@ import { TicketsBoardClient } from "@/app/tickets/TicketsBoardClient";
 // Tickets reflect live filesystem state; do not cache.
 export const dynamic = "force-dynamic";
 
-export default async function TicketsPage() {
-  const tickets = await listTickets();
-  return <TicketsBoardClient tickets={tickets} />;
+export default async function TicketsPage({ searchParams }: { searchParams?: { team?: string } }) {
+  const teamId = typeof searchParams?.team === "string" ? searchParams.team : undefined;
+  const tickets = await listTickets({ teamId });
+  return <TicketsBoardClient tickets={tickets} teamId={teamId ?? null} />;
 }

--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -1,4 +1,4 @@
-import { listAllTeamsTickets, listTickets } from "@/lib/tickets";
+import { listTickets } from "@/lib/tickets";
 import { TicketsBoardClient } from "@/app/tickets/TicketsBoardClient";
 
 // Tickets reflect live filesystem state; do not cache.
@@ -7,14 +7,15 @@ export const dynamic = "force-dynamic";
 export default async function TicketsPage({
   searchParams,
 }: {
-  searchParams?: {
-    team?: string;
-  };
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  const rawTeam = typeof searchParams?.team === "string" ? searchParams.team.trim() : "";
-  const teamParam = rawTeam && rawTeam !== "all" ? rawTeam : null;
+  const sp = await searchParams;
+  const team = typeof sp.team === "string" ? sp.team.trim() : "";
 
-  const tickets = teamParam ? await listTickets(teamParam) : await listAllTeamsTickets();
+  // If no team is specified, fall back to legacy behavior.
+  // (AppShell will try to keep /tickets synced with the globally selected team via ?team=.)
+  const teamId = team || "development-team";
 
-  return <TicketsBoardClient tickets={tickets} basePath="/tickets" selectedTeamId={teamParam} />;
+  const tickets = await listTickets(teamId);
+  return <TicketsBoardClient tickets={tickets} basePath="/tickets" />;
 }

--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -17,5 +17,5 @@ export default async function TicketsPage({
   const teamId = team || "development-team";
 
   const tickets = await listTickets(teamId);
-  return <TicketsBoardClient tickets={tickets} basePath="/tickets" />;
+  return <TicketsBoardClient tickets={tickets} basePath="/tickets" selectedTeamId={team || null} />;
 }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -51,96 +51,35 @@ function SideNavLink({
   );
 }
 
-function safeDecode(v: string) {
-  try {
-    return decodeURIComponent(v);
-  } catch {
-    return v;
-  }
-}
-
 export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname() || "/";
   const router = useRouter();
-
-  const routeTeamId = useMemo(() => {
+  const teamIdFromPath = useMemo(() => {
     const m = pathname.match(/^\/teams\/([^/]+)(?:\/|$)/);
-    return m ? safeDecode(m[1]) : null;
+    return m ? decodeURIComponent(m[1]) : null;
   }, [pathname]);
 
-  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
-
-  // Initial hydrate from localStorage.
-  useEffect(() => {
+  const [storedTeamId, setStoredTeamId] = useState<string>(() => {
+    if (typeof window === "undefined") return "";
     try {
-      const v = localStorage.getItem("ck-selected-team");
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- hydrate from localStorage after mount.
-      if (v) setSelectedTeamId(v);
+      return (localStorage.getItem("ck-selected-team") || "").trim();
     } catch {
-      // ignore
+      return "";
     }
-  }, []);
+  });
 
-  // Query param override (on mount) and route override (whenever team editor page is visited).
+  const selectedTeamId = (teamIdFromPath || storedTeamId).trim();
+
+  // Keep localStorage in sync with the effective selected team (when we can compute it).
   useEffect(() => {
-    let q: string | null = null;
+    if (typeof window === "undefined") return;
     try {
-      const sp = new URLSearchParams(window.location.search);
-      const v = sp.get("team");
-      if (v) q = safeDecode(v);
-    } catch {
-      // ignore
-    }
-
-    const override = q;
-    if (!override) return;
-
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- query deep link should win on first load.
-    setSelectedTeamId((prev) => {
-      if (prev === override) return prev;
-      try {
-        localStorage.setItem("ck-selected-team", override);
-      } catch {
-        // ignore
-      }
-      return override;
-    });
-  }, []);
-
-  useEffect(() => {
-    const override = routeTeamId;
-    if (!override) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- team editor route should sync selection.
-    setSelectedTeamId((prev) => {
-      if (prev === override) return prev;
-      try {
-        localStorage.setItem("ck-selected-team", override);
-      } catch {
-        // ignore
-      }
-      return override;
-    });
-  }, [routeTeamId]);
-
-  function setSelectedTeamIdPersist(next: string | null) {
-    setSelectedTeamId(next);
-    try {
-      if (next) localStorage.setItem("ck-selected-team", next);
+      if (selectedTeamId) localStorage.setItem("ck-selected-team", selectedTeamId);
       else localStorage.removeItem("ck-selected-team");
     } catch {
       // ignore
     }
-
-    // Optional: keep team-scoped pages deep-linkable.
-    if (pathname === "/tickets" || pathname.startsWith("/tickets/")) {
-      const url = next ? `/tickets?team=${encodeURIComponent(next)}` : "/tickets";
-      router.replace(url);
-    }
-    if (pathname === "/goals" || pathname.startsWith("/goals/")) {
-      const url = next ? `/goals?team=${encodeURIComponent(next)}` : "/goals";
-      router.replace(url);
-    }
-  }
+  }, [selectedTeamId]);
 
   const [collapsed, setCollapsed] = useState(false);
 
@@ -155,6 +94,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
+
+
   function toggleCollapsed() {
     setCollapsed((v) => {
       const next = !v;
@@ -167,14 +108,14 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     });
   }
 
-  // Minimal team list (for switcher). We rely on existing /api/agents.
+  // Minimal team list (for switcher). We rely on existing /api/recipes.
   const [teamIds, setTeamIds] = useState<string[]>([]);
   useEffect(() => {
     (async () => {
       try {
         const json = await fetchJson<{ agents?: Array<{ workspace?: string }> }>("/api/agents", { cache: "no-store" });
         const agents = Array.isArray(json.agents)
-          ? (json.agents as Array<{ workspace?: string }>)
+          ? (json.agents as Array<{ workspace?: string }> )
           : [];
 
         const s = new Set<string>();
@@ -193,9 +134,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       }
     })();
   }, []);
-
-  const ticketsHref = selectedTeamId ? `/tickets?team=${encodeURIComponent(selectedTeamId)}` : "/tickets";
-  const goalsHref = selectedTeamId ? `/goals?team=${encodeURIComponent(selectedTeamId)}` : "/goals";
 
   const globalNav = [
     {
@@ -224,7 +162,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       ),
     },
     {
-      href: ticketsHref,
+      href: `/tickets`,
       label: "Tickets",
       icon: (
         <Icon>
@@ -235,7 +173,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       ),
     },
     {
-      href: goalsHref,
+      href: `/goals`,
       label: "Goals",
       icon: (
         <Icon>
@@ -297,7 +235,18 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                 className="w-full rounded-[var(--ck-radius-sm)] bg-white/5 px-2 py-2 text-xs font-medium text-[color:var(--ck-text-secondary)] hover:bg-white/10"
                 title={selectedTeamId ? `Team: ${selectedTeamId}` : "Select team"}
                 onClick={() => {
-                  if (!selectedTeamId && teamIds[0]) setSelectedTeamIdPersist(teamIds[0]);
+                  const id = teamIds[0] || "";
+                  if (!id) return;
+                  setStoredTeamId(id);
+                  try {
+                    localStorage.setItem("ck-selected-team", id);
+                  } catch {
+                    // ignore
+                  }
+
+                  if (pathname === "/tickets") {
+                    router.replace(`/tickets?team=${encodeURIComponent(id)}`);
+                  }
                 }}
               >
                 👥
@@ -310,50 +259,47 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                 <select
                   value={selectedTeamId ?? ""}
                   onChange={(e) => {
-                    const id = e.target.value;
-                    setSelectedTeamIdPersist(id || null);
+                    const id = (e.target.value || "").trim();
+                    setStoredTeamId(id);
+                    try {
+                      localStorage.setItem("ck-selected-team", id);
+                    } catch {
+                      // ignore
+                    }
+
+                    // Keep the user on the current page; just update page-level filters where supported.
+                    if (pathname === "/tickets") {
+                      if (id) router.replace(`/tickets?team=${encodeURIComponent(id)}`);
+                      else router.replace("/tickets");
+                    }
                   }}
                   className="w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-2 text-sm text-[color:var(--ck-text-primary)]"
                 >
-                  <option value="">(all)</option>
+                  <option value="">(select)</option>
                   {teamIds.map((id) => (
                     <option key={id} value={id}>
                       {id}
                     </option>
                   ))}
                 </select>
-
-                <div className="flex items-center justify-between px-2 pt-1 text-xs text-[color:var(--ck-text-tertiary)]">
-                  <span>{routeTeamId ? `Editing: ${routeTeamId}` : selectedTeamId ? `Selected: ${selectedTeamId}` : "Selected: all"}</span>
-                  {selectedTeamId ? (
-                    <Link
-                      href={`/teams/${encodeURIComponent(selectedTeamId)}`}
-                      className="text-[color:var(--ck-text-secondary)] hover:underline"
-                      title="Edit team"
-                    >
-                      Edit team
-                    </Link>
-                  ) : null}
-                </div>
               </div>
             )}
           </div>
 
           <nav className="min-h-0 flex-1 overflow-auto p-2">
-            <div className="mt-2 px-2 pb-2 pt-2">{/* section label intentionally omitted */}</div>
-            {globalNav.map((it) => {
-              const hrefPath = it.href.split("?")[0];
-              return (
-                <SideNavLink
-                  key={it.href}
-                  href={it.href}
-                  label={it.label}
-                  icon={<span aria-hidden>{it.icon}</span>}
-                  collapsed={collapsed}
-                  active={pathname === hrefPath || pathname.startsWith(hrefPath + "/")}
-                />
-              );
-            })}
+            <div className="mt-2 px-2 pb-2 pt-2">
+              {/* section label intentionally omitted */}
+            </div>
+            {globalNav.map((it) => (
+              <SideNavLink
+                key={it.href}
+                href={it.href}
+                label={it.label}
+                icon={<span aria-hidden>{it.icon}</span>}
+                collapsed={collapsed}
+                active={pathname === it.href || pathname.startsWith(it.href + "/")}
+              />
+            ))}
           </nav>
 
           <div className="flex items-center justify-between gap-2 border-t border-[color:var(--ck-border-subtle)] p-2">

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -70,6 +70,47 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   const selectedTeamId = (teamIdFromPath || storedTeamId).trim();
 
+  function withTeamQuery(href: string, teamId: string): string {
+    const [pathPart, qs] = href.split("?");
+    const sp = new URLSearchParams(qs ?? "");
+    sp.set("team", teamId);
+    return `${pathPart}?${sp.toString()}`;
+  }
+
+  function navHref(href: string): string {
+    if (!selectedTeamId) return href;
+    // Only carry team context for pages that currently support it.
+    if (href === "/tickets" || href === "/goals" || href === "/cron-jobs") {
+      return withTeamQuery(href, selectedTeamId);
+    }
+    return href;
+  }
+
+  function syncTeamToCurrentUrl(teamId: string) {
+    if (!teamId) return;
+    // Team editor routes already encode team in the path.
+    if (pathname.startsWith("/teams/")) return;
+    // Only enforce on pages that support it.
+    if (pathname !== "/tickets" && pathname !== "/goals" && pathname !== "/cron-jobs") return;
+
+    try {
+      const url = new URL(window.location.href);
+      if ((url.searchParams.get("team") ?? "").trim() === teamId) return;
+      url.searchParams.set("team", teamId);
+      router.replace(url.pathname + "?" + url.searchParams.toString());
+    } catch {
+      // ignore
+    }
+  }
+
+  // If a team is selected, ensure the current URL includes ?team=... (supported pages only).
+  useEffect(() => {
+    if (!selectedTeamId) return;
+    if (typeof window === "undefined") return;
+    syncTeamToCurrentUrl(selectedTeamId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- sync uses window.location
+  }, [pathname, selectedTeamId]);
+
   // Keep localStorage in sync with the effective selected team (when we can compute it).
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -162,7 +203,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       ),
     },
     {
-      href: `/tickets`,
+      href: navHref(`/tickets`),
       label: "Tickets",
       icon: (
         <Icon>
@@ -173,7 +214,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       ),
     },
     {
-      href: `/goals`,
+      href: navHref(`/goals`),
       label: "Goals",
       icon: (
         <Icon>
@@ -185,7 +226,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       ),
     },
     {
-      href: `/cron-jobs`,
+      href: navHref(`/cron-jobs`),
       label: "Cron jobs",
       icon: (
         <Icon>
@@ -244,9 +285,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                     // ignore
                   }
 
-                  if (pathname === "/tickets") {
-                    router.replace(`/tickets?team=${encodeURIComponent(id)}`);
-                  }
+                  syncTeamToCurrentUrl(id);
                 }}
               >
                 👥
@@ -267,11 +306,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                       // ignore
                     }
 
-                    // Keep the user on the current page; just update page-level filters where supported.
-                    if (pathname === "/tickets") {
-                      if (id) router.replace(`/tickets?team=${encodeURIComponent(id)}`);
-                      else router.replace("/tickets");
-                    }
+                    syncTeamToCurrentUrl(id);
                   }}
                   className="w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-2 text-sm text-[color:var(--ck-text-primary)]"
                 >
@@ -282,6 +317,15 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                     </option>
                   ))}
                 </select>
+
+                {selectedTeamId ? (
+                  <Link
+                    href={`/teams/${encodeURIComponent(selectedTeamId)}`}
+                    className="px-2 pb-1 text-xs font-medium text-[color:var(--ck-text-tertiary)] hover:text-[color:var(--ck-text-secondary)]"
+                  >
+                    Edit team
+                  </Link>
+                ) : null}
               </div>
             )}
           </div>

--- a/src/lib/__tests__/tickets.test.ts
+++ b/src/lib/__tests__/tickets.test.ts
@@ -19,10 +19,11 @@ vi.mock("node:fs/promises", () => ({
 describe("tickets", () => {
   describe("stageDir", () => {
     it("maps each stage to correct path", () => {
-      expect(stageDir("backlog")).toContain("work/backlog");
-      expect(stageDir("in-progress")).toContain("work/in-progress");
-      expect(stageDir("testing")).toContain("work/testing");
-      expect(stageDir("done")).toContain("work/done");
+      const teamDir = "/home/x/.openclaw/workspace-dev";
+      expect(stageDir(teamDir, "backlog")).toContain("work/backlog");
+      expect(stageDir(teamDir, "in-progress")).toContain("work/in-progress");
+      expect(stageDir(teamDir, "testing")).toContain("work/testing");
+      expect(stageDir(teamDir, "done")).toContain("work/done");
     });
   });
 
@@ -81,7 +82,7 @@ describe("tickets", () => {
         mtimeMs: new Date("2026-01-15T10:00:00Z").getTime(),
       } as ReturnType<typeof fs.stat> extends Promise<infer T> ? T : never);
 
-      const result = await listTickets();
+      const result = await listTickets({ teamId: "dev" });
       expect(result).toHaveLength(1);
       expect(result[0].number).toBe(33);
       expect(result[0].id).toBe("0033-fix-login");
@@ -97,7 +98,7 @@ describe("tickets", () => {
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([]);
 
-      const result = await listTickets();
+      const result = await listTickets({ teamId: "dev" });
       expect(result).toEqual([]);
     });
 
@@ -114,7 +115,7 @@ describe("tickets", () => {
         mtimeMs: Date.now(),
       } as ReturnType<typeof fs.stat> extends Promise<infer T> ? T : never);
 
-      const result = await listTickets();
+      const result = await listTickets({ teamId: "dev" });
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe("0033-a");
     });
@@ -137,21 +138,21 @@ describe("tickets", () => {
     });
 
     it("finds by id and returns markdown", async () => {
-      const result = await getTicketMarkdown("0033-fix");
+      const result = await getTicketMarkdown("0033-fix", { teamId: "dev" });
       expect(result).not.toBeNull();
       expect(result!.id).toBe("0033-fix");
       expect(result!.markdown).toContain("Fix it");
     });
 
     it("finds by number", async () => {
-      const result = await getTicketMarkdown("33");
+      const result = await getTicketMarkdown("33", { teamId: "dev" });
       expect(result).not.toBeNull();
       expect(result!.id).toBe("0033-fix");
     });
 
     it("returns null when not found", async () => {
       vi.mocked(fs.readdir).mockReset().mockResolvedValue([]);
-      const result = await getTicketMarkdown("9999");
+      const result = await getTicketMarkdown("9999", { teamId: "dev" });
       expect(result).toBeNull();
     });
   });


### PR DESCRIPTION
Re-opens 0116 after prior PR was closed.\n\n- Left-nav team dropdown sets global team context (no redirect)\n- Persists selection in localStorage\n- Supports deep-link override via ?team=... and syncs selection\n- /tickets defaults to selected team; supports all\n\nVerification: see ticket #0116 steps.