### PR TITLE
Fix: prevent accidental Telegram provider deletion in Channels UI

### DIFF
--- a/src/app/api/__tests__/channels-bindings-route.test.ts
+++ b/src/app/api/__tests__/channels-bindings-route.test.ts
@@ -121,7 +121,7 @@ describe("api channels bindings route", () => {
       const res = await DELETE(
         new Request("https://test", {
           method: "DELETE",
-          body: JSON.stringify({ provider: "telegram" }),
+          body: JSON.stringify({ provider: "telegram", confirm: "telegram" }),
         })
       );
       expect(res.status).toBe(200);
@@ -140,7 +140,7 @@ describe("api channels bindings route", () => {
       const res = await DELETE(
         new Request("https://test", {
           method: "DELETE",
-          body: JSON.stringify({ provider: "telegram" }),
+          body: JSON.stringify({ provider: "telegram", confirm: "telegram" }),
         })
       );
       expect(res.status).toBe(500);

--- a/src/app/api/channels/bindings/route.ts
+++ b/src/app/api/channels/bindings/route.ts
@@ -31,7 +31,6 @@ export async function PUT(req: Request) {
     const provider = String(body?.provider ?? "").trim();
     if (!provider) return NextResponse.json({ ok: false, error: "provider is required" }, { status: 400 });
 
-
     const cfg = isRecord(body?.config) ? body.config : null;
     if (!cfg) return NextResponse.json({ ok: false, error: "config must be an object" }, { status: 400 });
 
@@ -66,6 +65,13 @@ export async function DELETE(req: Request) {
     const provider = String(body?.provider ?? "").trim();
     if (!provider) return NextResponse.json({ ok: false, error: "provider is required" }, { status: 400 });
 
+    const confirm = String(body?.confirm ?? "").trim();
+    if (confirm != provider) {
+      return NextResponse.json(
+        { ok: false, error: `Typed confirmation required. Set confirm="${provider}" to delete.` },
+        { status: 400 }
+      );
+    }
 
     await patchOpenClawConfigFile({
       note: `ClawKitchen Channels delete: ${provider}`,

--- a/src/app/api/channels/bindings/route.ts
+++ b/src/app/api/channels/bindings/route.ts
@@ -31,6 +31,7 @@ export async function PUT(req: Request) {
     const provider = String(body?.provider ?? "").trim();
     if (!provider) return NextResponse.json({ ok: false, error: "provider is required" }, { status: 400 });
 
+
     const cfg = isRecord(body?.config) ? body.config : null;
     if (!cfg) return NextResponse.json({ ok: false, error: "config must be an object" }, { status: 400 });
 
@@ -57,13 +58,14 @@ export async function PUT(req: Request) {
   }
 }
 
-type DeleteBody = { provider: string };
+type DeleteBody = { provider: string; confirm?: string };
 
 export async function DELETE(req: Request) {
   try {
     const body = (await req.json()) as DeleteBody;
     const provider = String(body?.provider ?? "").trim();
     if (!provider) return NextResponse.json({ ok: false, error: "provider is required" }, { status: 400 });
+
 
     await patchOpenClawConfigFile({
       note: `ClawKitchen Channels delete: ${provider}`,

--- a/src/app/channels/channels-client.tsx
+++ b/src/app/channels/channels-client.tsx
@@ -46,6 +46,9 @@ export default function ChannelsClient() {
   const [configJson, setConfigJson] = useState<string>("{\n  \"enabled\": true\n}\n");
   const [saving, setSaving] = useState(false);
 
+  const [deleteProvider, setDeleteProvider] = useState<string | null>(null);
+  const [deleteTyped, setDeleteTyped] = useState<string>("");
+
   const isGatewayToolNotAvailable = useMemo(() => {
     const msg = String(error ?? "");
     return /Tool not available:\s*gateway/i.test(msg);
@@ -150,17 +153,22 @@ export default function ChannelsClient() {
     setSaving(false);
   }
 
+
   async function remove(p: string) {
     const expected = String(p ?? "").trim();
     if (!expected) return;
 
-    const typed = window.prompt(
-      `This will DELETE the channel binding "${expected}" from ~/.openclaw/openclaw.json.
+    // Avoid browser-native dialogs (prompt/confirm) since they can be blocked or unreliable
+    // in some environments (e.g., embedded webviews). Use an in-app typed-confirm modal instead.
+    setDeleteProvider(expected);
+    setDeleteTyped("");
+  }
 
-Type the provider id (exactly) to confirm:`,
-      expected
-    );
-    const confirm = String(typed ?? "").trim();
+  async function confirmDelete() {
+    const expected = String(deleteProvider ?? "").trim();
+    if (!expected) return;
+
+    const confirm = String(deleteTyped ?? "").trim();
     if (confirm !== expected) return;
 
     setSaving(true);
@@ -172,8 +180,16 @@ Type the provider id (exactly) to confirm:`,
       setSaving(false);
       return;
     }
+
+    setDeleteProvider(null);
+    setDeleteTyped("");
     await refresh();
     setSaving(false);
+  }
+
+  function cancelDelete() {
+    setDeleteProvider(null);
+    setDeleteTyped("");
   }
 
   function addBinding() {
@@ -191,6 +207,36 @@ Type the provider id (exactly) to confirm:`,
 
   return (
     <div className="space-y-6">
+      {deleteProvider ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <div className="ck-glass w-full max-w-lg border border-[color:var(--ck-border-subtle)] p-4">
+            <div className="text-sm font-medium text-red-200">Confirm destructive delete</div>
+            <div className="mt-2 text-sm text-[color:var(--ck-text-secondary)]">
+              This will <span className="font-medium text-red-200">DELETE</span> the channel binding
+              <span className="mx-1 font-mono">{deleteProvider}</span>
+              from <span className="font-mono">~/.openclaw/openclaw.json</span>.
+            </div>
+            <div className="mt-3 text-xs text-[color:var(--ck-text-tertiary)]">
+              Type <code className="font-mono">{deleteProvider}</code> to confirm.
+            </div>
+            <input
+              value={deleteTyped}
+              onChange={(e) => setDeleteTyped(e.target.value)}
+              className="mt-2 w-full rounded-[var(--ck-radius-sm)] border border-[color:var(--ck-border-subtle)] bg-transparent px-3 py-2 font-mono text-sm"
+              placeholder={deleteProvider}
+              autoFocus
+            />
+            <div className="mt-4 flex items-center justify-end gap-2">
+              <Button onClick={cancelDelete} disabled={saving}>
+                Cancel
+              </Button>
+              <Button kind="danger" onClick={() => void confirmDelete()} disabled={saving || deleteTyped.trim() != deleteProvider}>
+                {saving ? "Deleting…" : "Delete"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Channels</h1>

--- a/src/app/channels/channels-client.tsx
+++ b/src/app/channels/channels-client.tsx
@@ -107,7 +107,7 @@ export default function ChannelsClient() {
 
   async function mutate(
     method: "PUT" | "DELETE",
-    body: { provider: string; config?: Record<string, unknown> }
+    body: { provider: string; config?: Record<string, unknown>; confirm?: string }
   ): Promise<{ ok: true } | { ok: false; error: string }> {
     try {
       const data = await fetchJson<ChannelsResponse>("/api/channels/bindings", {
@@ -151,12 +151,22 @@ export default function ChannelsClient() {
   }
 
   async function remove(p: string) {
-    if (!window.confirm(`Delete channel binding "${p}"?`)) return;
+    const expected = String(p ?? "").trim();
+    if (!expected) return;
+
+    const typed = window.prompt(
+      `This will DELETE the channel binding "${expected}" from ~/.openclaw/openclaw.json.
+
+Type the provider id (exactly) to confirm:`,
+      expected
+    );
+    const confirm = String(typed ?? "").trim();
+    if (confirm !== expected) return;
 
     setSaving(true);
     setError(null);
 
-    const result = await mutate("DELETE", { provider: p });
+    const result = await mutate("DELETE", { provider: expected, confirm });
     if (!result.ok) {
       setError(result.error);
       setSaving(false);


### PR DESCRIPTION
Implements guardrails to prevent accidental deletion of channel provider configs (e.g. telegram).

Changes:
- UI: replace one-click window.confirm with typed confirmation requiring provider id.
- API: DELETE /api/channels/bindings now requires a `confirm` field matching provider.

Refs: dev ticket #0129.

QA:
1) Go to /channels.
2) Attempt to delete provider config.
3) Verify typed confirm is required.
4) Verify API rejects DELETE without confirm or with mismatched confirm.