### PR TITLE
fix(workflows-client): show 'Gathering ingredients' overlay on Run from team-editor list

### DIFF
--- a/src/app/teams/[teamId]/workflows/workflows-client.tsx
+++ b/src/app/teams/[teamId]/workflows/workflows-client.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { fetchJson } from "@/lib/fetch-json";
 import { errorMessage } from "@/lib/errors";
 import { ConfirmationModal } from "@/components/ConfirmationModal";
+import { RunLoadingOverlay } from "@/components/RunLoadingOverlay";
 
 type RunDetail = {
   id: string;
@@ -46,10 +47,16 @@ export default function WorkflowsClient({ teamId, llmTaskEnabled }: { teamId: st
   const [runBlockWorkflowId, setRunBlockWorkflowId] = useState<string>("");
   const [runBlockMissing, setRunBlockMissing] = useState<string[]>([]);
   const [runBlockError, setRunBlockError] = useState<string>("");
+  // Same "Gathering your ingredients..." overlay the workflow editor shows
+  // while a run is being enqueued. Stays open through the preflight + POST,
+  // then either the router.push to the run detail page takes over (success)
+  // or we close it so the block/error modal becomes visible.
+  const [runOverlayOpen, setRunOverlayOpen] = useState(false);
 
   const runWorkflow = useCallback(
     async (workflowId: string) => {
       setRunBusyFor(workflowId);
+      setRunOverlayOpen(true);
       setRunBlockError("");
       try {
         // 1. Load workflow to check meta.skipCronCheck + collect required agentIds
@@ -133,6 +140,7 @@ export default function WorkflowsClient({ teamId, llmTaskEnabled }: { teamId: st
         setRunBlockError(errorMessage(e));
       } finally {
         setRunBusyFor("");
+        setRunOverlayOpen(false);
       }
     },
     [teamId, router]
@@ -314,6 +322,7 @@ export default function WorkflowsClient({ teamId, llmTaskEnabled }: { teamId: st
 
   return (
     <div className="ck-card p-6">
+      <RunLoadingOverlay open={runOverlayOpen} />
       <div>
         <h2 className="text-lg font-semibold">Workflows (file-first)</h2>
         <p className="mt-1 text-sm text-[color:var(--ck-text-secondary)]">


### PR DESCRIPTION
## Summary
The Run button in the team editor's Workflows tab (renders `workflows-client.tsx`) didn't show the **"Gathering your ingredients..."** overlay that the workflow editor page (`workflows-editor-client.tsx`) shows when its Run now button fires. Same enqueue flow, two different entry points; the list-view entry was missing the visual feedback during preflight + POST.

## Change
- Imports `RunLoadingOverlay` from `@/components/RunLoadingOverlay`
- Adds `runOverlayOpen` state alongside the existing `runBusyFor` state
- Toggles it open at the start of `runWorkflow` and closes it in `finally`
- Mounts `<RunLoadingOverlay open={runOverlayOpen} />` at the top of the JSX

The block-modal (cron-missing) and error-banner paths remain visible because the overlay closes in `finally` before they render.

## Test plan
- [ ] In the team editor, open the **Workflows** tab
- [ ] Click **Run** on a workflow row
- [ ] Confirm the **"Gathering your ingredients..."** overlay appears immediately
- [ ] On success → page navigates to the new run detail (overlay unmounts with the page)
- [ ] On cron-missing block → overlay disappears and the cron-block confirmation modal renders
- [ ] On thrown error → overlay disappears and `runBlockError` text shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)