### PR TITLE
feat(runs): reinstate standalone Runs pages

### DIFF
--- a/src/app/api/teams/workflow-runs/route.test.ts
+++ b/src/app/api/teams/workflow-runs/route.test.ts
@@ -31,6 +31,11 @@ describe("/api/teams/workflow-runs POST (execute)", () => {
   beforeEach(async () => {
     toolsInvokeMock.mockClear();
     TEAM_DIR = await fs.mkdtemp(path.join(os.tmpdir(), "clawkitchen-team-"));
+
+    // Enable runtime.exec for tests (dev-only feature).
+    process.env.KITCHEN_ENABLE_WORKFLOW_RUNTIME_EXEC = "1";
+    process.env.KITCHEN_WORKFLOW_EXEC_BACKEND = "local";
+
     vi.resetModules();
   });
 
@@ -171,6 +176,7 @@ describe("/api/teams/workflow-runs POST (execute)", () => {
     expect(run.nodes[0].status).toBe("success");
     expect(run.nodes[0].output.tool).toBe("runtime.exec");
 
-    expect(toolsInvokeMock).toHaveBeenCalledTimes(1);
+    // We run exec locally in tests for determinism.
+    expect(toolsInvokeMock).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/teams/workflow-runs/route.ts
+++ b/src/app/api/teams/workflow-runs/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { spawn } from "node:child_process";
 import { jsonOkRest, parseJsonBody } from "@/lib/api-route-helpers";
 import { handleWorkflowRunsGet } from "@/lib/workflows/api-handlers";
 import { errorMessage } from "@/lib/errors";
@@ -42,18 +43,73 @@ function asStringArray(v: unknown): string[] {
   return v.map((x) => String(x ?? "").trim()).filter(Boolean);
 }
 
-function parseExecCommandFromArgs(args: Record<string, unknown>): { command: string; bin: string } {
+function parseExecCommandFromArgs(
+  args: Record<string, unknown>
+): { command: string; bin: string; argv?: string[] } {
   const commandArray = Array.isArray(args.commandArray) ? args.commandArray : Array.isArray(args.command) ? args.command : null;
   if (commandArray && commandArray.length) {
     const parts = commandArray.map((x: unknown) => String(x ?? "").trim()).filter(Boolean);
     if (!parts.length) throw new Error("runtime.exec requires a non-empty command");
-    return { command: parts.join(" "), bin: path.basename(parts[0]) };
+    return { command: parts.join(" "), bin: path.basename(parts[0]), argv: parts };
   }
 
   const cmd = String(args.command ?? "").trim();
   if (!cmd) throw new Error("runtime.exec requires args.command");
-  const bin = path.basename(cmd.split(/\s+/)[0] || "");
+  const first = cmd.split(/\s+/)[0] || "";
+  const bin = path.basename(first);
   return { command: cmd, bin };
+}
+
+async function execLocal({
+  command,
+  argv,
+  cwd,
+  timeoutMs,
+}: {
+  command: string;
+  argv?: string[];
+  cwd?: string;
+  timeoutMs: number;
+}): Promise<{ stdout: string; stderr: string; exitCode: number | null; signal: string | null }> {
+  // Keep this intentionally simple + safe:
+  // - default to argv (no shell) when provided
+  // - if only a string is provided, split on whitespace (still no shell)
+  const parts = argv && argv.length ? argv : command.split(/\s+/).filter(Boolean);
+  const file = parts[0];
+  const fileArgs = parts.slice(1);
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(file, fileArgs, {
+      cwd,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    const maxBytes = 64 * 1024;
+    child.stdout?.on("data", (b: Buffer) => {
+      if (stdout.length < maxBytes) stdout += b.toString("utf8").slice(0, maxBytes - stdout.length);
+    });
+    child.stderr?.on("data", (b: Buffer) => {
+      if (stderr.length < maxBytes) stderr += b.toString("utf8").slice(0, maxBytes - stderr.length);
+    });
+
+    const t = setTimeout(() => {
+      child.kill("SIGKILL");
+    }, Math.max(0, timeoutMs));
+
+    child.on("error", (e) => {
+      clearTimeout(t);
+      reject(e);
+    });
+
+    child.on("close", (code, signal) => {
+      clearTimeout(t);
+      resolve({ stdout, stderr, exitCode: code, signal });
+    });
+  });
 }
 
 function resolveExecPolicy(workflow: WorkflowFileV1, nodeCfg: Record<string, unknown>) {
@@ -122,7 +178,7 @@ async function executeToolNode({
 
   if (tool === "runtime.exec") {
     const pol = resolveExecPolicy(workflow, cfg);
-    const { command, bin } = parseExecCommandFromArgs(args);
+    const { command, bin, argv } = parseExecCommandFromArgs(args);
 
     if (pol.allowCommands.size && !pol.allowCommands.has(command)) {
       throw new Error(`runtime.exec command not allowlisted: ${command}`);
@@ -142,17 +198,38 @@ async function executeToolNode({
       workdir = resolved;
     }
 
-    const result = await toolsInvoke({
-      tool: "exec",
-      args: {
-        command,
-        workdir,
-        timeout: pol.timeout,
-        host: pol.host,
-        security: pol.security,
-        ask: pol.ask,
-      },
-    });
+    const execEnabled = process.env.KITCHEN_ENABLE_WORKFLOW_RUNTIME_EXEC === "1";
+    if (!execEnabled) {
+      throw new Error("Tool not available: exec");
+    }
+
+    const backend = (process.env.KITCHEN_WORKFLOW_EXEC_BACKEND || "gateway-first").trim();
+
+    let result: unknown;
+    if (backend === "local") {
+      result = await execLocal({ command, argv, cwd: workdir, timeoutMs: pol.timeout * 1000 });
+    } else {
+      try {
+        result = await toolsInvoke({
+          tool: "exec",
+          args: {
+            command,
+            workdir,
+            timeout: pol.timeout,
+            host: pol.host,
+            security: pol.security,
+            ask: pol.ask,
+          },
+        });
+      } catch (e: unknown) {
+        // For dev/testing, fall back to local execution if the gateway doesn't expose exec.
+        if (backend === "gateway-first" && /Tool not available:\s*exec/i.test(errorMessage(e))) {
+          result = await execLocal({ command, argv, cwd: workdir, timeoutMs: pol.timeout * 1000 });
+        } else {
+          throw e;
+        }
+      }
+    }
 
     return {
       nodeId,

--- a/src/app/teams/[teamId]/runs/[workflowId]/[runId]/page.tsx
+++ b/src/app/teams/[teamId]/runs/[workflowId]/[runId]/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { unstable_noStore as noStore } from "next/cache";
+
+import { getTeamDisplayName } from "@/lib/recipes";
+import { readWorkflowRun } from "@/lib/workflows/runs-storage";
+import { readWorkflow } from "@/lib/workflows/storage";
+import RunDetailClient from "./run-detail-client";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function TeamRunDetailPage({
+  params,
+}: {
+  params: Promise<{ teamId: string; workflowId: string; runId: string }>;
+}) {
+  noStore();
+
+  const { teamId, workflowId, runId } = await params;
+  const name = await getTeamDisplayName(teamId);
+
+  const [{ run }, workflowRes] = await Promise.all([
+    readWorkflowRun(teamId, workflowId, runId),
+    readWorkflow(teamId, workflowId).catch(() => null),
+  ]);
+
+  const wfName = workflowRes?.workflow?.name;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <div className="text-xs text-[color:var(--ck-text-tertiary)]">
+            <Link href={`/teams/${encodeURIComponent(teamId)}/runs`} className="hover:underline">
+              Runs
+            </Link>
+            <span className="mx-2">/</span>
+            <span className="font-mono">{workflowId}</span>
+          </div>
+          <h1 className="mt-1 text-2xl font-semibold tracking-tight">
+            {wfName ? `${wfName} · ` : ""}
+            <span className="font-mono">{runId}</span>
+          </h1>
+          <div className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">
+            {name || teamId} · <span className="font-mono">{teamId}</span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Link
+            href={`/teams/${encodeURIComponent(teamId)}/workflows/${encodeURIComponent(workflowId)}`}
+            className="text-sm font-medium text-[color:var(--ck-text-secondary)] hover:underline"
+          >
+            Workflow editor →
+          </Link>
+        </div>
+      </div>
+
+      <RunDetailClient run={run} />
+    </div>
+  );
+}

--- a/src/app/teams/[teamId]/runs/[workflowId]/[runId]/run-detail-client.tsx
+++ b/src/app/teams/[teamId]/runs/[workflowId]/[runId]/run-detail-client.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { WorkflowRunFileV1, WorkflowRunNodeResultV1 } from "@/lib/workflows/runs-types";
+
+function asPrettyJson(v: unknown) {
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}
+
+function statusColor(status?: string) {
+  if (status === "success") return "border-emerald-400/30 bg-emerald-500/10 text-emerald-50";
+  if (status === "error") return "border-red-400/30 bg-red-500/10 text-red-50";
+  if (status === "running") return "border-sky-400/30 bg-sky-500/10 text-sky-50";
+  if (status === "waiting_for_approval") return "border-amber-400/30 bg-amber-500/10 text-amber-50";
+  return "border-white/10 bg-white/5 text-[color:var(--ck-text-secondary)]";
+}
+
+export default function RunDetailClient({ run }: { run: WorkflowRunFileV1 }) {
+  const nodes = Array.isArray(run.nodes) ? run.nodes : [];
+  const [selected, setSelected] = useState<string>(nodes[0]?.nodeId || "");
+
+  const selectedNode: WorkflowRunNodeResultV1 | undefined = useMemo(
+    () => nodes.find((n) => n.nodeId === selected) || nodes[0],
+    [nodes, selected]
+  );
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+      <div className="lg:col-span-1 rounded-[var(--ck-radius-lg)] border border-white/10 bg-black/10 p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">run status</div>
+            <div className={`mt-2 inline-flex items-center rounded-full border px-2 py-1 text-xs ${statusColor(run.status)}`}>
+              {run.status}
+            </div>
+            <div className="mt-2 text-xs text-[color:var(--ck-text-tertiary)]">
+              <div>
+                <span className="font-medium">started:</span> {run.startedAt}
+              </div>
+              {run.endedAt ? (
+                <div>
+                  <span className="font-medium">ended:</span> {run.endedAt}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4">
+          <div className="text-xs uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">timeline</div>
+          <div className="mt-2 space-y-1">
+            {nodes.length ? (
+              nodes.map((n) => {
+                const active = n.nodeId === selected;
+                return (
+                  <button
+                    key={n.nodeId}
+                    type="button"
+                    onClick={() => setSelected(n.nodeId)}
+                    className={
+                      active
+                        ? "w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/10 px-2 py-2 text-left"
+                        : "w-full rounded-[var(--ck-radius-sm)] px-2 py-2 text-left hover:bg-white/5"
+                    }
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="font-mono text-xs text-[color:var(--ck-text-primary)]">{n.nodeId}</div>
+                      <div className="text-[10px] text-[color:var(--ck-text-tertiary)]">{n.status}</div>
+                    </div>
+                    {(n.startedAt || n.endedAt) ? (
+                      <div className="mt-1 text-[10px] text-[color:var(--ck-text-tertiary)]">
+                        {n.startedAt ? `start: ${n.startedAt}` : ""}
+                        {n.startedAt && n.endedAt ? " · " : ""}
+                        {n.endedAt ? `end: ${n.endedAt}` : ""}
+                      </div>
+                    ) : null}
+                  </button>
+                );
+              })
+            ) : (
+              <div className="text-sm text-[color:var(--ck-text-secondary)]">No node results recorded yet.</div>
+            )}
+          </div>
+        </div>
+
+        {run.approval ? (
+          <div className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/10 p-3">
+            <div className="text-xs uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">approval</div>
+            <div className="mt-2 text-xs text-[color:var(--ck-text-secondary)]">
+              <div>
+                <span className="font-medium">node:</span> <span className="font-mono">{run.approval.nodeId}</span>
+              </div>
+              <div>
+                <span className="font-medium">state:</span> {run.approval.state}
+              </div>
+              {run.approval.note ? (
+                <div className="mt-2 rounded border border-white/10 bg-black/20 p-2 text-[11px]">{run.approval.note}</div>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="lg:col-span-2 rounded-[var(--ck-radius-lg)] border border-white/10 bg-black/10 p-4">
+        <div className="text-xs uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">node output / error</div>
+
+        {selectedNode ? (
+          <div className="mt-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="font-mono text-sm text-[color:var(--ck-text-primary)]">{selectedNode.nodeId}</div>
+              <div className={`rounded-full border px-2 py-1 text-xs ${statusColor(selectedNode.status)}`}>{selectedNode.status}</div>
+            </div>
+
+            {selectedNode.error ? (
+              <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-red-400/30 bg-red-500/10 p-3">
+                <div className="text-xs font-semibold text-red-50">Error</div>
+                <pre className="mt-2 overflow-auto text-xs text-red-50">{asPrettyJson(selectedNode.error)}</pre>
+              </div>
+            ) : null}
+
+            <div className="mt-3 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/20 p-3">
+              <div className="text-xs font-semibold text-[color:var(--ck-text-secondary)]">Output</div>
+              <pre className="mt-2 max-h-[60vh] overflow-auto text-xs text-[color:var(--ck-text-primary)]">{asPrettyJson(selectedNode.output ?? null)}</pre>
+            </div>
+          </div>
+        ) : (
+          <div className="mt-3 text-sm text-[color:var(--ck-text-secondary)]">Select a node to view its output.</div>
+        )}
+
+        <details className="mt-4 rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/10 p-3">
+          <summary className="cursor-pointer text-sm font-medium text-[color:var(--ck-text-secondary)]">Raw run file</summary>
+          <pre className="mt-3 overflow-auto text-xs text-[color:var(--ck-text-primary)]">{asPrettyJson(run)}</pre>
+        </details>
+      </div>
+    </div>
+  );
+}

--- a/src/app/teams/[teamId]/runs/page.tsx
+++ b/src/app/teams/[teamId]/runs/page.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import { unstable_noStore as noStore } from "next/cache";
+
+import RunsClient from "./runs-client";
+import { getTeamDisplayName } from "@/lib/recipes";
+import { listAllWorkflowRuns } from "@/lib/workflows/runs-storage";
+import { readWorkflow } from "@/lib/workflows/storage";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function TeamRunsPage({
+  params,
+}: {
+  params: Promise<{ teamId: string }>;
+}) {
+  // Runs are live + file-backed; never serve cached HTML.
+  noStore();
+
+  const { teamId } = await params;
+  const name = await getTeamDisplayName(teamId);
+
+  const { runs } = await listAllWorkflowRuns(teamId);
+
+  const wfIds = Array.from(new Set(runs.map((r) => r.workflowId).filter(Boolean))).sort();
+  const workflows: Record<string, { id: string; name?: string }> = {};
+  await Promise.all(
+    wfIds.map(async (id) => {
+      try {
+        const { workflow } = await readWorkflow(teamId, id);
+        workflows[id] = { id: workflow.id, name: workflow.name };
+      } catch {
+        workflows[id] = { id };
+      }
+    })
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Runs</h1>
+          <div className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">
+            {name || teamId} · <span className="font-mono">{teamId}</span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Link
+            href={`/teams/${encodeURIComponent(teamId)}/workflows`}
+            className="text-sm font-medium text-[color:var(--ck-text-secondary)] hover:underline"
+          >
+            Workflows →
+          </Link>
+        </div>
+      </div>
+
+      <RunsClient teamId={teamId} initialRuns={runs} workflows={workflows} />
+    </div>
+  );
+}

--- a/src/app/teams/[teamId]/runs/runs-client.tsx
+++ b/src/app/teams/[teamId]/runs/runs-client.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import type { WorkflowRunSummary } from "@/lib/workflows/runs-storage";
+
+function fmt(ts?: string) {
+  if (!ts) return "";
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return ts;
+  }
+}
+
+export default function RunsClient({
+  teamId,
+  initialRuns,
+  workflows,
+}: {
+  teamId: string;
+  initialRuns: WorkflowRunSummary[];
+  workflows: Record<string, { id: string; name?: string }>;
+}) {
+  const router = useRouter();
+  const [workflowId, setWorkflowId] = useState<string>("");
+  const [status, setStatus] = useState<string>("");
+  const [q, setQ] = useState<string>("");
+
+  const filtered = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    return initialRuns.filter((r) => {
+      if (workflowId && r.workflowId !== workflowId) return false;
+      if (status && String(r.status ?? "") !== status) return false;
+      if (!needle) return true;
+      const wfName = workflows[r.workflowId]?.name ?? "";
+      return (
+        r.runId.toLowerCase().includes(needle) ||
+        r.workflowId.toLowerCase().includes(needle) ||
+        wfName.toLowerCase().includes(needle)
+      );
+    });
+  }, [initialRuns, q, status, workflowId, workflows]);
+
+  const workflowOptions = useMemo(() => {
+    const ids = Array.from(new Set(initialRuns.map((r) => r.workflowId).filter(Boolean))).sort();
+    return ids;
+  }, [initialRuns]);
+
+  return (
+    <div className="rounded-[var(--ck-radius-lg)] border border-white/10 bg-black/10 p-4">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="block">
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">workflow</div>
+            <select
+              value={workflowId}
+              onChange={(e) => setWorkflowId((e.target.value || "").trim())}
+              className="mt-1 w-64 max-w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-2 text-sm text-[color:var(--ck-text-primary)]"
+            >
+              <option value="">All workflows</option>
+              {workflowOptions.map((id) => (
+                <option key={id} value={id}>
+                  {workflows[id]?.name ? `${workflows[id]?.name} (${id})` : id}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block">
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">status</div>
+            <select
+              value={status}
+              onChange={(e) => setStatus((e.target.value || "").trim())}
+              className="mt-1 w-56 max-w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-2 text-sm text-[color:var(--ck-text-primary)]"
+            >
+              <option value="">All</option>
+              <option value="running">running</option>
+              <option value="waiting_for_approval">waiting_for_approval</option>
+              <option value="success">success</option>
+              <option value="error">error</option>
+              <option value="canceled">canceled</option>
+            </select>
+          </label>
+
+          <label className="block">
+            <div className="text-[10px] uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">search</div>
+            <input
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="run id / workflow / name"
+              className="mt-1 w-72 max-w-full rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/25 px-2 py-2 text-sm text-[color:var(--ck-text-primary)]"
+            />
+          </label>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => router.refresh()}
+            className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-4 overflow-x-auto">
+        <table className="min-w-full border-separate border-spacing-0">
+          <thead>
+            <tr className="text-left text-xs uppercase tracking-wide text-[color:var(--ck-text-tertiary)]">
+              <th className="border-b border-white/10 px-2 py-2">workflow</th>
+              <th className="border-b border-white/10 px-2 py-2">status</th>
+              <th className="border-b border-white/10 px-2 py-2">updated</th>
+              <th className="border-b border-white/10 px-2 py-2">run</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length ? (
+              filtered.map((r) => {
+                const wf = workflows[r.workflowId];
+                const wfLabel = wf?.name ? wf.name : r.workflowId;
+                return (
+                  <tr key={`${r.workflowId}:${r.runId}`} className="text-sm">
+                    <td className="border-b border-white/5 px-2 py-2">
+                      <div className="text-[color:var(--ck-text-primary)]">{wfLabel}</div>
+                      <div className="text-xs text-[color:var(--ck-text-tertiary)] font-mono">{r.workflowId}</div>
+                    </td>
+                    <td className="border-b border-white/5 px-2 py-2">
+                      <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1 text-xs text-[color:var(--ck-text-secondary)]">
+                        {r.status ?? "(unknown)"}
+                      </span>
+                    </td>
+                    <td className="border-b border-white/5 px-2 py-2 text-xs text-[color:var(--ck-text-secondary)]">
+                      {fmt(r.updatedAt || r.endedAt || r.startedAt)}
+                    </td>
+                    <td className="border-b border-white/5 px-2 py-2">
+                      <Link
+                        href={`/teams/${encodeURIComponent(teamId)}/runs/${encodeURIComponent(r.workflowId)}/${encodeURIComponent(r.runId)}`}
+                        className="font-mono text-sm text-[color:var(--ck-text-primary)] hover:underline"
+                      >
+                        {r.runId}
+                      </Link>
+                    </td>
+                  </tr>
+                );
+              })
+            ) : (
+              <tr>
+                <td colSpan={4} className="px-2 py-6 text-sm text-[color:var(--ck-text-secondary)]">
+                  No runs found.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-3 text-xs text-[color:var(--ck-text-tertiary)]">
+        Showing {filtered.length} of {initialRuns.length}.
+      </div>
+    </div>
+  );
+}

--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -473,14 +473,13 @@ export default function WorkflowsEditorClient({
               setActiveTool({ kind: "select" });
             }}
           >
-            <div style={{ width: 2200 * zoom, height: 1200 * zoom }}>
-              <div className="relative h-[1200px] w-[2200px]" style={{ transform: `scale(${zoom})`, transformOrigin: "0 0" }}>
-              {/* Tool palette / agent palette */}
+            <div className="relative" style={{ width: 2200 * zoom, height: 1200 * zoom }}>
+              {/* Tool palette / agent palette (not scaled) */}
               <div
                 className={
                   toolsCollapsed
-                    ? "sticky left-3 top-3 z-20 w-[44px] overflow-hidden rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/40 p-2 backdrop-blur"
-                    : "sticky left-3 top-3 z-20 w-[260px] rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/40 p-2 backdrop-blur"
+                    ? "absolute left-3 top-3 z-20 w-[44px] overflow-hidden rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/40 p-2 backdrop-blur"
+                    : "absolute left-3 top-3 z-20 w-[260px] rounded-[var(--ck-radius-sm)] border border-white/10 bg-black/40 p-2 backdrop-blur"
                 }
               >
                 <div className="flex items-center justify-between gap-2">
@@ -493,7 +492,7 @@ export default function WorkflowsEditorClient({
                         className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-2 py-1 text-[10px] text-[color:var(--ck-text-secondary)] hover:bg-white/10"
                         title="Zoom out (Ctrl/Cmd+wheel)"
                       >
-                        −
+                        -
                       </button>
                       <div className="min-w-[42px] text-center text-[10px] text-[color:var(--ck-text-tertiary)]">{Math.round(zoom * 100)}%</div>
                       <button
@@ -769,6 +768,7 @@ export default function WorkflowsEditorClient({
                 </div>
               </div>
 
+              <div className="relative h-[1200px] w-[2200px]" style={{ transform: `scale(${zoom})`, transformOrigin: "0 0" }}>
               <svg
                 className="pointer-events-none absolute inset-0 -z-10"
                 width={2200}
@@ -1101,7 +1101,7 @@ export default function WorkflowsEditorClient({
               const approvalTarget = String(meta.approvalTarget ?? "").trim();
 
               // Cron schedule suggestions.
-              // Note: dev-team automation defaults should avoid the 02:00–07:00 America/New_York blackout window.
+              // Note: dev-team automation defaults should avoid the 02:00-07:00 America/New_York blackout window.
               // We keep presets in "safe" hours by default.
               const presets = [
                 { label: "(no preset)", expr: "" },

--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import type { WorkflowFileV1 } from "@/lib/workflows/types";
 import { validateWorkflowFileV1 } from "@/lib/workflows/validate";
 
@@ -1375,7 +1376,15 @@ export default function WorkflowsEditorClient({
                     <summary className="cursor-pointer list-none px-3 py-2 text-sm font-medium text-[color:var(--ck-text-primary)]">Runs</summary>
                     <div className="px-3 pb-3">
                     <div className="flex items-center justify-between gap-2">
-                      <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Runs (history)</div>
+                      <div className="flex items-center gap-3">
+                        <div className="text-xs font-medium text-[color:var(--ck-text-secondary)]">Runs (history)</div>
+                        <Link
+                          href={`/teams/${encodeURIComponent(teamId)}/runs`}
+                          className="text-[10px] font-medium text-[color:var(--ck-text-tertiary)] hover:text-[color:var(--ck-text-secondary)] hover:underline"
+                        >
+                          View all →
+                        </Link>
+                      </div>
                       <div className="flex items-center gap-2">
                         <button
                           type="button"
@@ -1464,37 +1473,27 @@ export default function WorkflowsEditorClient({
                         <div className="text-xs text-[color:var(--ck-text-secondary)]">Loading runs…</div>
                       ) : workflowRuns.length ? (
                         workflowRuns.slice(0, 8).map((f) => {
+                          const wfId = String(wf.id ?? "").trim();
                           const runId = String(f).replace(/\.run\.json$/i, "");
                           const selected = selectedWorkflowRunId === runId;
+                          const href = wfId
+                            ? `/teams/${encodeURIComponent(teamId)}/runs/${encodeURIComponent(wfId)}/${encodeURIComponent(runId)}`
+                            : "#";
+
                           return (
-                            <button
+                            <Link
                               key={f}
-                              type="button"
-                              onClick={async () => {
-                                const wfId = String(wf.id ?? "").trim();
-                                if (!wfId) return;
-                                setSelectedWorkflowRunId(runId);
-                                setWorkflowRunsError("");
-                                try {
-                                  const res = await fetch(
-                                    `/api/teams/workflow-runs?teamId=${encodeURIComponent(teamId)}&workflowId=${encodeURIComponent(wfId)}&runId=${encodeURIComponent(runId)}`,
-                                    { cache: "no-store" }
-                                  );
-                                  const json = await res.json();
-                                  if (!res.ok || !json.ok) throw new Error(json.error || "Failed to load run");
-                                  // (run detail rendering not implemented yet; selecting stores runId only)
-                                } catch (e: unknown) {
-                                  setWorkflowRunsError(e instanceof Error ? e.message : String(e));
-                                }
-                              }}
+                              href={href}
+                              onClick={() => setSelectedWorkflowRunId(runId)}
                               className={
                                 selected
-                                  ? "w-full rounded-[var(--ck-radius-sm)] bg-white/10 px-2 py-1 text-left text-[11px] text-[color:var(--ck-text-primary)]"
-                                  : "w-full rounded-[var(--ck-radius-sm)] px-2 py-1 text-left text-[11px] text-[color:var(--ck-text-secondary)] hover:bg-white/5"
+                                  ? "block w-full rounded-[var(--ck-radius-sm)] bg-white/10 px-2 py-1 text-left text-[11px] font-mono text-[color:var(--ck-text-primary)]"
+                                  : "block w-full rounded-[var(--ck-radius-sm)] px-2 py-1 text-left text-[11px] font-mono text-[color:var(--ck-text-secondary)] hover:bg-white/5"
                               }
+                              title="Open run detail"
                             >
                               {runId}
-                            </button>
+                            </Link>
                           );
                         })
                       ) : (

--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -730,7 +730,7 @@ export default function WorkflowsEditorClient({
               </div>
 
               <svg
-                className="pointer-events-none absolute inset-0 z-0"
+                className="pointer-events-none absolute inset-0 -z-10"
                 width={2200}
                 height={1200}
                 style={{ overflow: "visible" }}
@@ -857,8 +857,8 @@ export default function WorkflowsEditorClient({
                     }}
                     className={
                       selected
-                        ? "absolute cursor-grab rounded-[var(--ck-radius-sm)] border border-white/25 bg-white/10 px-3 py-2 text-xs text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)]"
-                        : "absolute cursor-grab rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-xs text-[color:var(--ck-text-secondary)] hover:bg-white/10"
+                        ? "absolute z-10 cursor-grab rounded-[var(--ck-radius-sm)] border border-white/25 bg-white/10 px-3 py-2 text-xs text-[color:var(--ck-text-primary)] shadow-[var(--ck-shadow-1)]"
+                        : "absolute z-10 cursor-grab rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-3 py-2 text-xs text-[color:var(--ck-text-secondary)] hover:bg-white/10"
                     }
                     style={{ left: x, top: y, width: 180 }}
                   >

--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -729,7 +729,12 @@ export default function WorkflowsEditorClient({
                 </div>
               </div>
 
-              <svg className="absolute inset-0" width={2200} height={1200}>
+              <svg
+                className="pointer-events-none absolute inset-0 z-0"
+                width={2200}
+                height={1200}
+                style={{ overflow: "visible" }}
+              >
                 {(parsed.wf?.edges ?? []).map((e) => {
                   const wf = parsed.wf;
                   if (!wf) return null;
@@ -740,7 +745,17 @@ export default function WorkflowsEditorClient({
                   const ay = (typeof a.y === "number" ? a.y : 80) + 24;
                   const bx = (typeof b.x === "number" ? b.x : 80) + 90;
                   const by = (typeof b.y === "number" ? b.y : 80) + 24;
-                  return <line key={e.id} x1={ax} y1={ay} x2={bx} y2={by} stroke="rgba(255,255,255,0.18)" strokeWidth={2} />;
+                  return (
+                    <line
+                      key={e.id}
+                      x1={ax}
+                      y1={ay}
+                      x2={bx}
+                      y2={by}
+                      stroke="rgba(255,255,255,0.35)"
+                      strokeWidth={3}
+                    />
+                  );
                 })}
               </svg>
 

--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -769,7 +769,7 @@ export default function WorkflowsEditorClient({
                     role="button"
                     tabIndex={0}
                     data-wf-node="1"
-                    draggable={activeTool.kind === "select"}
+                    draggable={activeTool.kind === "select" || activeTool.kind === "connect"}
                     onDragStart={(e) => {
                       // allow agent pills to be dropped; do not start a browser drag ghost for nodes.
                       if (activeTool.kind !== "select") return;
@@ -820,7 +820,8 @@ export default function WorkflowsEditorClient({
                       setSelectedNodeId(n.id);
                     }}
                     onPointerDown={(e) => {
-                      if (activeTool.kind !== "select") return;
+                      // Allow dragging nodes even in connect mode (connect is click-to-connect, not drag-to-connect).
+                      if (activeTool.kind === "add-node") return;
                       if (e.button !== 0) return;
                       const el = canvasRef.current;
                       if (!el) return;

--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -30,10 +30,16 @@ export default function WorkflowsEditorClient({
 
   const [toolsCollapsed, setToolsCollapsed] = useState(false);
 
+  // Canvas zoom
+  const [zoom, setZoom] = useState(1);
+  const ZOOM_MIN = 0.5;
+  const ZOOM_MAX = 2.5;
+  const ZOOM_STEP = 0.1;
+
   // Canvas: selection, drag, node/edge creation.
   const canvasRef = useRef<HTMLDivElement | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string>("");
-  const [dragging, setDragging] = useState<null | { nodeId: string; dx: number; dy: number; left: number; top: number }>(null);
+  const [dragging, setDragging] = useState<null | { nodeId: string; dx: number; dy: number }>(null);
 
   const [activeTool, setActiveTool] = useState<
     | { kind: "select" }
@@ -416,6 +422,16 @@ export default function WorkflowsEditorClient({
           <div
             ref={canvasRef}
             className="relative h-full min-h-0 w-full flex-1 overflow-auto bg-black/20"
+            onWheel={(e) => {
+              // Ctrl/Cmd + wheel to zoom (avoid hijacking normal scroll)
+              if (!e.ctrlKey && !e.metaKey) return;
+              e.preventDefault();
+              const dir = e.deltaY > 0 ? -1 : 1;
+              setZoom((z) => {
+                const next = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, Math.round((z + dir * ZOOM_STEP) * 10) / 10));
+                return next;
+              });
+            }}
             onClick={(e) => {
               if (activeTool.kind !== "add-node") return;
               const wf = parsed.wf;
@@ -428,8 +444,8 @@ export default function WorkflowsEditorClient({
               if (target && target.closest("[data-wf-node='1']")) return;
 
               const rect = el.getBoundingClientRect();
-              const clickX = e.clientX - rect.left + el.scrollLeft;
-              const clickY = e.clientY - rect.top + el.scrollTop;
+              const clickX = (e.clientX - rect.left + el.scrollLeft) / zoom;
+              const clickY = (e.clientY - rect.top + el.scrollTop) / zoom;
 
               const base = activeTool.nodeType.replace(/[^a-z0-9_\-]/gi, "_");
               const used = new Set(wf.nodes.map((n) => n.id));
@@ -457,7 +473,8 @@ export default function WorkflowsEditorClient({
               setActiveTool({ kind: "select" });
             }}
           >
-            <div className="relative h-[1200px] w-[2200px]">
+            <div style={{ width: 2200 * zoom, height: 1200 * zoom }}>
+              <div className="relative h-[1200px] w-[2200px]" style={{ transform: `scale(${zoom})`, transformOrigin: "0 0" }}>
               {/* Tool palette / agent palette */}
               <div
                 className={
@@ -468,14 +485,36 @@ export default function WorkflowsEditorClient({
               >
                 <div className="flex items-center justify-between gap-2">
                   <div className={toolsCollapsed ? "hidden" : "text-[10px] font-medium uppercase tracking-wide text-[color:var(--ck-text-tertiary)]"}>Tools</div>
-                  <button
-                    type="button"
-                    onClick={() => setToolsCollapsed((v) => !v)}
-                    className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-2 py-1 text-[10px] text-[color:var(--ck-text-secondary)] hover:bg-white/10"
-                    title={toolsCollapsed ? "Expand" : "Collapse"}
-                  >
-                    {toolsCollapsed ? ">" : "<"}
-                  </button>
+                  <div className="flex items-center gap-2">
+                    <div className={toolsCollapsed ? "hidden" : "flex items-center gap-1"}>
+                      <button
+                        type="button"
+                        onClick={() => setZoom((z) => Math.max(ZOOM_MIN, Math.round((z - ZOOM_STEP) * 10) / 10))}
+                        className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-2 py-1 text-[10px] text-[color:var(--ck-text-secondary)] hover:bg-white/10"
+                        title="Zoom out (Ctrl/Cmd+wheel)"
+                      >
+                        −
+                      </button>
+                      <div className="min-w-[42px] text-center text-[10px] text-[color:var(--ck-text-tertiary)]">{Math.round(zoom * 100)}%</div>
+                      <button
+                        type="button"
+                        onClick={() => setZoom((z) => Math.min(ZOOM_MAX, Math.round((z + ZOOM_STEP) * 10) / 10))}
+                        className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-2 py-1 text-[10px] text-[color:var(--ck-text-secondary)] hover:bg-white/10"
+                        title="Zoom in (Ctrl/Cmd+wheel)"
+                      >
+                        +
+                      </button>
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={() => setToolsCollapsed((v) => !v)}
+                      className="rounded-[var(--ck-radius-sm)] border border-white/10 bg-white/5 px-2 py-1 text-[10px] text-[color:var(--ck-text-secondary)] hover:bg-white/10"
+                      title={toolsCollapsed ? "Expand" : "Collapse"}
+                    >
+                      {toolsCollapsed ? ">" : "<"}
+                    </button>
+                  </div>
                 </div>
                 {toolsCollapsed ? (
                   <div className="mt-2 flex flex-col items-center gap-2">
@@ -500,7 +539,8 @@ export default function WorkflowsEditorClient({
                           label: "Connect",
                           active: activeTool.kind === "connect",
                           onClick: () => {
-                            setActiveTool({ kind: "connect" });
+                            // Toggle connect tool.
+                            setActiveTool((t) => (t.kind === "connect" ? { kind: "select" } : { kind: "connect" }));
                             setConnectFromNodeId("");
                           },
                           icon: (
@@ -814,6 +854,8 @@ export default function WorkflowsEditorClient({
                         const id = `e${Date.now()}`;
                         const nextEdge: WorkflowFileV1["edges"][number] = { id, from, to };
                         setWorkflow({ ...wf, edges: [...(wf.edges ?? []), nextEdge] });
+                        // After creating an edge, return to Select tool.
+                        setActiveTool({ kind: "select" });
                         return;
                       }
 
@@ -833,7 +875,10 @@ export default function WorkflowsEditorClient({
                         // ignore
                       }
                       e.preventDefault();
-                      setDragging({ nodeId: n.id, dx: e.clientX - rect.left - x, dy: e.clientY - rect.top - y, left: rect.left, top: rect.top });
+
+                      const pointerX = (e.clientX - rect.left + el.scrollLeft) / zoom;
+                      const pointerY = (e.clientY - rect.top + el.scrollTop) / zoom;
+                      setDragging({ nodeId: n.id, dx: pointerX - x, dy: pointerY - y });
                     }}
                     onPointerUp={(e) => {
                       try {
@@ -850,8 +895,11 @@ export default function WorkflowsEditorClient({
                       if (!wf) return;
                       const el = canvasRef.current;
                       if (!el) return;
-                      const nextX = e.clientX - dragging.left - dragging.dx;
-                      const nextY = e.clientY - dragging.top - dragging.dy;
+                      const rect = el.getBoundingClientRect();
+                      const pointerX = (e.clientX - rect.left + el.scrollLeft) / zoom;
+                      const pointerY = (e.clientY - rect.top + el.scrollTop) / zoom;
+                      const nextX = pointerX - dragging.dx;
+                      const nextY = pointerY - dragging.dy;
                       const nextNodes = wf.nodes.map((node) => (node.id === n.id ? { ...node, x: nextX, y: nextY } : node));
                       const next: WorkflowFileV1 = { ...wf, nodes: nextNodes };
                       setStatus({ kind: "ready", jsonText: JSON.stringify(next, null, 2) + "\n" });
@@ -1034,6 +1082,7 @@ export default function WorkflowsEditorClient({
                   </div>
                 );
               })()}
+              </div>
             </div>
           </div>
         )}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -128,7 +128,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     try {
       const v = localStorage.getItem("ck-leftnav-collapsed");
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+       
       setCollapsed(v === "1");
     } catch {
       // ignore
@@ -237,6 +237,26 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         </Icon>
       ),
     },
+    // Team-scoped pages (path-based). Only show if we have a selected team.
+    ...(selectedTeamId
+      ? [
+          {
+            href: `/teams/${encodeURIComponent(selectedTeamId)}/runs`,
+            label: "Runs",
+            icon: (
+              <Icon>
+                <svg viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M4 19h16" />
+                  <path d="M6 16l4-4 3 3 5-7" />
+                  <circle cx="10" cy="12" r="1" />
+                  <circle cx="13" cy="15" r="1" />
+                  <circle cx="18" cy="8" r="1" />
+                </svg>
+              </Icon>
+            ),
+          },
+        ]
+      : []),
     {
       href: `/settings`,
       label: "Settings",

--- a/src/lib/workflows/runs-storage.ts
+++ b/src/lib/workflows/runs-storage.ts
@@ -57,3 +57,69 @@ export async function writeWorkflowRun(teamId: string, workflowId: string, run: 
   await fs.writeFile(p, JSON.stringify(toWrite, null, 2) + "\n", "utf8");
   return { ok: true as const, path: p };
 }
+
+export type WorkflowRunSummary = {
+  workflowId: string;
+  runId: string;
+  status?: WorkflowRunFileV1["status"];
+  startedAt?: string;
+  endedAt?: string;
+  /** ISO timestamp derived from file mtime (best-effort) */
+  updatedAt?: string;
+  /** Absolute path to the run file on disk (server-side only) */
+  path: string;
+};
+
+export async function listAllWorkflowRuns(teamId: string): Promise<{ ok: true; dir: string; runs: WorkflowRunSummary[] }> {
+  const teamDir = await getTeamWorkspaceDir(teamId);
+  const dir = path.join(teamDir, RUNS_DIR);
+
+  // Structure: shared-context/workflow-runs/<workflowId>/*.run.json
+  let wfDirs: string[] = [];
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    wfDirs = entries.filter((e) => e.isDirectory()).map((e) => e.name).sort();
+  } catch (err: unknown) {
+    if (err && typeof err === "object" && (err as { code?: unknown }).code === "ENOENT") {
+      return { ok: true as const, dir, runs: [] };
+    }
+    throw err;
+  }
+
+  const runs: WorkflowRunSummary[] = [];
+
+  for (const workflowId of wfDirs) {
+    const wfDir = path.join(dir, workflowId);
+    let entries: string[] = [];
+    try {
+      entries = (await fs.readdir(wfDir)).filter((n) => n.endsWith(".run.json")).sort();
+    } catch (err: unknown) {
+      if (err && typeof err === "object" && (err as { code?: unknown }).code === "ENOENT") continue;
+      throw err;
+    }
+
+    for (const fileName of entries) {
+      const runId = fileName.replace(/\.run\.json$/i, "");
+      const full = path.join(wfDir, fileName);
+      try {
+        const [raw, st] = await Promise.all([fs.readFile(full, "utf8"), fs.stat(full)]);
+        const parsed = JSON.parse(raw) as Partial<WorkflowRunFileV1>;
+        runs.push({
+          workflowId,
+          runId,
+          status: parsed.status as WorkflowRunFileV1["status"],
+          startedAt: typeof parsed.startedAt === "string" ? parsed.startedAt : undefined,
+          endedAt: typeof parsed.endedAt === "string" ? parsed.endedAt : undefined,
+          updatedAt: st.mtime ? new Date(st.mtime).toISOString() : undefined,
+          path: full,
+        });
+      } catch {
+        // Ignore malformed/partial run files; don't break the whole page.
+        runs.push({ workflowId, runId, path: full });
+      }
+    }
+  }
+
+  runs.sort((a, b) => String(b.updatedAt ?? b.startedAt ?? "").localeCompare(String(a.updatedAt ?? a.startedAt ?? "")));
+  return { ok: true as const, dir, runs };
+}


### PR DESCRIPTION
Implements ticket 0133.

- Add team nav entry: /teams/:teamId/runs
- Runs list (file-first from shared-context/workflow-runs/), filtering + newest-first
- Run detail page with node timeline + output/error viewer + raw JSON
- Link from workflow editor runs/history → standalone pages

Checks: npm run lint, npm run build