### PR TITLE
Release/0.3.18

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "kitchen",
   "name": "ClawKitchen",
   "description": "Local UI for managing OpenClaw recipes, teams, agents, cron jobs, and skills.",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "kitchen",
   "name": "ClawKitchen",
   "description": "Local UI for managing OpenClaw recipes, teams, agents, cron jobs, and skills.",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jiggai/kitchen",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jiggai/kitchen",
-      "version": "0.3.17",
+      "version": "0.3.18",
       "dependencies": {
         "next": "16.1.6",
         "react": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "private": false,
   "openclaw": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jiggai/kitchen",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "private": false,
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
## Summary

## Test Plan
- [ ] Added/updated unit tests
- [ ] `npm run lint`
- [ ] `npm run coverage`

## Guardrails
- If this PR touches `src/lib/**`, it must include tests (`src/**/__tests__/**` or `*.test.*`) unless a maintainer applies the **no-tests-ok** label with justification.
