### PR TITLE
0.3.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jiggai/kitchen",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": false,
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
## Summary

## Test Plan
- [ ] Added/updated unit tests
- [ ] `npm run lint`
- [ ] `npm run coverage`

## Guardrails
- If this PR touches `src/lib/**`, it must include tests (`src/**/__tests__/**` or `*.test.*`) unless a maintainer applies the **no-tests-ok** label with justification.
