### PR TITLE
fix(workflows-client): keep overlay open through navigation to run detail

### DIFF
--- a/src/app/teams/[teamId]/workflows/workflows-client.tsx
+++ b/src/app/teams/[teamId]/workflows/workflows-client.tsx
@@ -58,6 +58,12 @@ export default function WorkflowsClient({ teamId, llmTaskEnabled }: { teamId: st
       setRunBusyFor(workflowId);
       setRunOverlayOpen(true);
       setRunBlockError("");
+      // Track whether we successfully kicked off a navigation. If we did, the
+      // overlay is left open so it spans the page transition; this component
+      // unmounts when the run detail page renders, taking the portal with it.
+      // If we DIDN'T navigate (block path, fallback path, error), we close the
+      // overlay explicitly so the block modal / error banner becomes visible.
+      let navigated = false;
       try {
         // 1. Load workflow to check meta.skipCronCheck + collect required agentIds
         const wfRes = await fetchJson<{ ok?: boolean; error?: string; workflow?: unknown }>(
@@ -130,6 +136,7 @@ export default function WorkflowsClient({ teamId, llmTaskEnabled }: { teamId: st
         const newRunId = String(runRes.runId ?? "").trim();
         if (newRunId) {
           router.push(`/teams/${encodeURIComponent(teamId)}/runs/${encodeURIComponent(workflowId)}/${encodeURIComponent(newRunId)}`);
+          navigated = true;
         } else {
           // Fall back to showing runs for the workflow inline.
           setExpandedWorkflowId(workflowId);
@@ -140,7 +147,12 @@ export default function WorkflowsClient({ teamId, llmTaskEnabled }: { teamId: st
         setRunBlockError(errorMessage(e));
       } finally {
         setRunBusyFor("");
-        setRunOverlayOpen(false);
+        // Keep the overlay open if a navigation was kicked off so the user
+        // sees a continuous loading state until the run detail page renders.
+        // The component unmounts on navigation completion, so the portal
+        // disappears with it. On any non-nav path, close so the user sees
+        // the block modal / error banner.
+        if (!navigated) setRunOverlayOpen(false);
       }
     },
     [teamId, router]


### PR DESCRIPTION
## Summary
Follow-up to merged PR #405. The original fix opened the **"Gathering your ingredients..."** overlay when the user clicked Run from the team-editor's Workflows list, but closed it via `setRunOverlayOpen(false)` in `finally` on every code path — **including the success/router.push path**. Next.js navigation to the run detail page can take 5-60s on cold compile, so the overlay disappeared while the user was still waiting; they saw the workflows list again before the new page rendered.

## Change
- Track a `navigated` flag inside `runWorkflow`
- Only close the overlay in `finally` if `!navigated`
- On the navigation path the overlay stays mounted; the workflows-client component unmounts when the run detail page renders, taking the portal with it
- Block-modal and error paths still close the overlay so the secondary UI is visible

One file, ~13 line addition.

## Test plan
- [ ] On `/teams/<teamId>?tab=workflows`, click Run on a row
- [ ] Confirm the "Gathering your ingredients..." overlay appears immediately
- [ ] Confirm the overlay **stays visible** for the full duration of navigation, then disappears as the run detail page renders
- [ ] Cron-block path: overlay closes, block confirmation modal renders
- [ ] Error path: overlay closes, error banner renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)