### PR TITLE
Fix kitchen plugin config schema (showExperimentalTabs)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "kitchen",
   "name": "ClawKitchen",
   "description": "Local UI for managing OpenClaw recipes, teams, agents, cron jobs, and skills.",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -33,6 +33,21 @@
       "qaToken": {
         "type": "string",
         "default": ""
+      },
+      "authMode": {
+        "type": "string",
+        "enum": [
+          "on",
+          "local",
+          "off"
+        ],
+        "default": "on",
+        "description": "Auth protection mode (on|local|off)."
+      },
+      "showExperimentalTabs": {
+        "type": "boolean",
+        "default": false,
+        "description": "UI-only: show unfinished Team Editor tabs (Memory/Workflows)."
       }
     }
   },
@@ -58,6 +73,14 @@
     "qaToken": {
       "label": "QA token (optional)",
       "help": "QA/dev-only. If set, visiting any URL with ?qaToken=<token> sets a short-lived cookie so headless browsers can access the UI without a Basic auth prompt."
+    },
+    "authMode": {
+      "label": "Auth mode",
+      "help": "on: require Basic auth; local: allow localhost unauthenticated; off: disable auth (not recommended)."
+    },
+    "showExperimentalTabs": {
+      "label": "Show experimental tabs",
+      "help": "UI-only. Enables Memory + Workflows tabs in Team Editor. Intended for local/internal development."
     }
   },
   "main": "openclaw/index.ts"


### PR DESCRIPTION
openclaw.plugin.json configSchema was missing new config keys added in code.

Adds:
- configSchema.properties.authMode
- configSchema.properties.showExperimentalTabs
- uiHints for both

Also bumps plugin version to 0.3.8 so installs/updates clearly pick up the schema change.