### PR TITLE
Fix Team Editor crash (Cannot access before initialization)

### DIFF
--- a/src/app/teams/[teamId]/team-editor/index.tsx
+++ b/src/app/teams/[teamId]/team-editor/index.tsx
@@ -51,13 +51,17 @@ export default function TeamEditor({ teamId, initialTab }: { teamId: string; ini
   const [toName, setToName] = useState<string>(teamId);
   const [content, setContent] = useState<string>("");
   const [loadedRecipeHash, setLoadedRecipeHash] = useState<string | null>(null);
+
+  // Must be declared BEFORE any hook initializers that reference it.
+  // (Avoids SSR/minifier TDZ issues like "Cannot access before initialization".)
+  const [showExperimentalTabs, setShowExperimentalTabs] = useState(false);
+
   const [activeTab, setActiveTab] = useState<TabId>(() => {
     const valid: TabId[] = showExperimentalTabs
       ? (["recipe", "agents", "skills", "cron", "files", "memory", "orchestrator", "workflows"] as TabId[])
       : (["recipe", "agents", "skills", "cron", "files", "orchestrator"] as TabId[]);
     return valid.includes(initialTab as TabId) ? (initialTab as TabId) : "recipe";
   });
-  const [showExperimentalTabs, setShowExperimentalTabs] = useState(false);
   const tabs = useMemo(() => (showExperimentalTabs ? [...BASE_TABS, ...EXPERIMENTAL_TABS] : [...BASE_TABS]), [showExperimentalTabs]);
 
 


### PR DESCRIPTION
Fixes a production crash in /teams/[teamId] Team Editor caused by a TDZ/minifier issue where activeTab useState initializer referenced showExperimentalTabs before it was initialized.

- Moves showExperimentalTabs state above activeTab initializer.
- Keeps existing runtime fetch of /api/settings/experimental-tabs.

This addresses errors like: "Cannot access before initialization" (var name differs in minified bundle).