### PR TITLE
fix: gate plugin gear icon to plugins that actually have settings

### DIFF
--- a/src/components/PluginTabs.tsx
+++ b/src/components/PluginTabs.tsx
@@ -17,6 +17,20 @@ interface PluginTabsProps {
   teamId: string;
 }
 
+/**
+ * Plugins that expose a settings UI.
+ *
+ * The gear icon + settings panel are currently hardcoded to render a single
+ * "Image compression quality" field, which is only meaningful for plugins
+ * that generate media. Showing the gear for plugins without a matching
+ * config surface (e.g. the YOT CRM plugin) silently writes ghost values
+ * into their plugin_config table that nothing reads.
+ *
+ * Follow-up: replace this allow-list with a manifest-driven settings schema
+ * (see HMX ticket 0091 — Kitchen plugin settings schema).
+ */
+const PLUGINS_WITH_SETTINGS_UI = new Set(['marketing']);
+
 function Section({
   title,
   defaultOpen = true,
@@ -257,7 +271,7 @@ export default function PluginTabs({ teamType, teamId }: PluginTabsProps) {
               >
                 {savingPluginId === plugin.id ? 'Saving…' : plugin.enabled ? 'Disable' : 'Enable'}
               </button>
-              {plugin.enabled && (
+              {plugin.enabled && PLUGINS_WITH_SETTINGS_UI.has(plugin.id) && (
                 <button
                   type="button"
                   onClick={() => handleSettingsToggle(plugin.id)}
@@ -299,7 +313,7 @@ export default function PluginTabs({ teamType, teamId }: PluginTabsProps) {
                 })}
               </div>
 
-              {showSettings[plugin.id] ? (
+              {showSettings[plugin.id] && PLUGINS_WITH_SETTINGS_UI.has(plugin.id) ? (
                 <div className="ck-card mt-2 p-4">
                   <div className="mb-4 flex items-center justify-between">
                     <h3 className="text-base font-semibold text-[color:var(--ck-text-primary)]">Plugin Settings</h3>


### PR DESCRIPTION
## Summary
Quick patch to the plugin gear icon introduced in #398. The gear currently renders for every enabled plugin and opens a hardcoded "Image compression quality" panel. That panel is only meaningful for `kitchen-plugin-marketing` (its runner reads `imageCompressionQuality` from `plugin_config` at generation time via `generation/runner.ts:21-35`).

For any other plugin — e.g. the new `kitchen-plugin-yot` CRM plugin — the gear produces a **ghost setting**: saving writes `{imageCompressionQuality: "70"}` into the plugin's `plugin_config` table where no code ever reads it.

## Change
Allow-list the plugins that have a real settings UI:

```tsx
const PLUGINS_WITH_SETTINGS_UI = new Set(['marketing']);
```

Used in two places:
- Gear icon render guard (line ~260 in the old code)
- Settings panel render guard (defensive, in case state carries over)

When the plugin id isn't in the set, no gear, no panel.

## Why this is a quick patch, not the real fix
The root problem is that plugin settings are currently hardcoded in Kitchen UI instead of declared by the plugin itself. The proper fix is a manifest-driven settings schema — each plugin's `openclaw.plugin.json` (or `package.json > kitchenPlugin`) declares its settings, Kitchen renders from that schema, and plugins without a schema get no gear.

Tracked in HMX workspace ticket 0091 — "Kitchen plugin settings schema". Full design notes + work breakdown in that ticket. Once that lands, the `PLUGINS_WITH_SETTINGS_UI` allow-list can be deleted.

## Test plan
- [x] YOT plugin: gear icon not rendered, settings panel not reachable.
- [x] Marketing plugin: gear icon rendered, settings panel opens, existing Image compression quality field works.
- [x] `npx tsc --noEmit`: zero new type errors (58 baseline errors unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)