### PR TITLE
Home: add Channels/Bindings link

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -123,6 +123,12 @@ export default function HomeClient({
             Tickets
           </Link>
           <Link
+            href="/channels"
+            className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
+          >
+            Channels / Bindings
+          </Link>
+          <Link
             href="/settings"
             className="text-sm font-medium text-[color:var(--ck-text-secondary)] transition-colors hover:text-[color:var(--ck-text-primary)]"
           >


### PR DESCRIPTION
Adds a top-level Home link to /channels (Channels / Bindings) so users can discover/manage bindings without hunting.

No functional changes to channels API.