### PR TITLE
Fix /api/channels/bindings without enabling gateway tool

### DIFF
--- a/src/app/api/__tests__/channels-bindings-route.test.ts
+++ b/src/app/api/__tests__/channels-bindings-route.test.ts
@@ -1,30 +1,34 @@
+// @vitest-environment node
+
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { GET, PUT, DELETE } from "../channels/bindings/route";
 
-vi.mock("@/lib/gateway", () => ({
-  gatewayConfigGet: vi.fn(),
-  gatewayConfigPatch: vi.fn(),
+vi.mock("@/lib/openclaw-config", () => ({
+  readOpenClawConfigRaw: vi.fn(),
+  redactChannels: (channels: unknown) => channels,
+  patchOpenClawConfigFile: vi.fn(),
 }));
 
-vi.mock("@/lib/paths", () => ({
-  readOpenClawConfig: vi.fn(),
-}));
+import { readOpenClawConfigRaw, patchOpenClawConfigFile } from "@/lib/openclaw-config";
 
-import { gatewayConfigGet, gatewayConfigPatch } from "@/lib/gateway";
-import { readOpenClawConfig } from "@/lib/paths";
+type PatchCall = {
+  note?: string;
+  patch: (prev: { channels?: Record<string, unknown> }) => { channels?: Record<string, unknown> };
+};
 
 describe("api channels bindings route", () => {
   beforeEach(() => {
-    vi.mocked(gatewayConfigGet).mockReset();
-    vi.mocked(gatewayConfigPatch).mockReset();
-    vi.mocked(readOpenClawConfig).mockReset();
+    vi.mocked(readOpenClawConfigRaw).mockReset();
+    vi.mocked(patchOpenClawConfigFile).mockReset();
 
-    vi.mocked(gatewayConfigGet).mockResolvedValue({
-      raw: JSON.stringify({ channels: { telegram: { botToken: "x" } } }),
+    vi.mocked(readOpenClawConfigRaw).mockResolvedValue({
+      path: "/home/test/.openclaw/openclaw.json",
+      raw: JSON.stringify({ channels: { telegram: { botToken: "x" } }, bindings: [] }),
       hash: "abc",
-    });
-    vi.mocked(readOpenClawConfig).mockResolvedValue({ bindings: [] } as never);
-    vi.mocked(gatewayConfigPatch).mockResolvedValue(undefined);
+      json: { channels: { telegram: { botToken: "x" } }, bindings: [] },
+    } as never);
+
+    vi.mocked(patchOpenClawConfigFile).mockResolvedValue({ ok: true, path: "/home/test/.openclaw/openclaw.json", hash: "def" } as never);
   });
 
   describe("GET", () => {
@@ -38,19 +42,8 @@ describe("api channels bindings route", () => {
       expect(json.bindings).toEqual([]);
     });
 
-    it("returns empty channels when invalid JSON", async () => {
-      vi.mocked(gatewayConfigGet).mockResolvedValue({
-        raw: "not json",
-        hash: "x",
-      });
-      const res = await GET();
-      expect(res.status).toBe(200);
-      const json = await res.json();
-      expect(json.channels).toEqual({});
-    });
-
-    it("returns 500 when gateway throws", async () => {
-      vi.mocked(gatewayConfigGet).mockRejectedValue(new Error("Gateway error"));
+    it("returns 500 when config read throws", async () => {
+      vi.mocked(readOpenClawConfigRaw).mockRejectedValue(new Error("read error"));
       const res = await GET();
       expect(res.status).toBe(500);
     });
@@ -58,9 +51,7 @@ describe("api channels bindings route", () => {
 
   describe("PUT", () => {
     it("returns 400 when provider or config missing", async () => {
-      const r1 = await PUT(
-        new Request("https://test", { method: "PUT", body: JSON.stringify({}) })
-      );
+      const r1 = await PUT(new Request("https://test", { method: "PUT", body: JSON.stringify({}) }));
       expect(r1.status).toBe(400);
       expect((await r1.json()).error).toBe("provider is required");
 
@@ -96,14 +87,19 @@ describe("api channels bindings route", () => {
         })
       );
       expect(res.status).toBe(200);
-      expect(gatewayConfigPatch).toHaveBeenCalledWith(
-        { channels: { telegram: { botToken: "secret" } } },
-        expect.stringContaining("telegram")
-      );
+      const json = await res.json();
+      expect(json.ok).toBe(true);
+      expect(json.restartRequired).toBe(true);
+
+      expect(patchOpenClawConfigFile).toHaveBeenCalledTimes(1);
+      const call = vi.mocked(patchOpenClawConfigFile).mock.calls[0]![0] as unknown as PatchCall;
+      expect(String(call.note)).toContain("telegram");
+      const next = call.patch({ channels: { slack: { x: 1 } } });
+      expect(next.channels).toEqual({ slack: { x: 1 }, telegram: { botToken: "secret" } });
     });
 
-    it("returns 500 when gatewayConfigPatch throws", async () => {
-      vi.mocked(gatewayConfigPatch).mockRejectedValue(new Error("Gateway error"));
+    it("returns 500 when patchOpenClawConfigFile throws", async () => {
+      vi.mocked(patchOpenClawConfigFile).mockRejectedValue(new Error("patch error"));
       const res = await PUT(
         new Request("https://test", {
           method: "PUT",
@@ -111,19 +107,17 @@ describe("api channels bindings route", () => {
         })
       );
       expect(res.status).toBe(500);
-      expect((await res.json()).error).toBe("Gateway error");
+      expect((await res.json()).error).toBe("patch error");
     });
   });
 
   describe("DELETE", () => {
     it("returns 400 when provider missing", async () => {
-      const res = await DELETE(
-        new Request("https://test", { method: "DELETE", body: JSON.stringify({}) })
-      );
+      const res = await DELETE(new Request("https://test", { method: "DELETE", body: JSON.stringify({}) }));
       expect(res.status).toBe(400);
     });
 
-    it("returns ok and patches provider to null", async () => {
+    it("returns ok and removes provider", async () => {
       const res = await DELETE(
         new Request("https://test", {
           method: "DELETE",
@@ -131,14 +125,18 @@ describe("api channels bindings route", () => {
         })
       );
       expect(res.status).toBe(200);
-      expect(gatewayConfigPatch).toHaveBeenCalledWith(
-        { channels: { telegram: null } },
-        expect.stringContaining("telegram")
-      );
+      const json = await res.json();
+      expect(json.ok).toBe(true);
+      expect(json.restartRequired).toBe(true);
+
+      expect(patchOpenClawConfigFile).toHaveBeenCalledTimes(1);
+      const call = vi.mocked(patchOpenClawConfigFile).mock.calls[0]![0] as unknown as PatchCall;
+      const next = call.patch({ channels: { telegram: { botToken: "x" }, slack: { y: 2 } } });
+      expect(next.channels).toEqual({ slack: { y: 2 } });
     });
 
-    it("returns 500 when gatewayConfigPatch throws", async () => {
-      vi.mocked(gatewayConfigPatch).mockRejectedValue(new Error("Gateway error"));
+    it("returns 500 when patchOpenClawConfigFile throws", async () => {
+      vi.mocked(patchOpenClawConfigFile).mockRejectedValue(new Error("patch error"));
       const res = await DELETE(
         new Request("https://test", {
           method: "DELETE",

--- a/src/app/api/channels/bindings/route.ts
+++ b/src/app/api/channels/bindings/route.ts
@@ -1,23 +1,19 @@
 import { NextResponse } from "next/server";
 import { errorMessage } from "@/lib/errors";
-import { gatewayConfigGet, gatewayConfigPatch } from "@/lib/gateway";
-import { safeJsonParse } from "@/lib/json";
-import { readOpenClawConfig } from "@/lib/paths";
+import { readOpenClawConfigRaw, redactChannels, patchOpenClawConfigFile } from "@/lib/openclaw-config";
 import { isRecord } from "@/lib/type-guards";
 
 export async function GET() {
   try {
-    const [{ raw, hash }, openclaw] = await Promise.all([gatewayConfigGet(), readOpenClawConfig()]);
-
-    const parsed = safeJsonParse(raw);
-    const root = isRecord(parsed) ? parsed : {};
+    const cfg = await readOpenClawConfigRaw();
+    const root = isRecord(cfg.json) ? cfg.json : {};
     const channels = isRecord(root.channels) ? root.channels : {};
+    const bindings = Array.isArray(root.bindings) ? root.bindings : [];
 
-    // Channel bindings live in ~/.openclaw/openclaw.json (not the gateway config).
-    // We only surface the bindings list (no secrets) so UI can present a dropdown.
-    const bindings = Array.isArray(openclaw.bindings) ? openclaw.bindings : [];
-
-    return NextResponse.json({ ok: true, hash, channels, bindings });
+    // NOTE: We intentionally avoid calling the Gateway tool (gateway.config.get/patch) here.
+    // Kitchen runs in-process with the gateway, but the /tools/invoke surface is sensitive.
+    // Instead, we read ~/.openclaw/openclaw.json directly and redact secrets.
+    return NextResponse.json({ ok: true, hash: cfg.hash, channels: redactChannels(channels), bindings });
   } catch (e: unknown) {
     const msg = errorMessage(e);
     return NextResponse.json({ ok: false, error: msg }, { status: 500 });
@@ -44,7 +40,16 @@ export async function PUT(req: Request) {
       if (!botToken) return NextResponse.json({ ok: false, error: "telegram.botToken is required" }, { status: 400 });
     }
 
-    await gatewayConfigPatch({ channels: { [provider]: cfg } }, `ClawKitchen Channels upsert: ${provider}`);
+    await patchOpenClawConfigFile({
+      note: `ClawKitchen Channels upsert: ${provider}`,
+      patch: (prev) => {
+        const next = { ...prev };
+        const prevChannels = isRecord(next.channels) ? (next.channels as Record<string, unknown>) : {};
+        next.channels = { ...prevChannels, [provider]: cfg };
+        return next;
+      },
+    });
+
     return NextResponse.json({ ok: true });
   } catch (e: unknown) {
     const msg = errorMessage(e);
@@ -60,8 +65,17 @@ export async function DELETE(req: Request) {
     const provider = String(body?.provider ?? "").trim();
     if (!provider) return NextResponse.json({ ok: false, error: "provider is required" }, { status: 400 });
 
-    // Patch semantics: setting a provider to null removes/clears it in the gateway config patcher.
-    await gatewayConfigPatch({ channels: { [provider]: null } }, `ClawKitchen Channels delete: ${provider}`);
+    await patchOpenClawConfigFile({
+      note: `ClawKitchen Channels delete: ${provider}`,
+      patch: (prev) => {
+        const next = { ...prev };
+        const prevChannels = isRecord(next.channels) ? (next.channels as Record<string, unknown>) : {};
+        const { [provider]: _removed, ...rest } = prevChannels;
+        next.channels = rest;
+        return next;
+      },
+    });
+
     return NextResponse.json({ ok: true });
   } catch (e: unknown) {
     const msg = errorMessage(e);

--- a/src/app/api/channels/bindings/route.ts
+++ b/src/app/api/channels/bindings/route.ts
@@ -50,7 +50,7 @@ export async function PUT(req: Request) {
       },
     });
 
-    return NextResponse.json({ ok: true });
+    return NextResponse.json({ ok: true, restartRequired: true, restartHint: "Restart OpenClaw Gateway to apply channel config changes." });
   } catch (e: unknown) {
     const msg = errorMessage(e);
     return NextResponse.json({ ok: false, error: msg }, { status: 500 });
@@ -77,7 +77,7 @@ export async function DELETE(req: Request) {
       },
     });
 
-    return NextResponse.json({ ok: true });
+    return NextResponse.json({ ok: true, restartRequired: true, restartHint: "Restart OpenClaw Gateway to apply channel config changes." });
   } catch (e: unknown) {
     const msg = errorMessage(e);
     return NextResponse.json({ ok: false, error: msg }, { status: 500 });

--- a/src/app/api/channels/bindings/route.ts
+++ b/src/app/api/channels/bindings/route.ts
@@ -70,7 +70,8 @@ export async function DELETE(req: Request) {
       patch: (prev) => {
         const next = { ...prev };
         const prevChannels = isRecord(next.channels) ? (next.channels as Record<string, unknown>) : {};
-        const { [provider]: _removed, ...rest } = prevChannels;
+        const rest = { ...prevChannels };
+        delete (rest as Record<string, unknown>)[provider];
         next.channels = rest;
         return next;
       },

--- a/src/lib/__tests__/openclaw-config.test.ts
+++ b/src/lib/__tests__/openclaw-config.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import { patchOpenClawConfigFile, readOpenClawConfigRaw, redactChannels } from "@/lib/openclaw-config";
+
+describe("openclaw-config (integration)", () => {
+  it("readOpenClawConfigRaw reads from HOME/.openclaw/openclaw.json", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-config-test-"));
+    process.env.HOME = home;
+
+    const dir = path.join(home, ".openclaw");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "openclaw.json"), JSON.stringify({ channels: { telegram: { botToken: "x" } } }, null, 2));
+
+    const res = await readOpenClawConfigRaw();
+    expect(res.path).toBe(path.join(dir, "openclaw.json"));
+    expect(res.hash).toMatch(/^[a-f0-9]{64}$/);
+
+    const json = res.json as unknown as { channels: { telegram: { botToken: string } } };
+    expect(json.channels.telegram.botToken).toBe("x");
+  });
+
+  it("redactChannels redacts secrets", () => {
+    const out = redactChannels({ telegram: { botToken: "secret", nested: { token: "abc" } } }) as unknown as {
+      telegram: { botToken: string; nested: { token: string } };
+    };
+
+    expect(out.telegram.botToken).toBe("__OPENCLAW_REDACTED__");
+    expect(out.telegram.nested.token).toBe("__OPENCLAW_REDACTED__");
+  });
+
+  it("patchOpenClawConfigFile updates channels and writes breadcrumb", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-config-test-"));
+    process.env.HOME = home;
+
+    const dir = path.join(home, ".openclaw");
+    await fs.mkdir(dir, { recursive: true });
+    const cfgPath = path.join(dir, "openclaw.json");
+    await fs.writeFile(cfgPath, JSON.stringify({ channels: { slack: { x: 1 } } }, null, 2) + "\n", "utf8");
+
+    const r = await patchOpenClawConfigFile({
+      note: "test-note",
+      patch: (prev) => {
+        const prevChannels = prev.channels && typeof prev.channels === "object" ? (prev.channels as Record<string, unknown>) : {};
+        return { ...prev, channels: { ...prevChannels, telegram: { enabled: true } } };
+      },
+    });
+
+    expect(r.ok).toBe(true);
+
+    const after = JSON.parse(await fs.readFile(cfgPath, "utf8")) as { channels: Record<string, unknown> };
+    expect(after.channels.slack).toEqual({ x: 1 });
+    expect(after.channels.telegram).toEqual({ enabled: true });
+
+    const breadcrumb = await fs.readFile(path.join(dir, "notes", "kitchen-config.log"), "utf8");
+    expect(breadcrumb).toContain("test-note");
+  });
+});

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -1,0 +1,83 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export type OpenClawConfigFile = {
+  gateway?: unknown;
+  channels?: unknown;
+  bindings?: unknown;
+  // allow extra keys
+  [k: string]: unknown;
+};
+
+function configPath() {
+  return path.join(os.homedir(), ".openclaw", "openclaw.json");
+}
+
+export async function readOpenClawConfigRaw(): Promise<{ path: string; raw: string; hash: string; json: OpenClawConfigFile }> {
+  const p = configPath();
+  const raw = await fs.readFile(p, "utf8");
+  const hash = crypto.createHash("sha256").update(raw).digest("hex");
+  const json = JSON.parse(raw) as OpenClawConfigFile;
+  return { path: p, raw, hash, json };
+}
+
+export function redactChannels(channels: unknown) {
+  if (!channels || typeof channels !== "object") return {};
+  const root = channels as Record<string, unknown>;
+
+  function redactObj(v: unknown): unknown {
+    if (!v || typeof v !== "object") return v;
+    if (Array.isArray(v)) return v.map(redactObj);
+
+    const o = v as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(o)) {
+      if (k === "botToken" || k === "token" || k === "authToken" || k.toLowerCase().includes("secret")) {
+        if (typeof val === "string" && val) out[k] = "__OPENCLAW_REDACTED__";
+        else out[k] = val;
+        continue;
+      }
+      out[k] = redactObj(val);
+    }
+    return out;
+  }
+
+  return redactObj(root);
+}
+
+export async function patchOpenClawConfigFile({
+  patch,
+  note,
+}: {
+  patch: (prev: OpenClawConfigFile) => OpenClawConfigFile;
+  note?: string;
+}): Promise<{ ok: true; path: string; hash: string }> {
+  const p = configPath();
+  const prevRaw = await fs.readFile(p, "utf8");
+  const prev = JSON.parse(prevRaw) as OpenClawConfigFile;
+
+  const next = patch(prev);
+  const nextRaw = JSON.stringify(next, null, 2) + "\n";
+
+  // Atomic-ish write: write temp then rename.
+  const dir = path.dirname(p);
+  const tmp = path.join(dir, `openclaw.json.tmp.${process.pid}.${Date.now()}`);
+  await fs.writeFile(tmp, nextRaw, "utf8");
+  await fs.rename(tmp, p);
+
+  // Best-effort breadcrumb.
+  if (note) {
+    try {
+      const notesDir = path.join(dir, "notes");
+      await fs.mkdir(notesDir, { recursive: true });
+      await fs.appendFile(path.join(notesDir, "kitchen-config.log"), `[${new Date().toISOString()}] ${note}\n`, "utf8");
+    } catch {
+      // ignore
+    }
+  }
+
+  const hash = crypto.createHash("sha256").update(nextRaw).digest("hex");
+  return { ok: true, path: p, hash };
+}

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -1,7 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
+import * as path from "node:path";
 
 export type OpenClawConfigFile = {
   gateway?: unknown;
@@ -12,7 +11,9 @@ export type OpenClawConfigFile = {
 };
 
 function configPath() {
-  return path.join(os.homedir(), ".openclaw", "openclaw.json");
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  if (!home) throw new Error("Could not resolve home directory (set HOME)");
+  return path.join(home, ".openclaw", "openclaw.json");
 }
 
 export async function readOpenClawConfigRaw(): Promise<{ path: string; raw: string; hash: string; json: OpenClawConfigFile }> {


### PR DESCRIPTION
Removes dependency on the Gateway tool for the Channels/Bindings API.

Problem:
- Kitchen /api/channels/bindings used toolsInvoke(tool="gateway", action=config.get/patch)
- This requires enabling gateway.tools.allow=["gateway"], which is security-sensitive.

Solution:
- Read ~/.openclaw/openclaw.json directly (Kitchen runs on same host)
- Redact secrets in the GET response
- Patch only the channels subtree on PUT/DELETE via an atomic write helper

Files:
- src/lib/openclaw-config.ts (read raw + sha256 hash + redaction + patch writer)
- src/app/api/channels/bindings/route.ts (now uses openclaw-config helpers)

Follow-up:
- After merge, gateway.tools.allow can be removed again.