### PR TITLE
Kitchen: banner + docs when bindings endpoint fails with 'Tool not available: gateway'

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ openclaw kitchen open
 Then open:
 - http://127.0.0.1:7777
 
+### Troubleshooting: “Tool not available: gateway” on Channels/Bindings
+
+If you see errors like `Tool not available: gateway` while loading **Channels** or workflow approval bindings,
+you are almost certainly running an **older Kitchen plugin build** that still tried to fetch bindings
+via the Gateway tool.
+
+Fix:
+
+```bash
+openclaw plugins update
+openclaw gateway restart
+```
+
+Notes:
+- A gateway restart is required after plugin updates and many config changes.
+- As a *last resort* you can enable the `gateway` tool via `gateway.tools.allow`, but that weakens hardening
+  and should not be required for normal Kitchen usage.
+
+
 ---
 
 ## Tailscale / remote access (recommended)

--- a/src/app/channels/channels-client.tsx
+++ b/src/app/channels/channels-client.tsx
@@ -46,6 +46,11 @@ export default function ChannelsClient() {
   const [configJson, setConfigJson] = useState<string>("{\n  \"enabled\": true\n}\n");
   const [saving, setSaving] = useState(false);
 
+  const isGatewayToolNotAvailable = useMemo(() => {
+    const msg = String(error ?? "");
+    return /Tool not available:\s*gateway/i.test(msg);
+  }, [error]);
+
   async function fetchBindings(): Promise<{ ok: true; channels: Record<string, unknown> } | { ok: false; error: string }> {
     try {
       const data = await fetchJson<ChannelsResponse>("/api/channels/bindings", { cache: "no-store" });
@@ -180,7 +185,8 @@ export default function ChannelsClient() {
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Channels</h1>
           <p className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">
-            Source of truth: OpenClaw gateway config (patched via <code className="font-mono">gateway config.patch</code>).
+            Source of truth: <code className="font-mono">~/.openclaw/openclaw.json</code>.
+            This page intentionally avoids calling the Gateway tool.
             Some changes may require a gateway restart depending on provider.
           </p>
         </div>
@@ -193,6 +199,23 @@ export default function ChannelsClient() {
           </Button>
         </div>
       </div>
+
+      {isGatewayToolNotAvailable ? (
+        <div className="ck-glass p-4 text-sm">
+          <div className="font-medium text-yellow-200">Kitchen looks out of date</div>
+          <div className="mt-1 text-[color:var(--ck-text-secondary)]">
+            This endpoint used to go through the Gateway tool and would fail on hardened systems. Update the Kitchen plugin
+            and restart the gateway to pick up the fix.
+          </div>
+          <pre className="mt-3 overflow-x-auto rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-black/20 p-3 text-xs">
+openclaw plugins update
+openclaw gateway restart
+          </pre>
+          <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
+            Last resort (not recommended): temporarily allow the <code className="font-mono">gateway</code> tool.
+          </div>
+        </div>
+      ) : null}
 
       {error ? <div className="ck-glass p-4 text-sm text-red-300">{error}</div> : null}
 

--- a/src/app/teams/[teamId]/team-editor/index.tsx
+++ b/src/app/teams/[teamId]/team-editor/index.tsx
@@ -23,24 +23,22 @@ import { TeamMemoryTab } from "./TeamMemoryTab";
 import { OrchestratorPanel } from "../OrchestratorPanel";
 import WorkflowsClient from "../workflows/workflows-client";
 
-function buildTabs(showExperimentalTabs: boolean) {
-  return [
-    { id: "recipe" as const, label: "Recipe" },
-    { id: "agents" as const, label: "Agents" },
-    { id: "skills" as const, label: "Skills" },
-    { id: "cron" as const, label: "Cron" },
-    { id: "files" as const, label: "Files" },
-    { id: "orchestrator" as const, label: "Orchestrator" },
-    ...(showExperimentalTabs
-      ? ([
-          { id: "memory" as const, label: "Memory" },
-          { id: "workflows" as const, label: "Workflows" },
-        ] as const)
-      : []),
-  ];
-}
+const BASE_TABS = [
+  { id: "recipe" as const, label: "Recipe" },
+  { id: "agents" as const, label: "Agents" },
+  { id: "skills" as const, label: "Skills" },
+  { id: "cron" as const, label: "Cron" },
+  { id: "files" as const, label: "Files" },
+  { id: "orchestrator" as const, label: "Orchestrator" },
+] as const;
 
-type TabId = ReturnType<typeof buildTabs>[number]["id"];
+const EXPERIMENTAL_TABS = [
+  { id: "memory" as const, label: "Memory" },
+  { id: "workflows" as const, label: "Workflows" },
+] as const;
+
+
+type TabId = (typeof BASE_TABS | typeof EXPERIMENTAL_TABS)[number]["id"];
 
 export default function TeamEditor({ teamId, initialTab }: { teamId: string; initialTab?: string }) {
   const router = useRouter();
@@ -60,7 +58,7 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
     return valid.includes(initialTab as TabId) ? (initialTab as TabId) : "recipe";
   });
   const [showExperimentalTabs, setShowExperimentalTabs] = useState(false);
-  const tabs = useMemo(() => buildTabs(showExperimentalTabs), [showExperimentalTabs]);
+  const tabs = useMemo(() => (showExperimentalTabs ? [...BASE_TABS, ...EXPERIMENTAL_TABS] : [...BASE_TABS]), [showExperimentalTabs]);
 
 
   useEffect(() => {

--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -48,6 +48,10 @@ export default function WorkflowsEditorClient({
   const [approvalBindings, setApprovalBindings] = useState<Array<{ id: string; label: string; channel: string; target: string }>>([]);
   const [approvalBindingsError, setApprovalBindingsError] = useState<string>("");
 
+  const approvalBindingsNeedsKitchenUpdate = useMemo(() => {
+    return /Tool not available:\s*gateway/i.test(String(approvalBindingsError || ""));
+  }, [approvalBindingsError]);
+
   // Inspector state (parity with modal)
   const [workflowRuns, setWorkflowRuns] = useState<string[]>([]);
   const [workflowRunsLoading, setWorkflowRunsLoading] = useState(false);
@@ -1099,6 +1103,12 @@ export default function WorkflowsEditorClient({
                             </option>
                           ))}
                         </select>
+                        {approvalBindingsNeedsKitchenUpdate ? (
+                          <div className="mt-1 text-[10px] text-yellow-200">
+                            Kitchen looks out of date. Run <code className="font-mono">openclaw plugins update</code> then
+                            <code className="ml-1 font-mono">openclaw gateway restart</code>.
+                          </div>
+                        ) : null}
                         {approvalBindingsError ? (
                           <div className="mt-1 text-[10px] text-red-200">Failed to load bindings: {approvalBindingsError}</div>
                         ) : null}


### PR DESCRIPTION
Fixes/helps with dev ticket 0127.

What:
- Detects the legacy error message (Tool not available: gateway) when loading channel bindings.
- Shows a clear UI hint (and docs) telling the user to update the Kitchen plugin + restart the gateway.

Why:
- Some deployments still have an older Kitchen build installed after PR #142; this makes the failure mode self-diagnosing.

Verification:
- npm run lint (warnings only)
- npm run build