### PR TITLE
Hide Team Editor Memory + Workflows tabs

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "kitchen",
   "name": "ClawKitchen",
   "description": "Local UI for managing OpenClaw recipes, teams, agents, cron jobs, and skills.",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jiggai/kitchen",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "private": false,
   "openclaw": {
     "extensions": [

--- a/src/app/api/teams/workflow-runs/route.test.ts
+++ b/src/app/api/teams/workflow-runs/route.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment node
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let TEAM_DIR = "";
+
+vi.mock("@/lib/paths", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/paths")>("@/lib/paths");
+  return {
+    ...actual,
+    getTeamWorkspaceDir: async () => TEAM_DIR,
+    readOpenClawConfig: async () => ({ bindings: [] }),
+  };
+});
+
+const toolsInvokeMock = vi.fn(async ({ tool }: { tool: string }) => {
+  if (tool === "exec") {
+    return { ok: true, stdout: "hi\n", stderr: "", exitCode: 0 };
+  }
+  return { ok: true };
+});
+
+vi.mock("@/lib/gateway", () => ({
+  toolsInvoke: toolsInvokeMock,
+}));
+
+describe("/api/teams/workflow-runs POST (execute)", () => {
+  beforeEach(async () => {
+    toolsInvokeMock.mockClear();
+    TEAM_DIR = await fs.mkdtemp(path.join(os.tmpdir(), "clawkitchen-team-"));
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    if (TEAM_DIR) {
+      await fs.rm(TEAM_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it("executes fs.append tool node and persists run file", async () => {
+    const teamId = "development-team";
+    const workflowId = "wf-append";
+
+    const { writeWorkflow } = await import("@/lib/workflows/storage");
+    await writeWorkflow(teamId, {
+      schema: "clawkitchen.workflow.v1",
+      id: workflowId,
+      name: "Append test",
+      nodes: [
+        {
+          id: "n1",
+          type: "tool",
+          config: {
+            tool: "fs.append",
+            args: { path: "notes/log.txt", content: "hello" },
+          },
+        },
+      ],
+    });
+
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      new Request("http://localhost/api/teams/workflow-runs", {
+        method: "POST",
+        body: JSON.stringify({ teamId, workflowId, mode: "execute" }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; path: string; runId: string };
+    expect(json.ok).toBe(true);
+    expect(json.runId).toMatch(/^run-/);
+
+    const runRaw = await fs.readFile(json.path, "utf8");
+    const run = JSON.parse(runRaw) as import("@/lib/workflows/runs-types").WorkflowRunFileV1;
+
+    expect(run.status).toBe("success");
+    expect(run.nodes).toHaveLength(1);
+    expect(run.nodes[0].status).toBe("success");
+    expect(run.nodes[0].output.tool).toBe("fs.append");
+    expect(String(run.nodes[0].output.appendedTo)).toContain(path.join(TEAM_DIR, "notes", "log.txt"));
+
+    const appended = await fs.readFile(path.join(TEAM_DIR, "notes", "log.txt"), "utf8");
+    expect(appended).toBe("hello");
+  });
+
+  it("denies runtime.exec when bin is not allowlisted", async () => {
+    const teamId = "development-team";
+    const workflowId = "wf-exec-deny";
+
+    const { writeWorkflow } = await import("@/lib/workflows/storage");
+    await writeWorkflow(teamId, {
+      schema: "clawkitchen.workflow.v1",
+      id: workflowId,
+      name: "Exec deny test",
+      nodes: [
+        {
+          id: "n1",
+          type: "tool",
+          config: {
+            tool: "runtime.exec",
+            args: { command: "echo hi" },
+          },
+        },
+      ],
+    });
+
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      new Request("http://localhost/api/teams/workflow-runs", {
+        method: "POST",
+        body: JSON.stringify({ teamId, workflowId, mode: "execute" }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; path: string; runId: string };
+
+    const runRaw = await fs.readFile(json.path, "utf8");
+    const run = JSON.parse(runRaw) as import("@/lib/workflows/runs-types").WorkflowRunFileV1;
+
+    expect(run.status).toBe("error");
+    expect(run.nodes[0].status).toBe("error");
+    expect(String(run.nodes[0].output.error)).toContain("not allowlisted");
+    expect(toolsInvokeMock).not.toHaveBeenCalled();
+  });
+
+  it("allows runtime.exec when bin is allowlisted in workflow meta", async () => {
+    const teamId = "development-team";
+    const workflowId = "wf-exec-allow";
+
+    const { writeWorkflow } = await import("@/lib/workflows/storage");
+    await writeWorkflow(teamId, {
+      schema: "clawkitchen.workflow.v1",
+      id: workflowId,
+      name: "Exec allow test",
+      meta: { execAllowBins: ["echo"] },
+      nodes: [
+        {
+          id: "n1",
+          type: "tool",
+          config: {
+            tool: "runtime.exec",
+            args: { command: "echo hi" },
+          },
+        },
+      ],
+    });
+
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      new Request("http://localhost/api/teams/workflow-runs", {
+        method: "POST",
+        body: JSON.stringify({ teamId, workflowId, mode: "execute" }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; path: string; runId: string };
+
+    const runRaw = await fs.readFile(json.path, "utf8");
+    const run = JSON.parse(runRaw) as import("@/lib/workflows/runs-types").WorkflowRunFileV1;
+
+    expect(run.status).toBe("success");
+    expect(run.nodes[0].status).toBe("success");
+    expect(run.nodes[0].output.tool).toBe("runtime.exec");
+
+    expect(toolsInvokeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/teams/[teamId]/team-editor/index.tsx
+++ b/src/app/teams/[teamId]/team-editor/index.tsx
@@ -19,9 +19,7 @@ import { TeamAgentsTab } from "./TeamAgentsTab";
 import { TeamSkillsTab } from "./TeamSkillsTab";
 import { TeamCronTab } from "./TeamCronTab";
 import { TeamFilesTab } from "./TeamFilesTab";
-import { TeamMemoryTab } from "./TeamMemoryTab";
 import { OrchestratorPanel } from "../OrchestratorPanel";
-import WorkflowsClient from "../workflows/workflows-client";
 
 const TABS = [
   { id: "recipe" as const, label: "Recipe" },
@@ -29,9 +27,9 @@ const TABS = [
   { id: "skills" as const, label: "Skills" },
   { id: "cron" as const, label: "Cron" },
   { id: "files" as const, label: "Files" },
-  { id: "memory" as const, label: "Memory" },
+  // NOTE: Memory tab hidden for public release (not ready).
   { id: "orchestrator" as const, label: "Orchestrator" },
-  { id: "workflows" as const, label: "Workflows" },
+  // NOTE: Workflows tab hidden for public release (not ready).
 ];
 
 type TabId = (typeof TABS)[number]["id"];
@@ -48,7 +46,7 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
   const [content, setContent] = useState<string>("");
   const [loadedRecipeHash, setLoadedRecipeHash] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>(() => {
-    const valid: TabId[] = ["recipe", "agents", "skills", "cron", "files", "memory", "orchestrator", "workflows"];
+    const valid: TabId[] = ["recipe", "agents", "skills", "cron", "files", "orchestrator"];
     return valid.includes(initialTab as TabId) ? (initialTab as TabId) : "recipe";
   });
   const [loading, setLoading] = useState(true);
@@ -138,7 +136,7 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
     setTeamMetaRecipeHash(null);
     setPublishOpen(false);
     setDeleteOpen(false);
-    const valid: TabId[] = ["recipe", "agents", "skills", "cron", "files", "memory", "orchestrator", "workflows"];
+    const valid: TabId[] = ["recipe", "agents", "skills", "cron", "files", "orchestrator"];
     if (initialTab && valid.includes(initialTab as TabId)) {
       setActiveTab(initialTab as TabId);
     }
@@ -459,19 +457,9 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
         />
       )}
 
-      {activeTab === "workflows" && (
-        <div className="mt-6">
-          <WorkflowsClient teamId={teamId} />
-        </div>
-      )}
 
       {activeTab === "orchestrator" && <OrchestratorPanel teamId={teamId} />}
 
-      {activeTab === "memory" && (
-        <div className="mt-6">
-          <TeamMemoryTab teamId={teamId} />
-        </div>
-      )}
 
       {activeTab === "files" && (
         <TeamFilesTab


### PR DESCRIPTION
Hides the Memory and Workflows tabs in the Team Editor so public users are not exposed to unfinished features yet.

Changes:
- Removed Memory + Workflows from Team Editor tab list.
- Removed the corresponding render blocks.
- Updated allowed initialTab list to exclude those tabs.

Note: routes/pages still exist; this is UI-only hiding (reversible).