### PR TITLE
perf(cache): bump default TTL to 30m and warm cache via cached call

### DIFF
--- a/src/app/recipes/[id]/page.tsx
+++ b/src/app/recipes/[id]/page.tsx
@@ -1,22 +1,21 @@
 import Link from "next/link";
 import { unstable_noStore as noStore } from "next/cache";
 
-import { listRecipes } from "@/lib/recipes";
+import { listRecipesCached } from "@/lib/recipes";
 import RecipeEditor from "./RecipeEditor";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-async function getKind(id: string): Promise<"agent" | "team" | null> {
-  const recipes = await listRecipes();
-  return recipes.find((r) => r.id === id)?.kind ?? null;
-}
-
 export default async function RecipePage({ params }: { params: Promise<{ id: string }> }) {
   noStore();
 
   const { id } = await params;
-  await getKind(id); // Resolved for future redirect logic; kept for cache consistency
+
+  // Warm the recipes-list cache so the client's /api/recipes/[id] fetch hits
+  // a populated entry instead of paying the full subprocess cost again.
+  // Result intentionally unused — we only care about the cache write.
+  await listRecipesCached();
 
   // NOTE: We do NOT redirect team recipes to /teams/<id>.
   // /recipes/<id> is the recipe editor/preview surface; /teams/<id> is the installed team editor.

--- a/src/lib/openclaw-cache.ts
+++ b/src/lib/openclaw-cache.ts
@@ -23,11 +23,11 @@ import { runOpenClaw, type OpenClawExecResult } from "@/lib/openclaw";
 // paying the full subprocess cost again. Each entry includes its expiry time;
 // expired entries are ignored on read.
 
-// 5 min default. Was 30s for in-memory; now that we persist to disk and
-// mutations invalidate explicitly, longer TTLs are safe and protect against
-// gateway restarts where the previous TTL would have expired before the user
-// finished navigating back. Caller can override via { ttlMs }.
-const DEFAULT_TTL_MS = 5 * 60_000;
+// 30 min default. Mutations invalidate explicitly via invalidateOpenClawCache,
+// and the disk cache survives gateway restarts, so a long TTL is safe and
+// keeps hot-render paths (recipes list, agents list, plugins list) off the
+// ~20s subprocess cost most of the time. Caller can override via { ttlMs }.
+const DEFAULT_TTL_MS = 30 * 60_000;
 const DISK_CACHE_DIR = path.join(os.homedir(), ".openclaw", ".kitchen-subprocess-cache");
 
 // Skip disk persistence during tests so module-level cache state is the only


### PR DESCRIPTION
## Summary
Two small fixes to reduce hard-refresh time on the **recipes detail page** (`/recipes/[id]`) and **team editor → Files tab** (`/teams/[teamId]?tab=files`). Both surfaces are gated on the `openclaw recipes list` subprocess, which has a ~20s baseline cold start.

## What changed
1. **`src/lib/openclaw-cache.ts`** — bump `DEFAULT_TTL_MS` from 5 min to 30 min. Mutations already invalidate explicitly via `invalidateOpenClawCache`, and the disk cache survives gateway restarts, so the longer TTL is safe and keeps hot-render paths off the subprocess most of the time.
2. **`src/app/recipes/[id]/page.tsx`** — was calling `listRecipes()` (uncached) at SSR time and discarding the result \"for cache consistency\", while the client subsequently fetched `/api/recipes/[id]` which uses `listRecipesCached()`. Net effect: **two full subprocesses on every hard refresh** — one wasted, one used. Switched SSR to `listRecipesCached()` so the SSR call warms the cache the client request will hit.

## Why `recipes list` is slow (investigation)
- Measured cold-run: 18-20s. Recipe scan itself is ~50ms (17 markdown files in `~/.openclaw/extensions/recipes/recipes/default/` + `~/.openclaw/workspace/recipes/`).
- Remainder is Node.js + OpenClaw CLI framework startup. Real fix lives upstream in OpenClaw (lazy plugin loading or bytecode caching). Cache layer is the practical workaround.

## Out of scope (deferred)
- **Stale-while-revalidate on disk cache** — would let expired disk entries serve immediately and refresh in background. Skipped because adding test coverage requires refactoring `openclaw-cache.ts` to make the disk dir injectable. Worthwhile follow-up.
- **`Cache-Control` headers on API responses** — would help soft refreshes within the cache window, but client fetches use `cache: 'no-store'` everywhere (`team-editor-data.ts:8,9,25`, etc.), which defeats `max-age`. Pairing the header with selective `no-store` removal is a separate change.

## Test plan
- [x] All 85 vitest test files / 521 tests pass
- [x] No new TypeScript errors (58 pre-existing on main, 58 with this change)
- [ ] After install: hard-refresh a recipe detail page, confirm time-to-render improves on the second refresh within 30 min
- [ ] After install: hard-refresh team editor → Files tab, confirm same

🤖 Generated with [Claude Code](https://claude.com/claude-code)