### PR TITLE
feat: narrow workflow-cron LLM scope to fix stuck worker queues

### DIFF
--- a/src/app/api/cron/__tests__/worker-route.test.ts
+++ b/src/app/api/cron/__tests__/worker-route.test.ts
@@ -87,7 +87,7 @@ describe("/api/cron/worker POST", () => {
 
     // Provenance is stored in the team workspace (not per-agent workspace)
     const mappingRaw = await fs.readFile(path.join(TEAM_DIR, "notes", "cron-jobs.json"), "utf8");
-    const mapping = JSON.parse(mappingRaw) as { version: number; entries: Record<string, { installedCronId: string; updatedAtMs?: number }> };
+    const mapping = JSON.parse(mappingRaw) as { version: number; entries: Record<string, { installedCronId: string; updatedAtMs?: number; payloadSchemaVersion?: number }> };
     expect(mapping.version).toBe(1);
 
     // Key format matches ClawRecipes CronMappingStateV1 convention
@@ -107,8 +107,60 @@ describe("/api/cron/worker POST", () => {
     expect(args).toContain("isolated");
     expect(args).toContain("--timeout-seconds");
     expect(args).toContain("120");
+    // Narrow-scope flags: LLM gets minimal context and can only invoke exec.
+    // Without these, workers occasionally hallucinate wrong CLI paths and
+    // silently drop ticks — we had a workflow stall for 25 minutes on this.
+    expect(args).toContain("--light-context");
+    expect(args).toContain("--tools");
+    expect(args).toContain("exec");
     // No --model flag unless KITCHEN_WORKFLOW_CRON_MODEL is set (see new test).
     expect(args).not.toContain("--model");
+
+    // Provenance records the payload schema version so future reconciles can
+    // detect stale crons and migrate them.
+    expect(mapping.entries[key].payloadSchemaVersion).toBe(2);
+  });
+
+  it("reinstalls a stale (pre-v2) worker cron on install", async () => {
+    // Seed a v1 entry (no payloadSchemaVersion, existing cron id).
+    await fs.mkdir(path.join(TEAM_DIR, "notes"), { recursive: true });
+    await fs.writeFile(
+      path.join(TEAM_DIR, "notes", "cron-jobs.json"),
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "team:claw-marketing-team:recipe:workflow-worker:cron:claw-marketing-team-writer": {
+            installedCronId: "cron-old",
+            updatedAtMs: Date.now() - 60000,
+          },
+        },
+      }, null, 2),
+      "utf8"
+    );
+
+    const { POST } = await import("../worker/route");
+
+    const res = await POST(
+      new Request("http://localhost/api/cron/worker", {
+        method: "POST",
+        body: JSON.stringify({ action: "install", teamId: "claw-marketing-team", agentId: "claw-marketing-team-writer" }),
+      })
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { installedCronId: string };
+
+    // Old v1 cron was removed, new v2 cron was installed.
+    const rmCall = runOpenClawMock.mock.calls.find((c) => c[0].slice(0, 2).join(" ") === "cron rm");
+    expect(rmCall).toBeDefined();
+    expect(rmCall![0]).toContain("cron-old");
+    expect(json.installedCronId).toBe("cron-123");
+
+    // Mapping was updated to v2.
+    const mappingRaw = await fs.readFile(path.join(TEAM_DIR, "notes", "cron-jobs.json"), "utf8");
+    const mapping = JSON.parse(mappingRaw) as { entries: Record<string, { installedCronId: string; payloadSchemaVersion?: number }> };
+    const key = "team:claw-marketing-team:recipe:workflow-worker:cron:claw-marketing-team-writer";
+    expect(mapping.entries[key].installedCronId).toBe("cron-123");
+    expect(mapping.entries[key].payloadSchemaVersion).toBe(2);
   });
 
   it("reconcile installs missing and disables orphaned in team mapping", async () => {
@@ -150,7 +202,7 @@ describe("/api/cron/worker POST", () => {
 
     // The orphaned entry should be marked orphaned
     const mappingRaw = await fs.readFile(path.join(TEAM_DIR, "notes", "cron-jobs.json"), "utf8");
-    const mapping = JSON.parse(mappingRaw) as { entries: Record<string, { orphaned?: boolean; updatedAtMs?: number }> };
+    const mapping = JSON.parse(mappingRaw) as { entries: Record<string, { installedCronId?: string; orphaned?: boolean; updatedAtMs?: number; payloadSchemaVersion?: number }> };
     const orphanKey = "team:claw-marketing-team:recipe:workflow-worker:cron:claw-marketing-team-old";
     expect(mapping.entries[orphanKey].orphaned).toBe(true);
 

--- a/src/app/api/cron/worker/route.ts
+++ b/src/app/api/cron/worker/route.ts
@@ -19,6 +19,31 @@ async function cronJobExists(id: string): Promise<boolean> {
   }
 }
 
+/**
+ * Schema version for the cron payload shape Kitchen installs.
+ *
+ * v1 = agentTurn message only (broad LLM context, all tools allowed).
+ *      LLM sometimes hallucinated the CLI path or skipped the exec, leaving
+ *      workflow queues to drain unreliably.
+ * v2 = agentTurn + --light-context + --tools exec. The LLM now loads a
+ *      minimal bootstrap context and can only invoke the exec tool, which
+ *      dramatically narrows the failure surface for worker/runner ticks.
+ *
+ * Bump this when the install shape changes so reconcile can detect stale
+ * crons and re-install them.
+ */
+const PAYLOAD_SCHEMA_VERSION = 2;
+
+/**
+ * Extra cron-add flags used for every Kitchen-installed workflow cron.
+ *
+ * - --light-context: skip heavy bootstrap (agent identity, skills, etc.).
+ *   The worker-tick / runner-tick commands do not need that context.
+ * - --tools exec: restrict the LLM session to the exec tool only. It cannot
+ *   wander into Read/Write/Search and cannot invent alternative workflows.
+ */
+const WORKFLOW_CRON_NARROW_SCOPE_ARGS: string[] = ["--light-context", "--tools", "exec"];
+
 // ---------------------------------------------------------------------------
 // Provenance format — matches ClawRecipes CronMappingStateV1 so both systems
 // read/write the same file and never create duplicates.
@@ -30,6 +55,12 @@ type MappingStateV1 = {
     specHash?: string;
     orphaned?: boolean;
     updatedAtMs?: number;
+    /**
+     * Payload schema version the cron was installed with. Missing or older
+     * values mean the cron predates a shape change and should be removed +
+     * re-installed on the next reconcile.
+     */
+    payloadSchemaVersion?: number;
   }>;
 };
 
@@ -150,10 +181,13 @@ async function installWorkerCron(teamId: string, agentId: string): Promise<{
   const existing = mapping.entries[key];
   if (existing && existing.installedCronId && !existing.orphaned) {
     const existingId = String(existing.installedCronId);
-    if (await cronJobExists(existingId)) {
+    const existingSchema = existing.payloadSchemaVersion ?? 1;
+    const isStale = existingSchema < PAYLOAD_SCHEMA_VERSION;
+    if (await cronJobExists(existingId) && !isStale) {
       await runOpenClaw(["cron", "enable", existingId]);
       return { alreadyInstalled: true, installedCronId: existingId, mappingPath: mp, key };
     }
+    if (isStale) await runOpenClaw(["cron", "rm", existingId]);
     delete mapping.entries[key];
     await writeMapping(mp, mapping);
   }
@@ -182,6 +216,7 @@ async function installWorkerCron(teamId: string, agentId: string): Promise<{
     description,
     "--message",
     message,
+    ...WORKFLOW_CRON_NARROW_SCOPE_ARGS,
     ...modelFlagArgs(),
     "--no-deliver",
     "--json",
@@ -192,7 +227,11 @@ async function installWorkerCron(teamId: string, agentId: string): Promise<{
   const installedCronId = String(parsed?.id ?? parsed?.job?.id ?? "").trim();
   if (!installedCronId) throw new Error("Cron add succeeded but did not return id");
 
-  mapping.entries[key] = { installedCronId, updatedAtMs: now };
+  mapping.entries[key] = {
+    installedCronId,
+    updatedAtMs: now,
+    payloadSchemaVersion: PAYLOAD_SCHEMA_VERSION,
+  };
   await writeMapping(mp, mapping);
 
   return { alreadyInstalled: false, installedCronId, mappingPath: mp, key };
@@ -213,9 +252,12 @@ async function installRunnerCron(teamId: string): Promise<{
   const existing = mapping.entries[key];
   if (existing && !existing.orphaned) {
     const existingId = String(existing.installedCronId ?? "").trim();
-    if (await cronJobExists(existingId)) {
+    const existingSchema = existing.payloadSchemaVersion ?? 1;
+    const isStale = existingSchema < PAYLOAD_SCHEMA_VERSION;
+    if (await cronJobExists(existingId) && !isStale) {
       return { alreadyInstalled: true, installedCronId: existingId, mappingPath: mp, key };
     }
+    if (isStale && existingId) await runOpenClaw(["cron", "rm", existingId]);
     delete mapping.entries[key];
     await writeMapping(mp, mapping);
   }
@@ -233,6 +275,7 @@ async function installRunnerCron(teamId: string): Promise<{
     "--tz", "America/New_York",
     "--no-deliver",
     "--message", message,
+    ...WORKFLOW_CRON_NARROW_SCOPE_ARGS,
     ...modelFlagArgs(),
     "--timeout-seconds", "900",
     "--json"
@@ -242,7 +285,11 @@ async function installRunnerCron(teamId: string): Promise<{
   const installedCronId = cronData.id;
   const now = Date.now();
 
-  mapping.entries[key] = { installedCronId, updatedAtMs: now };
+  mapping.entries[key] = {
+    installedCronId,
+    updatedAtMs: now,
+    payloadSchemaVersion: PAYLOAD_SCHEMA_VERSION,
+  };
   await writeMapping(mp, mapping);
 
   return { alreadyInstalled: false, installedCronId, mappingPath: mp, key };


### PR DESCRIPTION
## Summary
- Install workflow crons (worker-tick + runner-tick) with `--light-context --tools exec` so the LLM session gets a minimal bootstrap and can only invoke the exec tool. No room to hallucinate wrong CLI paths or silently drop ticks.
- Add `payloadSchemaVersion` to the `notes/cron-jobs.json` mapping entries so install/reconcile can detect pre-v2 crons and migrate them automatically via `cron rm` + reinstall.

## Why
Workflow runs were stalling for 20+ minutes between nodes because the agentTurn payload gives the LLM session broad context and full tool access. In one observed run, `social_handoff_packet` took 26 minutes to drain — the tick fired repeatedly but the LLM kept interpreting the message differently (e.g., invoking a non-existent `openclaw recipes workflows` subcommand) instead of just executing the one shell command it was handed.

This is the Layer-1 mitigation: we keep the cron inside OpenClaw's cron system (so Kitchen's auto-discovery + reconcile still work) but constrain what the LLM can do.

## Test plan
- [x] Existing worker-route tests still pass
- [x] New test: `install` asserts `--light-context` and `--tools exec` are present in the `cron add` args, and that provenance records `payloadSchemaVersion: 2`
- [x] New test: seeding a v1 mapping entry triggers `cron rm` of the old id + reinstall at v2
- [x] Full `vitest run` suite: 521/521 passing
- [ ] After merge + publish, deploy locally, then hit Kitchen `reconcile` to migrate existing HMX marketing-team workflow crons from v1 → v2 and observe tick reliability

🤖 Generated with [Claude Code](https://claude.com/claude-code)