### PR TITLE
perf(cache): stale-while-revalidate for disk cache

### DIFF
--- a/src/lib/__tests__/openclaw-cache.test.ts
+++ b/src/lib/__tests__/openclaw-cache.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
+
+vi.mock("../openclaw", () => ({ runOpenClaw: vi.fn() }));
+
+import { runOpenClaw } from "../openclaw";
+import {
+  cachedRunOpenClaw,
+  invalidateOpenClawCache,
+  _resetOpenClawCache,
+  __setDiskCacheConfigForTests,
+} from "../openclaw-cache";
+
+let tmpDir: string;
+
+function diskPathForArgs(dir: string, args: string[]): string {
+  const key = JSON.stringify(args);
+  const hash = createHash("sha256").update(key).digest("hex").slice(0, 40);
+  return path.join(dir, `${hash}.json`);
+}
+
+function writeEntry(dir: string, args: string[], stdout: string, expiresAt: number): void {
+  mkdirSync(dir, { recursive: true });
+  const value = { ok: true, exitCode: 0, stdout, stderr: "" };
+  writeFileSync(
+    diskPathForArgs(dir, args),
+    JSON.stringify({ args, expires: expiresAt, value }),
+    "utf8",
+  );
+}
+
+function readEntryStdout(dir: string, args: string[]): string | null {
+  try {
+    const parsed = JSON.parse(readFileSync(diskPathForArgs(dir, args), "utf8"));
+    return parsed?.value?.stdout ?? null;
+  } catch {
+    return null;
+  }
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(tmpdir(), "openclaw-cache-test-"));
+  __setDiskCacheConfigForTests({ enabled: true, dir: tmpDir });
+  _resetOpenClawCache();
+  vi.mocked(runOpenClaw).mockReset();
+});
+
+afterEach(() => {
+  __setDiskCacheConfigForTests({ reset: true });
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("cachedRunOpenClaw — stale-while-revalidate", () => {
+  it("serves expired disk entry immediately and triggers a background refresh", async () => {
+    writeEntry(tmpDir, ["recipes", "list"], "stale-data", Date.now() - 1000);
+    let resolveSubprocess: (v: { ok: true; exitCode: 0; stdout: string; stderr: string }) => void = () => {};
+    vi.mocked(runOpenClaw).mockReturnValue(
+      new Promise((r) => {
+        resolveSubprocess = r;
+      }),
+    );
+
+    const first = await cachedRunOpenClaw(["recipes", "list"]);
+    expect(first.stdout).toBe("stale-data");
+    expect(vi.mocked(runOpenClaw)).toHaveBeenCalledTimes(1);
+
+    resolveSubprocess({ ok: true, exitCode: 0, stdout: "fresh-data", stderr: "" });
+    // Yield so the background IIFE can write fresh value to memory + disk.
+    await new Promise((r) => setTimeout(r, 5));
+
+    const second = await cachedRunOpenClaw(["recipes", "list"]);
+    expect(second.stdout).toBe("fresh-data");
+    expect(vi.mocked(runOpenClaw)).toHaveBeenCalledTimes(1);
+    expect(readEntryStdout(tmpDir, ["recipes", "list"])).toBe("fresh-data");
+  });
+
+  it("returns fresh disk entry without triggering a subprocess", async () => {
+    writeEntry(tmpDir, ["recipes", "list"], "fresh-data", Date.now() + 60_000);
+
+    const got = await cachedRunOpenClaw(["recipes", "list"]);
+    expect(got.stdout).toBe("fresh-data");
+    expect(vi.mocked(runOpenClaw)).not.toHaveBeenCalled();
+  });
+
+  it("falls through to subprocess on full disk miss", async () => {
+    vi.mocked(runOpenClaw).mockResolvedValue({
+      ok: true,
+      exitCode: 0,
+      stdout: "subprocess-data",
+      stderr: "",
+    });
+
+    const got = await cachedRunOpenClaw(["recipes", "list"]);
+    expect(got.stdout).toBe("subprocess-data");
+    expect(vi.mocked(runOpenClaw)).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces concurrent stale reads into a single background subprocess", async () => {
+    writeEntry(tmpDir, ["recipes", "list"], "stale-data", Date.now() - 1000);
+    let resolveSubprocess: (v: { ok: true; exitCode: 0; stdout: string; stderr: string }) => void = () => {};
+    vi.mocked(runOpenClaw).mockReturnValue(
+      new Promise((r) => {
+        resolveSubprocess = r;
+      }),
+    );
+
+    const [a, b, c] = await Promise.all([
+      cachedRunOpenClaw(["recipes", "list"]),
+      cachedRunOpenClaw(["recipes", "list"]),
+      cachedRunOpenClaw(["recipes", "list"]),
+    ]);
+
+    expect(a.stdout).toBe("stale-data");
+    expect(b.stdout).toBe("stale-data");
+    expect(c.stdout).toBe("stale-data");
+    expect(vi.mocked(runOpenClaw)).toHaveBeenCalledTimes(1);
+
+    resolveSubprocess({ ok: true, exitCode: 0, stdout: "fresh-data", stderr: "" });
+  });
+
+  it("does not write a fresh value when the background refresh fails", async () => {
+    writeEntry(tmpDir, ["recipes", "list"], "stale-data", Date.now() - 1000);
+    vi.mocked(runOpenClaw).mockResolvedValue({
+      ok: false,
+      exitCode: 1,
+      stdout: "",
+      stderr: "boom",
+    });
+
+    const first = await cachedRunOpenClaw(["recipes", "list"]);
+    expect(first.stdout).toBe("stale-data");
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Stale disk entry untouched on failed refresh.
+    expect(readEntryStdout(tmpDir, ["recipes", "list"])).toBe("stale-data");
+  });
+
+  it("invalidate clears expired entries so SWR no longer serves stale", async () => {
+    writeEntry(tmpDir, ["recipes", "list"], "stale-data", Date.now() - 1000);
+    invalidateOpenClawCache(["recipes", "list"]);
+
+    vi.mocked(runOpenClaw).mockResolvedValue({
+      ok: true,
+      exitCode: 0,
+      stdout: "subprocess-data",
+      stderr: "",
+    });
+
+    const got = await cachedRunOpenClaw(["recipes", "list"]);
+    expect(got.stdout).toBe("subprocess-data");
+    expect(vi.mocked(runOpenClaw)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/openclaw-cache.ts
+++ b/src/lib/openclaw-cache.ts
@@ -20,20 +20,25 @@ import { runOpenClaw, type OpenClawExecResult } from "@/lib/openclaw";
 // Disk persistence: cache entries also write to
 // ~/.openclaw/.kitchen-subprocess-cache/<sha1>.json so the first request
 // after a gateway restart can read a still-fresh entry from disk instead of
-// paying the full subprocess cost again. Each entry includes its expiry time;
-// expired entries are ignored on read.
+// paying the full subprocess cost again. Each entry records its expiry; an
+// expired-but-readable entry is served stale-while-revalidate (returned
+// immediately while a background subprocess refreshes it).
 
 // 30 min default. Mutations invalidate explicitly via invalidateOpenClawCache,
 // and the disk cache survives gateway restarts, so a long TTL is safe and
 // keeps hot-render paths (recipes list, agents list, plugins list) off the
 // ~20s subprocess cost most of the time. Caller can override via { ttlMs }.
 const DEFAULT_TTL_MS = 30 * 60_000;
-const DISK_CACHE_DIR = path.join(os.homedir(), ".openclaw", ".kitchen-subprocess-cache");
+
+// Mutable so __setDiskCacheConfigForTests can redirect tests to a tmpdir
+// without polluting the real ~/.openclaw cache. Production code never
+// reassigns these.
+let DISK_CACHE_DIR = path.join(os.homedir(), ".openclaw", ".kitchen-subprocess-cache");
 
 // Skip disk persistence during tests so module-level cache state is the only
-// thing tests need to reason about. Tests already reset memory caches; mocking
-// disk reads on top of that would be noise.
-const DISK_CACHE_ENABLED =
+// thing tests need to reason about by default. The SWR test suite opts in
+// via __setDiskCacheConfigForTests with an isolated tmpdir.
+let DISK_CACHE_ENABLED =
   process.env.NODE_ENV !== "test" && !process.env.VITEST && !process.env.VITEST_WORKER_ID;
 
 const cache = new Map<string, { value: OpenClawExecResult; expires: number }>();
@@ -48,12 +53,13 @@ function diskPathForKey(key: string): string {
 
 type DiskEntry = { args: string[]; expires: number; value: OpenClawExecResult };
 
+// Returns the entry as recorded on disk, including expired ones. Caller
+// inspects `expires` to decide whether to serve fresh or stale-while-revalidate.
 function readDiskEntry(key: string): { value: OpenClawExecResult; expires: number } | null {
   if (!DISK_CACHE_ENABLED) return null;
   try {
     const raw = readFileSync(diskPathForKey(key), "utf8");
     const parsed = JSON.parse(raw) as DiskEntry;
-    if (parsed.expires <= Date.now()) return null;
     if (JSON.stringify(parsed.args) !== key) return null;
     return { value: parsed.value, expires: parsed.expires };
   } catch {
@@ -83,6 +89,31 @@ function deleteDiskEntry(key: string): void {
   }
 }
 
+// Fire-and-forget background refresh. Coalesced via the existing inflight
+// Map so concurrent stale reads only spawn one subprocess. On success, writes
+// the fresh value to memory + disk; on failure, the existing stale entry stays
+// in place and the next read will try again.
+function refreshInBackground(args: string[], ttl: number, key: string): void {
+  if (inflight.has(key)) return;
+  const promise = (async () => {
+    try {
+      const value = await runOpenClaw(args);
+      if (value.ok) {
+        const expires = Date.now() + ttl;
+        cache.set(key, { value, expires });
+        writeDiskEntry(args, value, expires);
+      }
+      return value;
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+  inflight.set(key, promise);
+  // Swallow rejections; the stale value already returned to the caller is
+  // acceptable, and an unhandled rejection here would crash the process.
+  promise.catch(() => {});
+}
+
 export async function cachedRunOpenClaw(
   args: string[],
   options: { ttlMs?: number } = {}
@@ -93,17 +124,25 @@ export async function cachedRunOpenClaw(
   const memHit = cache.get(key);
   if (memHit && Date.now() < memHit.expires) return memHit.value;
 
-  const existing = inflight.get(key);
-  if (existing) return existing;
-
-  // Disk fallback for the first request after gateway restart. If the disk
-  // entry is still valid, serve it AND populate the in-memory cache so further
-  // requests skip the disk read.
+  // Disk read happens before the inflight check so concurrent requests during
+  // a background refresh can each serve stale immediately, instead of all
+  // queueing on the refresh promise.
   const diskHit = readDiskEntry(key);
   if (diskHit) {
-    cache.set(key, diskHit);
+    if (Date.now() < diskHit.expires) {
+      cache.set(key, diskHit);
+      return diskHit.value;
+    }
+    // Stale: serve immediately, refresh in background. Don't write to memory
+    // — leaving memory empty means subsequent calls within the refresh window
+    // re-read disk and continue serving stale until the background subprocess
+    // writes the fresh value.
+    refreshInBackground(args, ttl, key);
     return diskHit.value;
   }
+
+  const existing = inflight.get(key);
+  if (existing) return existing;
 
   const promise = (async () => {
     try {
@@ -171,6 +210,26 @@ export function invalidateOpenClawCache(...argvs: string[][]): void {
     }
   }
   for (const key of diskKeysMatching(argvs)) deleteDiskEntry(key);
+}
+
+/**
+ * Test-only: redirect the disk cache to a tmpdir and/or override the
+ * disk-enabled flag. Pass `{ reset: true }` to restore production defaults
+ * (used in afterEach hooks). Production code never calls this.
+ */
+export function __setDiskCacheConfigForTests(opts: {
+  enabled?: boolean;
+  dir?: string;
+  reset?: boolean;
+}): void {
+  if (opts.reset) {
+    DISK_CACHE_ENABLED =
+      process.env.NODE_ENV !== "test" && !process.env.VITEST && !process.env.VITEST_WORKER_ID;
+    DISK_CACHE_DIR = path.join(os.homedir(), ".openclaw", ".kitchen-subprocess-cache");
+    return;
+  }
+  if (opts.enabled !== undefined) DISK_CACHE_ENABLED = opts.enabled;
+  if (opts.dir !== undefined) DISK_CACHE_DIR = opts.dir;
 }
 
 /** Test-only: clear all cached subprocess results (memory + disk). */


### PR DESCRIPTION
## Summary
Follow-up to #411. After the in-memory cache TTL expires (or after a gateway restart drops in-memory entries), hard refreshes were paying the full ~20s `openclaw recipes list` subprocess again — even though a recent-but-expired disk entry was sitting right there.

This PR adds **stale-while-revalidate**: an expired disk hit now returns the stale value **immediately** and kicks off a background subprocess that refreshes memory + disk for the next call.

## What changed
- `readDiskEntry` no longer rejects expired entries; it returns whatever is on disk and lets the caller decide.
- New `refreshInBackground` helper fires the subprocess, writes fresh value on success, and uses the existing `inflight` Map to coalesce concurrent stale reads into a **single** subprocess.
- `cachedRunOpenClaw` now reads disk **before** checking inflight so concurrent callers during a refresh each serve stale immediately, instead of queueing on the in-flight promise.
- Memory cache stays empty while serving stale, so subsequent calls within the refresh window keep re-reading disk and serving stale until the background write lands.

## Test infra
- Added `__setDiskCacheConfigForTests({ enabled, dir, reset })` to redirect the disk cache to a tmpdir; tests opt in to disk persistence to exercise the SWR path.
- New `src/lib/__tests__/openclaw-cache.test.ts` (6 tests):
  - serves expired disk entry immediately and triggers background refresh
  - returns fresh disk entry without triggering subprocess
  - falls through to subprocess on full disk miss
  - coalesces concurrent stale reads into a single background subprocess
  - does not write a fresh value when the background refresh fails (stale stays put)
  - `invalidateOpenClawCache` clears expired entries so SWR no longer serves stale

## Failure modes
- **Background refresh fails**: stale entry stays put, next read re-tries.
- **Promise rejection in refresh**: caught and swallowed (the user already has stale).
- **Mutation during stale serve**: the route handler still calls `invalidateOpenClawCache`, which deletes the stale disk entry. A refresh already in flight may write a fresh entry milliseconds after invalidation — small race window, acceptable since post-mutation reads typically happen well after the inflight refresh finishes.

## Test plan
- [x] All 86 vitest test files / 527 tests pass (was 85 / 521 — added 6 SWR tests)
- [x] No new TypeScript errors (58 pre-existing on main, 58 with this change)
- [ ] After install: hard-refresh recipe page after 30+ min idle → confirm stale serves instantly + fresh lands on next refresh
- [ ] After install: hard-refresh team editor → Files tab → same

## Caveats / future work
- Client fetches still use `cache: 'no-store'`. SWR helps the **server-side** cache layer (which sits between Next.js routes and the openclaw subprocess), so this PR makes hard refreshes fast even when the browser bypasses HTTP cache. Adding `Cache-Control` headers + selectively dropping `no-store` on read-only client fetches is a separate optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)