### PR TITLE
fix: removing dup openclaw settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,6 @@
       "openclawVersion": "2026.3.28"
     }
   },
-  "compat": {
-    "pluginApi": "2026.3"
-  },
-  "build": {
-    "openclawVersion": "2026.3.28"
-  },
   "scripts": {
     "dev": "next dev",
     "build": "NODE_ENV=production next build",


### PR DESCRIPTION
## Summary

## Test Plan
- [ ] Added/updated unit tests
- [ ] `npm run lint`
- [ ] `npm run coverage`

## Guardrails
- If this PR touches `src/lib/**`, it must include tests (`src/**/__tests__/**` or `*.test.*`) unless a maintainer applies the **no-tests-ok** label with justification.
