### PR TITLE
feat(workflows): skip cron check + Run button on workflow list

### DIFF
--- a/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
+++ b/src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx
@@ -431,6 +431,15 @@ export default function WorkflowsEditorClient({
   const [installCronBusy, setInstallCronBusy] = useState(false);
   const [installCronError, setInstallCronError] = useState<string>("");
 
+  // Skip cron check: session-only flag ("skipCronOnce") OR persisted flag on the
+  // workflow JSON at `meta.skipCronCheck` ("skipCronPermanent"). Either unblocks
+  // the Run Now button when worker crons aren't installed (e.g. when workers
+  // are running via launchd or an external scheduler).
+  const [skipCronOnce, setSkipCronOnce] = useState(false);
+  const [skipCronModalOpen, setSkipCronModalOpen] = useState(false);
+  const [skipCronSaving, setSkipCronSaving] = useState(false);
+  const [skipCronError, setSkipCronError] = useState<string>("");
+
   const [newNodeId, setNewNodeId] = useState("");
   const [newNodeName, setNewNodeName] = useState("");
   const [newNodeType, setNewNodeType] = useState<WorkflowFileV1["nodes"][number]["type"]>("llm");
@@ -695,9 +704,22 @@ export default function WorkflowsEditorClient({
 
     const agentIdsMissingCron = requiredAgentIds.filter((id) => !agentHasCron[id]);
 
-    const ok = missingAgentOnNodeIds.length === 0 && agentIdsMissingCron.length === 0;
-    return { missingAgentOnNodeIds, requiredAgentIds, agentIdsMissingCron, ok };
-  }, [parsed.wf, agentHasCron]);
+    // meta.skipCronCheck is the persisted "skip permanently" flag on the workflow itself.
+    const meta = wf.meta && typeof wf.meta === "object" && !Array.isArray(wf.meta)
+      ? (wf.meta as Record<string, unknown>)
+      : {};
+    const skipCronPermanent = meta.skipCronCheck === true;
+
+    const cronSatisfied = agentIdsMissingCron.length === 0 || skipCronOnce || skipCronPermanent;
+    const ok = missingAgentOnNodeIds.length === 0 && cronSatisfied;
+    return {
+      missingAgentOnNodeIds,
+      requiredAgentIds,
+      agentIdsMissingCron,
+      skipCronPermanent,
+      ok,
+    };
+  }, [parsed.wf, agentHasCron, skipCronOnce]);
 
   function setWorkflow(next: WorkflowFileV1) {
     const text = JSON.stringify(next, null, 2) + "\n";
@@ -3069,7 +3091,9 @@ export default function WorkflowsEditorClient({
 
                             // Cron reconciliation: keep the system clean by disabling orphaned worker crons,
                             // and install/enable missing worker crons before enqueue.
-                            if (runPreflight.agentIdsMissingCron.length) {
+                            // Skipped when the user opted to skip the cron check (once or permanently).
+                            const skipCronCheck = skipCronOnce || runPreflight.skipCronPermanent;
+                            if (runPreflight.agentIdsMissingCron.length && !skipCronCheck) {
                               setInstallCronBusy(true);
                               setInstallCronError("");
                               try {
@@ -3149,10 +3173,20 @@ export default function WorkflowsEditorClient({
                       <div className="mt-2 rounded-lg border border-red-400/30 bg-red-500/10 p-2 text-xs text-red-100">
                         All nodes must be assigned to an agent. Missing agentId on: {runPreflight.missingAgentOnNodeIds.join(", ")}
                       </div>
+                    ) : runPreflight.skipCronPermanent ? (
+                      <div className="mt-2 rounded-lg border border-sky-400/30 bg-sky-500/10 p-2 text-xs text-sky-50">
+                        Cron check is skipped permanently for this workflow (<span className="font-mono">meta.skipCronCheck: true</span>).
+                        Run Now will enqueue without installing worker crons.
+                      </div>
+                    ) : skipCronOnce ? (
+                      <div className="mt-2 rounded-lg border border-sky-400/30 bg-sky-500/10 p-2 text-xs text-sky-50">
+                        Cron check is skipped for this session. Run Now will enqueue without installing worker crons.
+                        Reload the page to re-enable the check.
+                      </div>
                     ) : runPreflight.agentIdsMissingCron.length ? (
                       <div className="mt-2 rounded-lg border border-amber-400/30 bg-amber-500/10 p-2 text-xs text-amber-50">
                         <div>Cron not set up for: {runPreflight.agentIdsMissingCron.join(", ")}</div>
-                        <div className="mt-2 flex items-center gap-2">
+                        <div className="mt-2 flex flex-wrap items-center gap-2">
                           <button
                             type="button"
                             onClick={() => {
@@ -3170,9 +3204,92 @@ export default function WorkflowsEditorClient({
                           >
                             Re-check
                           </button>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setSkipCronError("");
+                              setSkipCronModalOpen(true);
+                            }}
+                            className="rounded-lg border border-sky-400/30 bg-sky-500/10 px-2 py-1 text-[10px] font-medium text-sky-50 hover:bg-sky-500/15"
+                            title="Skip the cron-install check and enable Run Now (useful when workers run via launchd or an external scheduler)"
+                          >
+                            Skip
+                          </button>
                         </div>
                       </div>
                     ) : null}
+
+                    <ConfirmationModal
+                      open={skipCronModalOpen}
+                      title="Skip cron check?"
+                      busy={skipCronSaving}
+                      error={skipCronError || undefined}
+                      confirmLabel="Skip this run only"
+                      confirmBusyLabel="Saving…"
+                      onClose={() => {
+                        if (skipCronSaving) return;
+                        setSkipCronModalOpen(false);
+                      }}
+                      onConfirm={() => {
+                        setSkipCronOnce(true);
+                        setSkipCronModalOpen(false);
+                      }}
+                    >
+                      <div className="text-sm text-[color:var(--ck-text-secondary)] space-y-3">
+                        <p>
+                          Choose how long to bypass the worker-cron check for this workflow. The actual worker
+                          process must still be running somewhere (OpenClaw cron, macOS launchd, systemd, etc.)
+                          — skipping the check only stops Kitchen from blocking Run Now.
+                        </p>
+                        <div className="rounded-lg border border-white/10 bg-white/5 p-3">
+                          <div className="text-xs font-semibold text-[color:var(--ck-text-primary)]">Skip this run only</div>
+                          <div className="mt-1 text-xs text-[color:var(--ck-text-tertiary)]">
+                            Click the primary button below. Skip resets on page reload.
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          disabled={skipCronSaving}
+                          onClick={async () => {
+                            setSkipCronSaving(true);
+                            setSkipCronError("");
+                            try {
+                              if (status.kind !== "ready") throw new Error("Workflow not loaded");
+                              const current = JSON.parse(status.jsonText) as WorkflowFileV1;
+                              const nextMeta: Record<string, unknown> = {
+                                ...(current.meta && typeof current.meta === "object" && !Array.isArray(current.meta)
+                                  ? (current.meta as Record<string, unknown>)
+                                  : {}),
+                                skipCronCheck: true,
+                              };
+                              const nextWf: WorkflowFileV1 = { ...current, meta: nextMeta };
+                              const res = await fetch("/api/teams/workflows", {
+                                method: "POST",
+                                headers: { "content-type": "application/json" },
+                                body: JSON.stringify({ teamId, workflow: nextWf }),
+                              });
+                              const json = (await res.json()) as { ok?: boolean; error?: string };
+                              if (!res.ok || json.ok === false) {
+                                throw new Error(json.error || "Failed to save workflow");
+                              }
+                              setStatus({ kind: "ready", jsonText: JSON.stringify(nextWf, null, 2) + "\n" });
+                              setSkipCronModalOpen(false);
+                            } catch (e: unknown) {
+                              setSkipCronError(e instanceof Error ? e.message : String(e));
+                            } finally {
+                              setSkipCronSaving(false);
+                            }
+                          }}
+                          className="w-full rounded-lg border border-sky-400/30 bg-sky-500/10 p-3 text-left hover:bg-sky-500/15 disabled:opacity-60"
+                        >
+                          <div className="text-xs font-semibold text-sky-50">Skip permanently</div>
+                          <div className="mt-1 text-xs text-sky-100/80">
+                            Writes <span className="font-mono">meta.skipCronCheck: true</span> into the workflow JSON.
+                            Applies forever unless the flag is removed.
+                          </div>
+                        </button>
+                      </div>
+                    </ConfirmationModal>
 
                     <ConfirmationModal
                       open={installCronOpen}

--- a/src/app/teams/[teamId]/workflows/workflows-client.tsx
+++ b/src/app/teams/[teamId]/workflows/workflows-client.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { fetchJson } from "@/lib/fetch-json";
 import { errorMessage } from "@/lib/errors";
+import { ConfirmationModal } from "@/components/ConfirmationModal";
 
 type RunDetail = {
   id: string;
@@ -37,6 +38,105 @@ export default function WorkflowsClient({ teamId, llmTaskEnabled }: { teamId: st
   const [runError, setRunError] = useState<string>("");
   const [approvalNote, setApprovalNote] = useState<string>("");
   const [approvalBusy, setApprovalBusy] = useState<boolean>(false);
+
+  // Run-from-list state: when the user clicks Run on a list row, we need to
+  // (a) load the workflow to inspect meta.skipCronCheck, (b) check cron state,
+  // (c) either enqueue the run or show a block modal advising to edit/skip.
+  const [runBusyFor, setRunBusyFor] = useState<string>("");
+  const [runBlockWorkflowId, setRunBlockWorkflowId] = useState<string>("");
+  const [runBlockMissing, setRunBlockMissing] = useState<string[]>([]);
+  const [runBlockError, setRunBlockError] = useState<string>("");
+
+  const runWorkflow = useCallback(
+    async (workflowId: string) => {
+      setRunBusyFor(workflowId);
+      setRunBlockError("");
+      try {
+        // 1. Load workflow to check meta.skipCronCheck + collect required agentIds
+        const wfRes = await fetchJson<{ ok?: boolean; error?: string; workflow?: unknown }>(
+          `/api/teams/workflows?teamId=${encodeURIComponent(teamId)}&id=${encodeURIComponent(workflowId)}`,
+          { cache: "no-store" }
+        );
+        if (!wfRes.ok || !wfRes.workflow) throw new Error(wfRes.error || "Failed to load workflow");
+        const wf = wfRes.workflow as {
+          meta?: unknown;
+          nodes?: Array<{ type?: string; config?: unknown }>;
+        };
+        const meta = isRecord(wf.meta) ? wf.meta : {};
+        const skipCronCheck = meta.skipCronCheck === true;
+
+        if (!skipCronCheck) {
+          const nodes = Array.isArray(wf.nodes) ? wf.nodes : [];
+          const requiredAgents = Array.from(
+            new Set(
+              nodes
+                .filter((n) => n.type && !["start", "end", "human_approval"].includes(String(n.type)))
+                .map((n) => {
+                  const cfg = isRecord(n.config) ? n.config : {};
+                  return String(cfg.agentId ?? "").trim();
+                })
+                .filter(Boolean)
+            )
+          );
+
+          // 2. Fetch cron jobs and compute which required agents lack a worker-tick cron.
+          const cronRes = await fetchJson<{ ok?: boolean; error?: string; jobs?: unknown[] }>(
+            `/api/cron/jobs`,
+            { cache: "no-store" }
+          );
+          if (!cronRes.ok) throw new Error(cronRes.error || "Failed to load cron jobs");
+          const jobs = Array.isArray(cronRes.jobs) ? cronRes.jobs : [];
+          const agentHasCron: Record<string, boolean> = {};
+          for (const j of jobs) {
+            const job = j as { enabled?: unknown; name?: unknown; payload?: { message?: unknown } };
+            if (!job || !Boolean(job.enabled)) continue;
+            const jobName = String(job.name ?? "");
+            const payloadMsg = String(job.payload?.message ?? "");
+            const isWorkerTick = jobName.startsWith("workflow-worker:") || payloadMsg.includes("worker-tick");
+            if (!isWorkerTick) continue;
+            const m = jobName.match(/^workflow-worker:[^:]+:(.+)$/);
+            if (m?.[1]) {
+              agentHasCron[m[1]] = true;
+              continue;
+            }
+            const msgMatch = payloadMsg.match(/--agent-id\s+(\S+)/);
+            if (msgMatch?.[1]) agentHasCron[msgMatch[1]] = true;
+          }
+          const missing = requiredAgents.filter((id) => !agentHasCron[id]);
+          if (missing.length) {
+            setRunBlockMissing(missing);
+            setRunBlockWorkflowId(workflowId);
+            return;
+          }
+        }
+
+        // 3. Enqueue the run.
+        const runRes = await fetchJson<{ ok?: boolean; error?: string; runId?: string }>(
+          `/api/teams/workflow-runs`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ teamId, workflowId, mode: "run_now" }),
+          }
+        );
+        if (!runRes.ok) throw new Error(runRes.error || "Failed to create run");
+        const newRunId = String(runRes.runId ?? "").trim();
+        if (newRunId) {
+          router.push(`/teams/${encodeURIComponent(teamId)}/runs/${encodeURIComponent(workflowId)}/${encodeURIComponent(newRunId)}`);
+        } else {
+          // Fall back to showing runs for the workflow inline.
+          setExpandedWorkflowId(workflowId);
+        }
+      } catch (e: unknown) {
+        setRunBlockMissing([]);
+        setRunBlockWorkflowId("");
+        setRunBlockError(errorMessage(e));
+      } finally {
+        setRunBusyFor("");
+      }
+    },
+    [teamId, router]
+  );
 
   const load = useCallback(
     async (opts?: { quiet?: boolean }) => {
@@ -260,6 +360,41 @@ export default function WorkflowsClient({ teamId, llmTaskEnabled }: { teamId: st
         </div>
       ) : null}
 
+      {runBlockError ? (
+        <div className="mt-4 rounded-lg border border-red-400/30 bg-red-500/10 p-4 text-sm text-red-100">
+          {runBlockError}
+        </div>
+      ) : null}
+
+      <ConfirmationModal
+        open={Boolean(runBlockWorkflowId)}
+        title="Worker crons not set up"
+        confirmLabel="Edit workflow"
+        onClose={() => {
+          setRunBlockWorkflowId("");
+          setRunBlockMissing([]);
+        }}
+        onConfirm={() => {
+          const wfId = runBlockWorkflowId;
+          setRunBlockWorkflowId("");
+          setRunBlockMissing([]);
+          if (wfId) router.push(`/teams/${encodeURIComponent(teamId)}/workflows/${encodeURIComponent(wfId)}`);
+        }}
+      >
+        <div className="space-y-2 text-sm text-[color:var(--ck-text-secondary)]">
+          <p>
+            This workflow can’t run because worker cron jobs aren’t installed for the required agents. Open the
+            workflow editor to install them, or choose to skip the cron check (once or permanently) from the same
+            screen.
+          </p>
+          {runBlockMissing.length ? (
+            <div className="rounded-lg border border-white/10 bg-white/5 p-2 font-mono text-[11px] text-[color:var(--ck-text-primary)]">
+              Missing for: {runBlockMissing.join(", ")}
+            </div>
+          ) : null}
+        </div>
+      </ConfirmationModal>
+
       {workflows.length === 0 ? (
         <p className="mt-4 text-sm text-[color:var(--ck-text-secondary)]">No workflows yet.</p>
       ) : (
@@ -292,6 +427,15 @@ export default function WorkflowsClient({ teamId, llmTaskEnabled }: { teamId: st
                   </button>
 
                   <div className="flex shrink-0 items-center gap-2">
+                    <button
+                      type="button"
+                      disabled={runBusyFor === w.id}
+                      onClick={() => void runWorkflow(w.id)}
+                      className="rounded-lg border border-emerald-400/30 bg-emerald-500/10 px-3 py-1.5 text-sm font-medium text-emerald-50 transition-colors hover:bg-emerald-500/15 disabled:opacity-60"
+                      title="Enqueue a run for this workflow"
+                    >
+                      {runBusyFor === w.id ? "Starting…" : "Run"}
+                    </button>
                     <Link
                       href={`/teams/${encodeURIComponent(teamId)}/workflows/${encodeURIComponent(w.id)}`}
                       className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-sm font-medium text-[color:var(--ck-text-primary)] hover:bg-white/10"


### PR DESCRIPTION
## Summary

Two linked UX improvements for running workflows.

### 1. Workflow editor — Skip cron check

When required worker crons aren't installed, the amber "Cron not set up" block previously exposed only **Install worker cron(s)** + **Re-check** — Run Now was hard-disabled with no escape hatch. This hurts users running workers via launchd / systemd / any external scheduler (or when Kitchen's cron detection can't see them).

Adds a third **Skip** button that opens a modal with two options:
- **Skip this run only** — session-only React flag, resets on page reload
- **Skip permanently** — writes \`meta.skipCronCheck: true\` into the workflow JSON via \`POST /api/teams/workflows\`, persisted to disk

\`runPreflight.ok\` now treats cron as satisfied when either skip flag is active. The Run Now handler also skips the reconcile step in that case. An informational sky-colored banner displays when a skip is in effect so the state is obvious.

### 2. Workflow list tab — Run button

Adds a **Run** button in front of Edit/Delete on each list row. Clicking it:
1. Loads the workflow JSON to read \`meta.skipCronCheck\`
2. If not skipped, fetches \`/api/cron/jobs\` and computes which required \`agentId\`s have a worker-tick cron
3. If every required agent is covered (or \`skipCronCheck\` is set), POSTs to \`/api/teams/workflow-runs { mode: \"run_now\" }\` and navigates to the new run page
4. Otherwise opens a **Worker crons not set up** modal with an **Edit workflow** action that takes the user to the editor

No new API routes — the list flow reuses existing \`/api/teams/workflows\`, \`/api/cron/jobs\`, and \`/api/teams/workflow-runs\`.

## Diff scope

- \`src/app/teams/[teamId]/workflows/[workflowId]/workflows-editor-client.tsx\` (+~130 lines): skip state, skip modal, updated banner, skip-aware run handler
- \`src/app/teams/[teamId]/workflows/workflows-client.tsx\` (+~130 lines): \`runWorkflow\` helper, Run button per row, block modal

## Test plan

- [x] \`tsc --noEmit\` — 0 new errors (58 pre-existing on main, 58 on this branch)
- [x] \`eslint\` — 0 errors
- [ ] Editor flow: missing cron → Skip → pick **Skip permanently** → workflow JSON has \`meta.skipCronCheck: true\`, banner flips to sky state, Run Now enabled
- [ ] Editor flow: missing cron → Skip → pick **Skip this run only** → banner flips to sky (session-only), Run Now enabled, reload resets state
- [ ] List flow: click Run on a workflow with all crons installed → enqueue succeeds, navigates to run page
- [ ] List flow: click Run on a workflow missing crons (and not permanently skipped) → modal with missing-agent list + Edit workflow action
- [ ] List flow: click Run on a workflow with \`meta.skipCronCheck: true\` → enqueue succeeds without cron check, navigates to run page

🤖 Generated with [Claude Code](https://claude.com/claude-code)